### PR TITLE
feat(domain/user) : 도메인 이벤트 publisher , aop 추가 (#9)

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/example/dto/ExampleResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/example/dto/ExampleResponse.java
@@ -1,7 +1,7 @@
 package band.gosrock.api.example.dto;
 
 
-import band.gosrock.domain.example.domain.ExampleEntity;
+import band.gosrock.domain.domain.example.domain.ExampleEntity;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/DuDoong-Api/src/main/java/band/gosrock/api/example/service/ExampleApiService.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/example/service/ExampleApiService.java
@@ -2,8 +2,8 @@ package band.gosrock.api.example.service;
 
 
 import band.gosrock.api.example.dto.ExampleResponse;
-import band.gosrock.domain.example.domain.ExampleEntity;
-import band.gosrock.domain.example.service.ExampleDomainService;
+import band.gosrock.domain.domain.example.domain.ExampleEntity;
+import band.gosrock.domain.domain.example.service.ExampleDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/DuDoongDomainApplication.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/DuDoongDomainApplication.java
@@ -1,0 +1,8 @@
+package band.gosrock.domain;
+
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+// 테스팅 용도 어플리케이션입니다.
+@SpringBootApplication
+public class DuDoongDomainApplication {}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aspect/EventPublisherAspect.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aspect/EventPublisherAspect.java
@@ -1,0 +1,48 @@
+package band.gosrock.domain.common.aspect;
+
+
+import band.gosrock.domain.common.events.Events;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class EventPublisherAspect implements ApplicationEventPublisherAware {
+
+    private ApplicationEventPublisher publisher;
+    private ThreadLocal<Boolean> appliedLocal = new ThreadLocal<>();
+
+    @Around("@annotation(org.springframework.transaction.annotation.Transactional)")
+    public Object handleEvent(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        Boolean appliedValue = appliedLocal.get();
+        boolean nested = false;
+
+        if (appliedValue != null && appliedValue) {
+            nested = true;
+        } else {
+            nested = false;
+            appliedLocal.set(Boolean.TRUE);
+        }
+
+        if (!nested) Events.setPublisher(publisher);
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            if (!nested) {
+                Events.reset();
+                appliedLocal.remove();
+            }
+        }
+    }
+
+    @Override
+    public void setApplicationEventPublisher(ApplicationEventPublisher eventPublisher) {
+        this.publisher = eventPublisher;
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/DomainEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/DomainEvent.java
@@ -1,4 +1,5 @@
-package band.gosrock.events;
+package band.gosrock.domain.common.events;
+
 
 import java.time.LocalDateTime;
 import lombok.Getter;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/Events.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/Events.java
@@ -1,4 +1,5 @@
-package band.gosrock.events;
+package band.gosrock.domain.common.events;
+
 
 import org.springframework.context.ApplicationEventPublisher;
 
@@ -13,11 +14,11 @@ public class Events {
         }
     }
 
-    static void setPublisher(ApplicationEventPublisher publisher) {
+    public static void setPublisher(ApplicationEventPublisher publisher) {
         publisherLocal.set(publisher);
     }
 
-    static void reset() {
+    public static void reset() {
         publisherLocal.remove();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/user/UserRegisterEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/user/UserRegisterEvent.java
@@ -1,6 +1,7 @@
-package band.gosrock.events.user;
+package band.gosrock.domain.common.events.user;
 
-import band.gosrock.events.DomainEvent;
+
+import band.gosrock.domain.common.events.DomainEvent;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/config/EnableAsyncConfig.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/config/EnableAsyncConfig.java
@@ -1,0 +1,9 @@
+package band.gosrock.domain.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@Configuration
+public class EnableAsyncConfig {}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/example/domain/ExampleEntity.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/example/domain/ExampleEntity.java
@@ -1,4 +1,4 @@
-package band.gosrock.domain.example.domain;
+package band.gosrock.domain.domain.example.domain;
 
 
 import javax.persistence.Entity;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/example/repository/ExampleRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/example/repository/ExampleRepository.java
@@ -1,7 +1,7 @@
-package band.gosrock.domain.example.repository;
+package band.gosrock.domain.domain.example.repository;
 
 
-import band.gosrock.domain.example.domain.ExampleEntity;
+import band.gosrock.domain.domain.example.domain.ExampleEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExampleRepository extends JpaRepository<ExampleEntity, Long> {}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/example/service/ExampleDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/example/service/ExampleDomainService.java
@@ -1,9 +1,9 @@
-package band.gosrock.domain.example.service;
+package band.gosrock.domain.domain.example.service;
 
 
 import band.gosrock.common.exception.DuDoongException;
-import band.gosrock.domain.example.domain.ExampleEntity;
-import band.gosrock.domain.example.repository.ExampleRepository;
+import band.gosrock.domain.domain.example.domain.ExampleEntity;
+import band.gosrock.domain.domain.example.repository.ExampleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/AccountRole.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/AccountRole.java
@@ -1,4 +1,4 @@
-package band.gosrock.domain.user.domain;
+package band.gosrock.domain.domain.user.domain;
 
 
 import lombok.AllArgsConstructor;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/AccountState.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/AccountState.java
@@ -1,4 +1,4 @@
-package band.gosrock.domain.user.domain;
+package band.gosrock.domain.domain.user.domain;
 
 
 import lombok.AllArgsConstructor;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/OauthInfo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/OauthInfo.java
@@ -1,4 +1,4 @@
-package band.gosrock.domain.user.domain;
+package band.gosrock.domain.domain.user.domain;
 
 
 import band.gosrock.common.consts.DuDoongConsts;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/OauthProvider.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/OauthProvider.java
@@ -1,4 +1,4 @@
-package band.gosrock.domain.user.domain;
+package band.gosrock.domain.domain.user.domain;
 
 
 import lombok.AllArgsConstructor;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/Profile.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/Profile.java
@@ -1,4 +1,4 @@
-package band.gosrock.domain.user.domain;
+package band.gosrock.domain.domain.user.domain;
 
 
 import javax.persistence.Embeddable;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/User.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/User.java
@@ -1,6 +1,8 @@
 package band.gosrock.domain.domain.user.domain;
 
 
+import band.gosrock.domain.common.events.Events;
+import band.gosrock.domain.common.events.user.UserRegisterEvent;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -41,7 +43,8 @@ public class User {
 
     @PostPersist
     public void registerEvent() {
-        // TODO : 유저 등록 이벤트 발행
+        UserRegisterEvent userRegisterEvent = UserRegisterEvent.builder().userId(this.id).build();
+        Events.raise(userRegisterEvent);
     }
 
     public void changeProfile(final Profile newProfile) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/User.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/domain/User.java
@@ -1,4 +1,4 @@
-package band.gosrock.domain.user.domain;
+package band.gosrock.domain.domain.user.domain;
 
 
 import javax.persistence.Embedded;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/repository/UserRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/repository/UserRepository.java
@@ -1,7 +1,7 @@
-package band.gosrock.domain.user.repository;
+package band.gosrock.domain.domain.user.repository;
 
 
-import band.gosrock.domain.user.domain.User;
+import band.gosrock.domain.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/service/RegisterUserEventHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/service/RegisterUserEventHandler.java
@@ -17,7 +17,7 @@ public class RegisterUserEventHandler {
     @TransactionalEventListener(
             classes = UserRegisterEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
-    public void handleDeleteUserEvent(UserRegisterEvent userRegisterEvent) {
+    public void handleRegisterUserEvent(UserRegisterEvent userRegisterEvent) {
         Long userId = userRegisterEvent.getUserId();
         log.info(userId.toString() + "유저 등록");
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/service/RegisterUserEventHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/service/RegisterUserEventHandler.java
@@ -1,0 +1,24 @@
+package band.gosrock.domain.domain.user.service;
+
+
+import band.gosrock.domain.common.events.user.UserRegisterEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RegisterUserEventHandler {
+    @Async
+    @TransactionalEventListener(
+            classes = UserRegisterEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDeleteUserEvent(UserRegisterEvent userRegisterEvent) {
+        Long userId = userRegisterEvent.getUserId();
+        log.info(userId.toString() + "유저 등록");
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/service/UserDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/service/UserDomainService.java
@@ -1,7 +1,7 @@
-package band.gosrock.domain.user.service;
+package band.gosrock.domain.domain.user.service;
 
 
-import band.gosrock.domain.user.repository.UserRepository;
+import band.gosrock.domain.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/service/UserDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domain/user/service/UserDomainService.java
@@ -1,6 +1,9 @@
 package band.gosrock.domain.domain.user.service;
 
 
+import band.gosrock.domain.domain.user.domain.OauthInfo;
+import band.gosrock.domain.domain.user.domain.Profile;
+import band.gosrock.domain.domain.user.domain.User;
 import band.gosrock.domain.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,4 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserDomainService {
 
     private final UserRepository userRepository;
+
+    @Transactional
+    public User registerUser(Profile profile, OauthInfo oauthInfo) {
+        User newUser = User.builder().profile(profile).oauthInfo(oauthInfo).build();
+        userRepository.save(newUser);
+        return newUser;
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/events/DomainEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/events/DomainEvent.java
@@ -1,0 +1,13 @@
+package band.gosrock.events;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class DomainEvent {
+    private final LocalDateTime publishAt;
+
+    public DomainEvent() {
+        this.publishAt = LocalDateTime.now();
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/events/Events.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/events/Events.java
@@ -1,0 +1,23 @@
+package band.gosrock.events;
+
+import org.springframework.context.ApplicationEventPublisher;
+
+public class Events {
+    private static ThreadLocal<ApplicationEventPublisher> publisherLocal = new ThreadLocal<>();
+
+    public static void raise(DomainEvent event) {
+        if (event == null) return;
+
+        if (publisherLocal.get() != null) {
+            publisherLocal.get().publishEvent(event);
+        }
+    }
+
+    static void setPublisher(ApplicationEventPublisher publisher) {
+        publisherLocal.set(publisher);
+    }
+
+    static void reset() {
+        publisherLocal.remove();
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/events/user/UserRegisterEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/events/user/UserRegisterEvent.java
@@ -1,0 +1,15 @@
+package band.gosrock.events.user;
+
+import band.gosrock.events.DomainEvent;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserRegisterEvent extends DomainEvent {
+    private final Long userId;
+
+    @Builder
+    public UserRegisterEvent(Long userId) {
+        this.userId = userId;
+    }
+}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domain/user/service/RegisterUserEventHandlerTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domain/user/service/RegisterUserEventHandlerTest.java
@@ -1,0 +1,41 @@
+package band.gosrock.domain.domain.user.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+
+import band.gosrock.domain.domain.user.domain.OauthInfo;
+import band.gosrock.domain.domain.user.domain.Profile;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+class RegisterUserEventHandlerTest {
+
+    @Autowired UserDomainService userDomainService;
+    @MockBean RegisterUserEventHandler registerUserEventHandler;
+
+    @Test
+    void 유저등록시도메인이벤트가발생해야한다() {
+        // given
+        Profile profile = Profile.builder().build();
+        OauthInfo oauthInfo = OauthInfo.builder().build();
+        //        given(registerUserEventHandler.handleRegisterUserEvent(any())).will(new Answer() {
+        //            @Override
+        //            public UserRegisterEvent answer(InvocationOnMock invocation) throws Throwable
+        // {
+        //                Object[] args = invocation.getArguments();
+        //                UserRegisterEvent userRegisterEvent = (UserRegisterEvent) args[0];
+        //                System.out.println(userRegisterEvent.getUserId());
+        //                return UserRegisterEvent.builder().build();
+        //            }
+        //        });
+        // when
+        userDomainService.registerUser(profile, oauthInfo);
+
+        // then
+        BDDMockito.then(registerUserEventHandler).should(times(1)).handleRegisterUserEvent(any());
+    }
+}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/user/domain/OauthInfoTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/user/domain/OauthInfoTest.java
@@ -3,6 +3,8 @@ package band.gosrock.domain.user.domain;
 import static org.junit.jupiter.api.Assertions.*;
 
 import band.gosrock.common.consts.DuDoongConsts;
+import band.gosrock.domain.domain.user.domain.OauthInfo;
+import band.gosrock.domain.domain.user.domain.OauthProvider;
 import org.junit.jupiter.api.Test;
 
 class OauthInfoTest {

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/user/domain/UserTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/user/domain/UserTest.java
@@ -2,6 +2,8 @@ package band.gosrock.domain.user.domain;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import band.gosrock.domain.domain.user.domain.Profile;
+import band.gosrock.domain.domain.user.domain.User;
 import org.junit.jupiter.api.Test;
 
 class UserTest {


### PR DESCRIPTION
## 개요
- close #9 
- 도메인간 이벤트 발생을 위한 객체를 추가했습니다.
- Transactional 어노테이션이 달린 메소드 레벨에서 도메인 객체 내부에서 이벤트를 발생시키면
이벤트를 퍼블리싱합니다.

## 작업사항
- 도메인 모듈  내부에서 테스트를 위한 DuDoongDomainApplication 추가
- 이벤트 퍼블리싱 되는지 유저 등록 이벤트로 확인

## 변경로직
