### PR TITLE
feat(domain) : redisson 기반 분산락 aop 설정 (#8) 

### DIFF
--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
@@ -28,7 +28,8 @@ public enum ErrorCode {
     OTHER_SERVER_BAD_REQUEST(BAD_REQUEST, "FEIGN-400-1", "Other server bad request"),
     OTHER_SERVER_UNAUTHORIZED(BAD_REQUEST, "FEIGN-400-2", "Other server unauthorized"),
     OTHER_SERVER_FORBIDDEN(BAD_REQUEST, "FEIGN-400-3", "Other server forbidden"),
-    OTHER_SERVER_EXPIRED_TOKEN(BAD_REQUEST, "FEIGN-400-4", "Other server expired token");
+    OTHER_SERVER_EXPIRED_TOKEN(BAD_REQUEST, "FEIGN-400-4", "Other server expired token"),
+    NOT_AVAILABLE_REDISSON_LOCK(500, "Redisson-500-1", "can not get redisson lock");
     private int status;
     private String code;
     private String reason;

--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/NotAvailableRedissonLockException.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/NotAvailableRedissonLockException.java
@@ -1,0 +1,10 @@
+package band.gosrock.common.exception;
+
+public class NotAvailableRedissonLockException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new NotAvailableRedissonLockException();
+
+    private NotAvailableRedissonLockException() {
+        super(ErrorCode.NOT_AVAILABLE_REDISSON_LOCK);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/domainEvent/DomainEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/domainEvent/DomainEvent.java
@@ -1,4 +1,4 @@
-package band.gosrock.domain.common.events;
+package band.gosrock.domain.common.aop.domainEvent;
 
 
 import java.time.LocalDateTime;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/domainEvent/EventPublisherAspect.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/domainEvent/EventPublisherAspect.java
@@ -1,7 +1,7 @@
-package band.gosrock.domain.common.aspect;
+package band.gosrock.domain.common.aop.domainEvent;
 
 
-import band.gosrock.domain.common.events.Events;
+import band.gosrock.domain.common.aop.domainEvent.Events;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/domainEvent/EventPublisherAspect.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/domainEvent/EventPublisherAspect.java
@@ -1,7 +1,6 @@
 package band.gosrock.domain.common.aop.domainEvent;
 
 
-import band.gosrock.domain.common.aop.domainEvent.Events;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/domainEvent/Events.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/domainEvent/Events.java
@@ -1,4 +1,4 @@
-package band.gosrock.domain.common.events;
+package band.gosrock.domain.common.aop.domainEvent;
 
 
 import org.springframework.context.ApplicationEventPublisher;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonCallTransaction.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonCallTransaction.java
@@ -1,0 +1,23 @@
+package band.gosrock.domain.common.aop.redissonLock;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedissonCallTransaction {
+    // 다른 트랜젹선이 걸린서비스가 해당 조인포인트(메서드를) 호출하더라도
+    // 새로운 트랜잭션이 보장되어야합니다. (재고를 감소시키는 로직이므로)
+    // leaseTime 보다 트랜잭션 타임아웃을 작게 설정
+    // leastTimeOut 발생전에 rollback 시키기 위함
+    @Transactional(propagation = Propagation.REQUIRES_NEW, timeout = 9)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLock.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLock.java
@@ -1,0 +1,24 @@
+package band.gosrock.domain.common.aop.redissonLock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Redisson 을 활용한 분산락을 걸 메소드에 다는 어노테이션 입니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RedissonLock {
+    // 분산락을 걸 고유 키값
+    String key();
+
+    // redisson default waitTime 이 30 s 임
+    long waitTime() default 5L;
+
+    long leaseTime() default 3L;
+    // 초단위 계산
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLock.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLock.java
@@ -1,14 +1,13 @@
 package band.gosrock.domain.common.aop.redissonLock;
 
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.concurrent.TimeUnit;
 
-/**
- * Redisson 을 활용한 분산락을 걸 메소드에 다는 어노테이션 입니다.
- */
+/** Redisson 을 활용한 분산락을 걸 메소드에 다는 어노테이션 입니다. */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RedissonLock {
@@ -16,9 +15,9 @@ public @interface RedissonLock {
     String key();
 
     // redisson default waitTime 이 30 s 임
-    long waitTime() default 5L;
+    long waitTime() default 10L;
 
-    long leaseTime() default 3L;
+    long leaseTime() default 10L;
     // 초단위 계산
     TimeUnit timeUnit() default TimeUnit.SECONDS;
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAop.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAop.java
@@ -1,0 +1,77 @@
+package band.gosrock.domain.common.aop.redissonLock;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+import band.gosrock.common.exception.DuDoongDynamicException;
+import band.gosrock.common.exception.NotAvailableRedissonLockException;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.TransactionTimedOutException;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedissonLockAop {
+    private final RedissonClient redissonClient;
+    private final RedissonCallTransaction redissonCallTransaction;
+
+    @Around("@annotation(band.gosrock.domain.common.aop.redissonLock.RedissonLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        RedissonLock redissonLock = method.getAnnotation(RedissonLock.class);
+        String key = this.createKey(signature.getParameterNames(), joinPoint.getArgs(), redissonLock.key());
+        RLock rLock = redissonClient.getLock(key);
+
+        long waitTime = redissonLock.waitTime();
+        long leaseTime = redissonLock.leaseTime();
+        TimeUnit timeUnit = redissonLock.timeUnit();
+        try {
+            boolean available = rLock.tryLock(waitTime, leaseTime, timeUnit);
+            if (!available) {
+                throw NotAvailableRedissonLockException.EXCEPTION;
+            }
+            return redissonCallTransaction.proceed(joinPoint);
+        } catch (DuDoongCodeException | DuDoongDynamicException | TransactionTimedOutException e) {
+            throw e;
+        } finally {
+            try {
+                rLock.unlock();
+            } catch (IllegalMonitorStateException e) {
+                rLock.forceUnlock();
+            }
+        }
+    }
+
+    /**
+     * Redisson Key Create
+     * @param parameterNames
+     * @param args
+     * @param key
+     * @return
+     */
+    private String createKey(String[] parameterNames, Object[] args, String key) {
+        String resultKey = key;
+
+        /* key = parameterName */
+        for (int i = 0; i < parameterNames.length; i++) {
+            if (parameterNames[i].equals(key)) {
+                resultKey += args[i];
+                break;
+            }
+        }
+
+        return resultKey;
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAop.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAop.java
@@ -31,7 +31,9 @@ public class RedissonLockAop {
         Method method = signature.getMethod();
 
         RedissonLock redissonLock = method.getAnnotation(RedissonLock.class);
-        String key = this.createKey(signature.getParameterNames(), joinPoint.getArgs(), redissonLock.key());
+        String key =
+                this.createKey(
+                        signature.getParameterNames(), joinPoint.getArgs(), redissonLock.key());
         RLock rLock = redissonClient.getLock(key);
 
         long waitTime = redissonLock.waitTime();
@@ -56,6 +58,7 @@ public class RedissonLockAop {
 
     /**
      * Redisson Key Create
+     *
      * @param parameterNames
      * @param args
      * @param key

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/user/UserRegisterEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/user/UserRegisterEvent.java
@@ -1,7 +1,7 @@
 package band.gosrock.domain.common.events.user;
 
 
-import band.gosrock.domain.common.events.DomainEvent;
+import band.gosrock.domain.common.aop.domainEvent.DomainEvent;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
@@ -1,7 +1,7 @@
 package band.gosrock.domain.domains.user.domain;
 
 
-import band.gosrock.domain.common.events.Events;
+import band.gosrock.domain.common.aop.domainEvent.Events;
 import band.gosrock.domain.common.events.user.UserRegisterEvent;
 import band.gosrock.domain.common.model.BaseTimeEntity;
 import javax.persistence.Embedded;


### PR DESCRIPTION
## 개요
- close #8 

## 작업사항
- redisson 기반으로 분산락 aop 추가했습니다
- 중요한 포인트는 락을 잡을 key 값을 꼭 설정해야하는겁니다.
- 파라미터로 String userId 를 넘겨준다했을때
- key 로 userId 를 잡아야합니다.
- 그래야 5번이 수정중인데 6번도 못수정하는 레코드간 영역 침범이 일어나지않습니다.

## 변경로직
- 내용을 적어주세요.