### PR TITLE
feat(api) : 유저 회원 탈퇴, 로그아웃  로직 (#37)

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/controller/AuthController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/controller/AuthController.java
@@ -87,17 +87,17 @@ public class AuthController {
         return refreshUseCase.execute(code);
     }
 
-    @Operation(summary = "refreshToken 용입니다.")
+    @Operation(summary = "회원탈퇴를 합니다.")
     @SecurityRequirement(name = "access-token")
     @DeleteMapping("/me")
     public void withDrawUser() {
-        return withDrawUseCase.execute();
+        withDrawUseCase.execute();
     }
 
-    @Operation(summary = "refreshToken 용입니다.")
+    @Operation(summary = "로그아웃을 합니다.")
     @SecurityRequirement(name = "access-token")
     @PostMapping("/logout")
     public void logoutUser() {
-        return logoutUseCase.execute();
+        //        return logoutUseCase.execute();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/controller/AuthController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/controller/AuthController.java
@@ -7,13 +7,17 @@ import band.gosrock.api.auth.model.dto.response.OauthLoginLinkResponse;
 import band.gosrock.api.auth.model.dto.response.OauthUserInfoResponse;
 import band.gosrock.api.auth.model.dto.response.TokenAndUserResponse;
 import band.gosrock.api.auth.service.LoginUseCase;
+import band.gosrock.api.auth.service.LogoutUseCase;
 import band.gosrock.api.auth.service.OauthUserInfoUseCase;
 import band.gosrock.api.auth.service.RefreshUseCase;
 import band.gosrock.api.auth.service.RegisterUseCase;
+import band.gosrock.api.auth.service.WithDrawUseCase;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,6 +37,9 @@ public class AuthController {
     private final RefreshUseCase refreshUseCase;
 
     private final OauthUserInfoUseCase oauthUserInfoUseCase;
+
+    private final WithDrawUseCase withDrawUseCase;
+    private final LogoutUseCase logoutUseCase;
 
     @Operation(summary = "kakao oauth 링크발급", description = "kakao 링크를 받아볼수 있습니다.")
     @GetMapping("/oauth/kakao/link")
@@ -78,5 +85,19 @@ public class AuthController {
     @PostMapping("/token/refresh")
     public TokenAndUserResponse tokenRefresh(@RequestParam("token") String code) {
         return refreshUseCase.execute(code);
+    }
+
+    @Operation(summary = "refreshToken 용입니다.")
+    @SecurityRequirement(name = "access-token")
+    @DeleteMapping("/me")
+    public void withDrawUser() {
+        return withDrawUseCase.execute();
+    }
+
+    @Operation(summary = "refreshToken 용입니다.")
+    @SecurityRequirement(name = "access-token")
+    @PostMapping("/logout")
+    public void logoutUser() {
+        return logoutUseCase.execute();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/controller/AuthController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/controller/AuthController.java
@@ -98,6 +98,6 @@ public class AuthController {
     @SecurityRequirement(name = "access-token")
     @PostMapping("/logout")
     public void logoutUser() {
-        //        return logoutUseCase.execute();
+        logoutUseCase.execute();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/LoginUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/LoginUseCase.java
@@ -2,6 +2,8 @@ package band.gosrock.api.auth.service;
 
 
 import band.gosrock.api.auth.model.dto.response.TokenAndUserResponse;
+import band.gosrock.api.auth.service.helper.KakaoOauthHelper;
+import band.gosrock.api.auth.service.helper.TokenGenerateHelper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.user.domain.OauthInfo;
 import band.gosrock.domain.domains.user.domain.User;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/LogoutUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/LogoutUseCase.java
@@ -1,10 +1,9 @@
 package band.gosrock.api.auth.service;
 
+
 import band.gosrock.common.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
 @RequiredArgsConstructor
-public class LogoutUseCase {
-
-}
+public class LogoutUseCase {}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/LogoutUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/LogoutUseCase.java
@@ -1,0 +1,10 @@
+package band.gosrock.api.auth.service;
+
+import band.gosrock.common.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class LogoutUseCase {
+
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/LogoutUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/LogoutUseCase.java
@@ -1,9 +1,18 @@
 package band.gosrock.api.auth.service;
 
 
+import band.gosrock.api.config.security.SecurityUtils;
 import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.user.adaptor.RefreshTokenAdaptor;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
 @RequiredArgsConstructor
-public class LogoutUseCase {}
+public class LogoutUseCase {
+    private final RefreshTokenAdaptor refreshTokenAdaptor;
+
+    public void execute() {
+        Long currentUserId = SecurityUtils.getCurrentUserId();
+        refreshTokenAdaptor.deleteByUserId(currentUserId);
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/OauthUserInfoUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/OauthUserInfoUseCase.java
@@ -3,6 +3,7 @@ package band.gosrock.api.auth.service;
 
 import band.gosrock.api.auth.model.dto.KakaoUserInfoDto;
 import band.gosrock.api.auth.model.dto.response.OauthUserInfoResponse;
+import band.gosrock.api.auth.service.helper.KakaoOauthHelper;
 import band.gosrock.common.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/RefreshUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/RefreshUseCase.java
@@ -2,6 +2,7 @@ package band.gosrock.api.auth.service;
 
 
 import band.gosrock.api.auth.model.dto.response.TokenAndUserResponse;
+import band.gosrock.api.auth.service.helper.TokenGenerateHelper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.common.jwt.JwtTokenProvider;
 import band.gosrock.domain.domains.user.adaptor.RefreshTokenAdaptor;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/RegisterUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/RegisterUseCase.java
@@ -6,6 +6,8 @@ import band.gosrock.api.auth.model.dto.request.RegisterRequest;
 import band.gosrock.api.auth.model.dto.response.AvailableRegisterResponse;
 import band.gosrock.api.auth.model.dto.response.OauthLoginLinkResponse;
 import band.gosrock.api.auth.model.dto.response.TokenAndUserResponse;
+import band.gosrock.api.auth.service.helper.KakaoOauthHelper;
+import band.gosrock.api.auth.service.helper.TokenGenerateHelper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.user.domain.OauthInfo;
 import band.gosrock.domain.domains.user.domain.Profile;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/WithDrawUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/WithDrawUseCase.java
@@ -1,9 +1,12 @@
 package band.gosrock.api.auth.service;
 
+
 import band.gosrock.api.auth.service.helper.KakaoOauthHelper;
 import band.gosrock.api.config.security.SecurityUtils;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.user.adaptor.RefreshTokenAdaptor;
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
+import band.gosrock.domain.domains.user.domain.User;
 import band.gosrock.domain.domains.user.service.UserDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,13 +17,16 @@ public class WithDrawUseCase {
 
     private final RefreshTokenAdaptor refreshTokenAdaptor;
     private final UserDomainService userDomainService;
+    private final UserAdaptor userAdaptor;
     private final KakaoOauthHelper kakaoOauthHelper;
 
     @Transactional
     public void execute() {
         Long currentUserId = SecurityUtils.getCurrentUserId();
-        kakaoOauthHelper.unlink();
         refreshTokenAdaptor.deleteByUserId(currentUserId);
+        User user = userAdaptor.queryUser(currentUserId);
+        String oid = user.getOauthInfo().getOid();
         userDomainService.withDrawUser(currentUserId);
+        kakaoOauthHelper.unlink(oid);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/WithDrawUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/WithDrawUseCase.java
@@ -1,0 +1,26 @@
+package band.gosrock.api.auth.service;
+
+import band.gosrock.api.auth.service.helper.KakaoOauthHelper;
+import band.gosrock.api.config.security.SecurityUtils;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.user.adaptor.RefreshTokenAdaptor;
+import band.gosrock.domain.domains.user.service.UserDomainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class WithDrawUseCase {
+
+    private final RefreshTokenAdaptor refreshTokenAdaptor;
+    private final UserDomainService userDomainService;
+    private final KakaoOauthHelper kakaoOauthHelper;
+
+    @Transactional
+    public void execute() {
+        Long currentUserId = SecurityUtils.getCurrentUserId();
+        kakaoOauthHelper.unlink();
+        refreshTokenAdaptor.deleteByUserId(currentUserId);
+        userDomainService.withDrawUser(currentUserId);
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/KakaoOauthHelper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/KakaoOauthHelper.java
@@ -1,9 +1,10 @@
-package band.gosrock.api.auth.service;
+package band.gosrock.api.auth.service.helper;
 
 import static band.gosrock.common.consts.DuDoongStatic.BEARER;
 import static band.gosrock.common.consts.DuDoongStatic.KAKAO_OAUTH_QUERY_STRING;
 
 import band.gosrock.api.auth.model.dto.KakaoUserInfoDto;
+import band.gosrock.api.auth.service.helper.OauthOIDCHelper;
 import band.gosrock.common.annotation.Helper;
 import band.gosrock.common.dto.OIDCDecodePayload;
 import band.gosrock.common.properties.OauthProperties;
@@ -25,7 +26,7 @@ public class KakaoOauthHelper {
 
     private final OauthOIDCHelper oauthOIDCHelper;
 
-    protected String getKaKaoOauthLink() {
+    public String getKaKaoOauthLink() {
         return oauthProperties.getKakaoBaseUrl()
                 + String.format(
                         KAKAO_OAUTH_QUERY_STRING,

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/KakaoOauthHelper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/KakaoOauthHelper.java
@@ -4,7 +4,6 @@ import static band.gosrock.common.consts.DuDoongStatic.BEARER;
 import static band.gosrock.common.consts.DuDoongStatic.KAKAO_OAUTH_QUERY_STRING;
 
 import band.gosrock.api.auth.model.dto.KakaoUserInfoDto;
-import band.gosrock.api.auth.service.helper.OauthOIDCHelper;
 import band.gosrock.common.annotation.Helper;
 import band.gosrock.common.dto.OIDCDecodePayload;
 import band.gosrock.common.properties.OauthProperties;
@@ -14,6 +13,7 @@ import band.gosrock.infrastructure.outer.api.client.KakaoInfoClient;
 import band.gosrock.infrastructure.outer.api.client.KakaoOauthClient;
 import band.gosrock.infrastructure.outer.api.dto.KakaoInformationResponse;
 import band.gosrock.infrastructure.outer.api.dto.OIDCPublicKeysResponse;
+import band.gosrock.infrastructure.outer.api.dto.UnlinkKaKaoTarget;
 import lombok.RequiredArgsConstructor;
 
 @Helper
@@ -74,5 +74,12 @@ public class KakaoOauthHelper {
                 .provider(OauthProvider.KAKAO)
                 .oid(oidcDecodePayload.getSub())
                 .build();
+    }
+
+    public void unlink(String oid) {
+        String kakaoAdminKey = oauthProperties.getKakaoAdminKey();
+        UnlinkKaKaoTarget unlinkKaKaoTarget = UnlinkKaKaoTarget.from(oid);
+        String header = "KakaoAK " + kakaoAdminKey;
+        kakaoInfoClient.unlinkUser(header, unlinkKaKaoTarget);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/OauthOIDCHelper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/OauthOIDCHelper.java
@@ -1,4 +1,4 @@
-package band.gosrock.api.auth.service;
+package band.gosrock.api.auth.service.helper;
 
 
 import band.gosrock.common.annotation.Helper;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/TokenGenerateHelper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/TokenGenerateHelper.java
@@ -1,4 +1,4 @@
-package band.gosrock.api.auth.service;
+package band.gosrock.api.auth.service.helper;
 
 
 import band.gosrock.api.auth.model.dto.response.TokenAndUserResponse;

--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
@@ -32,7 +32,8 @@ public enum ErrorCode {
     NOT_AVAILABLE_REDISSON_LOCK(500, "Redisson-500-1", "can not get redisson lock"),
     SECURITY_CONTEXT_NOT_FOUND(500, "GLOBAL-500-2", "security context not found"),
     USER_ALREADY_SIGNUP(BAD_REQUEST, "USER-400-1", "User already signup"),
-    USER_FORBIDDEN(FORBIDDEN, "USER_403_1", "user forbidden");
+    USER_FORBIDDEN(FORBIDDEN, "USER_403_1", "user forbidden"),
+    USER_ALREADY_DELETED(FORBIDDEN, "USER_403_2", "user already deleted");
     private int status;
     private String code;
     private String reason;

--- a/DuDoong-Common/src/main/java/band/gosrock/common/properties/OauthProperties.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/properties/OauthProperties.java
@@ -15,6 +15,10 @@ public class OauthProperties {
 
     private OAuthSecret kakao;
 
+    public String getKakaoAdminKey() {
+        return kakao.getAdminKey();
+    }
+
     @Getter
     @Setter
     public static class OAuthSecret {
@@ -23,6 +27,7 @@ public class OauthProperties {
         private String clientSecret;
         private String redirectUrl;
         private String appId;
+        private String adminKey;
     }
 
     public String getKakaoBaseUrl() {

--- a/DuDoong-Common/src/main/resources/application-common.yml
+++ b/DuDoong-Common/src/main/resources/application-common.yml
@@ -11,3 +11,4 @@ oauth:
     client-secret: ${KAKAO_SECRET}
     redirect-url: ${KAKAO_REDIRECT}
     app-id: ${KAKAO_APP_ID}
+    admin-key: ${KAKAO_ADMIN_KEY}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/adaptor/RefreshTokenAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/adaptor/RefreshTokenAdaptor.java
@@ -22,4 +22,8 @@ public class RefreshTokenAdaptor {
     public RefreshTokenEntity save(RefreshTokenEntity refreshToken) {
         return refreshTokenRepository.save(refreshToken);
     }
+
+    public void deleteByUserId(Long userId) {
+        refreshTokenRepository.deleteById(userId.toString());
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/OauthInfo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/OauthInfo.java
@@ -2,6 +2,8 @@ package band.gosrock.domain.domains.user.domain;
 
 
 import band.gosrock.common.consts.DuDoongStatic;
+import java.time.LocalDateTime;
+import java.util.Date;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -27,9 +29,8 @@ public class OauthInfo {
     }
 
     public OauthInfo withDrawOauthInfo() {
-        // TODO : 탈퇴이벤트
         return OauthInfo.builder()
-                .oid(DuDoongStatic.WITHDRAW_PREFIX + oid)
+                .oid(DuDoongStatic.WITHDRAW_PREFIX + LocalDateTime.now() +":"+ oid)
                 .provider(provider)
                 .build();
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/OauthInfo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/OauthInfo.java
@@ -3,7 +3,6 @@ package band.gosrock.domain.domains.user.domain;
 
 import band.gosrock.common.consts.DuDoongStatic;
 import java.time.LocalDateTime;
-import java.util.Date;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -30,7 +29,7 @@ public class OauthInfo {
 
     public OauthInfo withDrawOauthInfo() {
         return OauthInfo.builder()
-                .oid(DuDoongStatic.WITHDRAW_PREFIX + LocalDateTime.now() +":"+ oid)
+                .oid(DuDoongStatic.WITHDRAW_PREFIX + LocalDateTime.now() + ":" + oid)
                 .provider(provider)
                 .build();
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
@@ -58,7 +58,7 @@ public class User extends BaseTimeEntity {
     }
 
     public void withDrawUser() {
-        if(accountState.equals(AccountState.DELETED)){
+        if (accountState.equals(AccountState.DELETED)) {
             throw AlreadyDeletedUserException.EXCEPTION;
         }
         accountState = AccountState.DELETED;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
@@ -4,6 +4,7 @@ package band.gosrock.domain.domains.user.domain;
 import band.gosrock.domain.common.aop.domainEvent.Events;
 import band.gosrock.domain.common.events.user.UserRegisterEvent;
 import band.gosrock.domain.common.model.BaseTimeEntity;
+import band.gosrock.domain.domains.user.exception.AlreadyDeletedUserException;
 import band.gosrock.domain.domains.user.exception.ForbiddenUserException;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -57,6 +58,9 @@ public class User extends BaseTimeEntity {
     }
 
     public void withDrawUser() {
+        if(accountState.equals(AccountState.DELETED)){
+            throw AlreadyDeletedUserException.EXCEPTION;
+        }
         accountState = AccountState.DELETED;
         oauthInfo = oauthInfo.withDrawOauthInfo();
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/exception/AlreadyDeletedUserException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/exception/AlreadyDeletedUserException.java
@@ -1,0 +1,14 @@
+package band.gosrock.domain.domains.user.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+import band.gosrock.common.exception.ErrorCode;
+
+public class AlreadyDeletedUserException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new AlreadyDeletedUserException();
+
+    private AlreadyDeletedUserException() {
+        super(ErrorCode.USER_ALREADY_DELETED);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/service/UserDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/service/UserDomainService.java
@@ -56,9 +56,8 @@ public class UserDomainService {
     }
 
     @Transactional
-    public User withDrawUser(Long userId){
+    public void withDrawUser(Long userId) {
         User user = userAdaptor.queryUser(userId);
         user.withDrawUser();
-        return user;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/service/UserDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/service/UserDomainService.java
@@ -54,4 +54,11 @@ public class UserDomainService {
         user.login();
         return user;
     }
+
+    @Transactional
+    public User withDrawUser(Long userId){
+        User user = userAdaptor.queryUser(userId);
+        user.withDrawUser();
+        return user;
+    }
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domains/user/domain/OauthInfoTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domains/user/domain/OauthInfoTest.java
@@ -21,6 +21,6 @@ class OauthInfoTest {
         OauthInfo withDrawOauthInfo = oauthInfo.withDrawOauthInfo();
 
         // then
-        assertEquals(withDrawOid, withDrawOauthInfo.getOid());
+        assertTrue(withDrawOauthInfo.getOid().startsWith(DuDoongStatic.WITHDRAW_PREFIX));
     }
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/feign/FeignConfig.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/feign/FeignConfig.java
@@ -3,6 +3,7 @@ package band.gosrock.infrastructure.config.feign;
 
 import band.gosrock.infrastructure.DuDoongInfraApplication;
 import feign.Logger.Level;
+import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.openfeign.EnableFeignClients;
@@ -24,5 +25,10 @@ public class FeignConfig {
     @ConditionalOnMissingBean(value = ErrorDecoder.class)
     public FeignClientErrorDecoder commonFeignErrorDecoder() {
         return new FeignClientErrorDecoder();
+    }
+
+    @Bean
+    Encoder formEncoder() {
+        return new feign.form.FormEncoder();
     }
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/client/KakaoInfoClient.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/client/KakaoInfoClient.java
@@ -2,7 +2,9 @@ package band.gosrock.infrastructure.outer.api.client;
 
 
 import band.gosrock.infrastructure.outer.api.dto.KakaoInformationResponse;
+import band.gosrock.infrastructure.outer.api.dto.UnlinkKaKaoTarget;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -13,6 +15,7 @@ public interface KakaoInfoClient {
     @GetMapping("/v2/user/me")
     KakaoInformationResponse kakaoUserInfo(@RequestHeader("Authorization") String accessToken);
 
-    @PostMapping("/v1/user/unlink")
-    void unlinkUser(@RequestHeader("Authorization") String accessToken);
+    @PostMapping(path = "/v1/user/unlink", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    void unlinkUser(
+            @RequestHeader("Authorization") String adminKey, UnlinkKaKaoTarget unlinkKaKaoTarget);
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/dto/UnlinkKaKaoTarget.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/dto/UnlinkKaKaoTarget.java
@@ -1,0 +1,22 @@
+package band.gosrock.infrastructure.outer.api.dto;
+
+
+import lombok.Getter;
+
+@Getter
+public class UnlinkKaKaoTarget {
+
+    @feign.form.FormProperty("target_id_type")
+    private String targetIdType = "user_id";
+
+    @feign.form.FormProperty("target_id")
+    private String aud;
+
+    public UnlinkKaKaoTarget(String aud) {
+        this.aud = aud;
+    }
+
+    public static UnlinkKaKaoTarget from(String aud) {
+        return new UnlinkKaKaoTarget(aud);
+    }
+}


### PR DESCRIPTION
## 개요
- close #37 

## 작업사항
- 카카오 어드민 키로 unlink feign 요청
- 레디스에서 리프레쉬 토큰 지워주기
- 유저 회원 탈퇴 상태 변화

## 변경로직
- 내용을 적어주세요.