### PR TITLE
feat(domain) : 분산락 락 키 관련 커스텀 오브젝트 안에 키도 가져올수 있도록 설정 (#40)

### DIFF
--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/BadLockIdentifierException.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/BadLockIdentifierException.java
@@ -1,0 +1,10 @@
+package band.gosrock.common.exception;
+
+public class BadLockIdentifierException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new BadLockIdentifierException();
+
+    private BadLockIdentifierException() {
+        super(ErrorCode.BAD_LOCK_IDENTIFIER);
+    }
+}

--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
@@ -33,7 +33,8 @@ public enum ErrorCode {
     SECURITY_CONTEXT_NOT_FOUND(500, "GLOBAL-500-2", "security context not found"),
     USER_ALREADY_SIGNUP(BAD_REQUEST, "USER-400-1", "User already signup"),
     USER_FORBIDDEN(FORBIDDEN, "USER_403_1", "user forbidden"),
-    USER_ALREADY_DELETED(FORBIDDEN, "USER_403_2", "user already deleted");
+    USER_ALREADY_DELETED(FORBIDDEN, "USER_403_2", "user already deleted"),
+    BAD_LOCK_IDENTIFIER(500, "AOP_500_1", "락의 키값이 잘못 세팅 되었습니다");
     private int status;
     private String code;
     private String reason;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLock.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLock.java
@@ -12,8 +12,9 @@ import java.util.concurrent.TimeUnit;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RedissonLock {
     // 분산락을 걸 파라미터 네임
-    String key();
+    String identifier();
 
+    // 락 이름
     String LockName();
 
     Class<?> paramClassType() default Object.class;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAop.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAop.java
@@ -5,8 +5,6 @@ import band.gosrock.common.exception.DuDoongCodeException;
 import band.gosrock.common.exception.DuDoongDynamicException;
 import band.gosrock.common.exception.NotAvailableRedissonLockException;
 import java.lang.reflect.Method;
-import java.util.LinkedHashSet;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,12 +14,9 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
-import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.env.Environment;
-import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.TransactionTimedOutException;
-import org.springframework.util.ClassUtils;
 
 @Aspect
 @Component
@@ -38,11 +33,16 @@ public class RedissonLockAop {
         Method method = signature.getMethod();
 
         RedissonLock redissonLock = method.getAnnotation(RedissonLock.class);
-        //        String key =
-        //                this.createKey(
-        //                        signature.getParameterNames(), joinPoint.getArgs(),
-        // redissonLock.key());
-        RLock rLock = redissonClient.getLock("key");
+        String baseKey = redissonLock.LockName();
+
+        String DynamicKey =
+                generateDynamicKey(
+                        redissonLock.identifier(),
+                        joinPoint.getArgs(),
+                        redissonLock.paramClassType(),
+                        signature.getParameterNames());
+
+        RLock rLock = redissonClient.getLock(baseKey + DynamicKey);
 
         long waitTime = redissonLock.waitTime();
         long leaseTime = redissonLock.leaseTime();
@@ -64,10 +64,22 @@ public class RedissonLockAop {
         }
     }
 
+    private String generateDynamicKey(
+            String identifier, Object[] args, Class<?> paramClassType, String[] parameterNames)
+            throws NoSuchFieldException {
+
+        String dynamicKey;
+        if (paramClassType.equals(Object.class)) {
+            dynamicKey = createDynamicKeyFromPrimitive(parameterNames, args, identifier);
+        } else {
+            dynamicKey = createDynamicKeyFromObject(parameterNames, paramClassType, identifier);
+        }
+        return dynamicKey;
+    }
+
     private String createDynamicKeyFromPrimitive(
             String[] methodParameterNames, Object[] args, String key) {
         String dynamicKey = "";
-        /* key = parameterName */
         for (int i = 0; i < methodParameterNames.length; i++) {
             if (methodParameterNames[i].equals(key)) {
                 dynamicKey += args[i];
@@ -77,31 +89,16 @@ public class RedissonLockAop {
         return dynamicKey;
     }
 
-    private String createDynamicKeyFromObject(Object[] args, String key, Class<?> paramClassType)
+    private String createDynamicKeyFromObject(Object[] args, Class<?> paramClassType, String key)
             throws NoSuchFieldException {
         String dynamicKey = "";
-        /* key = parameterName */
-        String name = paramClassType.getName();
+        String name = paramClassType.getSimpleName();
         for (int i = 0; i < args.length; i++) {
-            if (args[i].getClass().getName().equals(name)) {
+            if (args[i].getClass().getSimpleName().equals(name)) {
                 dynamicKey += args[i].getClass().getField(key);
                 break;
             }
         }
         return dynamicKey;
-    }
-
-    private Set<String> getPackagesToScan(AnnotationMetadata metadata) {
-        AnnotationAttributes attributes =
-                AnnotationAttributes.fromMap(
-                        metadata.getAnnotationAttributes(RedissonLock.class.getName()));
-        Set<String> classScan = new LinkedHashSet<>();
-
-        for (Class<?> basePackageClass : attributes.getClassArray("paramClassType")) {
-            classScan.add(
-                    this.environment.resolvePlaceholders(
-                            ClassUtils.getPackageName(basePackageClass)));
-        }
-        return classScan;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAop.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAop.java
@@ -43,9 +43,9 @@ public class RedissonLockAop {
                         redissonLock.paramClassType(),
                         signature.getParameterNames());
 
-        RLock rLock = redissonClient.getLock(baseKey+":" + dynamicKey);
+        RLock rLock = redissonClient.getLock(baseKey + ":" + dynamicKey);
 
-        log.info("redisson 키 설정" + baseKey+":" + dynamicKey);
+        log.info("redisson 키 설정" + baseKey + ":" + dynamicKey);
 
         long waitTime = redissonLock.waitTime();
         long leaseTime = redissonLock.leaseTime();

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/service/UserDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/service/UserDomainService.java
@@ -19,10 +19,7 @@ public class UserDomainService {
     private final UserAdaptor userAdaptor;
 
     @Transactional
-    @RedissonLock(
-            LockName = "유저등록",
-            identifier = "oid",
-            paramClassType = OauthInfo.class)
+    @RedissonLock(LockName = "유저등록", identifier = "oid", paramClassType = OauthInfo.class)
     public User registerUser(Profile profile, OauthInfo oauthInfo) {
         validUserCanRegister(oauthInfo);
         User newUser = User.builder().profile(profile).oauthInfo(oauthInfo).build();
@@ -31,10 +28,7 @@ public class UserDomainService {
     }
 
     @Transactional
-    @RedissonLock(
-        LockName = "개발용회원가입",
-        identifier = "oid",
-        paramClassType = OauthInfo.class)
+    @RedissonLock(LockName = "개발용회원가입", identifier = "oid", paramClassType = OauthInfo.class)
     public User upsertUser(Profile profile, OauthInfo oauthInfo) {
         return userRepository
                 .findByOauthInfo(oauthInfo)
@@ -63,9 +57,7 @@ public class UserDomainService {
     }
 
     @Transactional
-    @RedissonLock(
-        LockName = "유저탈퇴",
-        identifier = "userId")
+    @RedissonLock(LockName = "유저탈퇴", identifier = "userId")
     public void withDrawUser(Long userId) {
         User user = userAdaptor.queryUser(userId);
         user.withDrawUser();

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/service/UserDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/service/UserDomainService.java
@@ -2,6 +2,7 @@ package band.gosrock.domain.domains.user.service;
 
 
 import band.gosrock.common.annotation.DomainService;
+import band.gosrock.domain.common.aop.redissonLock.RedissonLock;
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
 import band.gosrock.domain.domains.user.domain.OauthInfo;
 import band.gosrock.domain.domains.user.domain.Profile;
@@ -18,8 +19,10 @@ public class UserDomainService {
     private final UserAdaptor userAdaptor;
 
     @Transactional
-    //    @RedissonLock(LockName = "registerUser", paramName = "oauthInfo", paramClassType =
-    // OauthInfo.class)
+    @RedissonLock(
+            LockName = "유저등록",
+            identifier = "oid",
+            paramClassType = OauthInfo.class)
     public User registerUser(Profile profile, OauthInfo oauthInfo) {
         validUserCanRegister(oauthInfo);
         User newUser = User.builder().profile(profile).oauthInfo(oauthInfo).build();
@@ -28,6 +31,10 @@ public class UserDomainService {
     }
 
     @Transactional
+    @RedissonLock(
+        LockName = "개발용회원가입",
+        identifier = "oid",
+        paramClassType = OauthInfo.class)
     public User upsertUser(Profile profile, OauthInfo oauthInfo) {
         return userRepository
                 .findByOauthInfo(oauthInfo)
@@ -56,6 +63,9 @@ public class UserDomainService {
     }
 
     @Transactional
+    @RedissonLock(
+        LockName = "유저탈퇴",
+        identifier = "userId")
     public void withDrawUser(Long userId) {
         User user = userAdaptor.queryUser(userId);
         user.withDrawUser();

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAopTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAopTest.java
@@ -1,0 +1,53 @@
+package band.gosrock.domain.common.aop.redissonLock;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import band.gosrock.domain.common.dto.ProfileViewDto;
+import band.gosrock.domain.domains.user.domain.Profile;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RedissonLockAopTest {
+    @Mock
+    RedissonClient redissonClient;
+    @Mock
+    RedissonCallTransaction redissonCallTransaction;
+
+    RedissonLockAop redissonLockAop;
+
+    @BeforeEach
+    public void beforeEach() {
+        redissonLockAop = new RedissonLockAop(redissonClient,
+            redissonCallTransaction);
+    }
+
+    @Test
+    public void testMyMethod()
+        throws NoSuchMethodException, NoSuchFieldException, IllegalAccessException, InvocationTargetException {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        MethodSignature signature = mock(MethodSignature.class);
+        ProfileViewDto profileViewDto = ProfileViewDto.builder().id(1000L).build();
+        String otherParam = "param";
+
+        Object[] testargs = {profileViewDto,otherParam};
+        String[] parameterNames = {"profileViewDto", "otherParam"};
+        Class<?> paramClassType = profileViewDto.getClass();
+        Object[] args = joinPoint.getArgs();
+        String dynamicKey = redissonLockAop.createDynamicKeyFromObject(testargs, paramClassType,
+           "id" );
+        assertEquals("1000",dynamicKey);
+    }
+
+}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAopTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAopTest.java
@@ -1,53 +1,78 @@
 package band.gosrock.domain.common.aop.redissonLock;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
+import band.gosrock.common.exception.BadLockIdentifierException;
 import band.gosrock.domain.common.dto.ProfileViewDto;
-import band.gosrock.domain.domains.user.domain.Profile;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import org.aspectj.lang.ProceedingJoinPoint;
-import org.aspectj.lang.reflect.MethodSignature;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.redisson.api.RedissonClient;
-import org.springframework.beans.factory.annotation.Autowired;
 
 class RedissonLockAopTest {
-    @Mock
-    RedissonClient redissonClient;
-    @Mock
-    RedissonCallTransaction redissonCallTransaction;
+    @Mock RedissonClient redissonClient;
+    @Mock RedissonCallTransaction redissonCallTransaction;
 
     RedissonLockAop redissonLockAop;
 
     @BeforeEach
     public void beforeEach() {
-        redissonLockAop = new RedissonLockAop(redissonClient,
-            redissonCallTransaction);
+        redissonLockAop = new RedissonLockAop(redissonClient, redissonCallTransaction);
     }
 
     @Test
-    public void testMyMethod()
-        throws NoSuchMethodException, NoSuchFieldException, IllegalAccessException, InvocationTargetException {
-        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
-        MethodSignature signature = mock(MethodSignature.class);
+    public void 커스텀오브젝트에서_클래스타입과_식별자로_키를_가져와야한다()
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         ProfileViewDto profileViewDto = ProfileViewDto.builder().id(1000L).build();
         String otherParam = "param";
 
-        Object[] testargs = {profileViewDto,otherParam};
+        Object[] testArgs = {profileViewDto, otherParam};
         String[] parameterNames = {"profileViewDto", "otherParam"};
         Class<?> paramClassType = profileViewDto.getClass();
-        Object[] args = joinPoint.getArgs();
-        String dynamicKey = redissonLockAop.createDynamicKeyFromObject(testargs, paramClassType,
-           "id" );
-        assertEquals("1000",dynamicKey);
+        String dynamicKey =
+                redissonLockAop.createDynamicKeyFromObject(testArgs, paramClassType, "id");
+        assertEquals("1000", dynamicKey);
     }
 
+    @Test
+    public void 기본오브젝트에서_식별자로_키를_가져와야한다() {
+        ProfileViewDto profileViewDto = ProfileViewDto.builder().id(1000L).build();
+        String keyParamName = "다이내믹키가될값";
+
+        Object[] testArgs = {profileViewDto, keyParamName};
+        String[] parameterNames = {"파라미터첫번째", "파라미터두번째"};
+        Class<?> paramClassType = profileViewDto.getClass();
+
+        String dynamicKey =
+                redissonLockAop.createDynamicKeyFromPrimitive(parameterNames, testArgs, "파라미터두번째");
+        assertEquals("다이내믹키가될값", dynamicKey);
+    }
+
+    @Test
+    public void 잘못된_인자를_설정하면_오류가_발생해야한다() {
+        ProfileViewDto profileViewDto = ProfileViewDto.builder().id(1000L).build();
+        // 키값
+        String keyParamName = "다른값";
+        // 실제 인자로 넘겨질 값들
+        Object[] testArgs = {profileViewDto, keyParamName};
+        // 파라미터 이름
+        String[] parameterNames = {"profileViewDto", "otherParam"};
+        // 클래스 타입
+        Class<?> paramClassType = profileViewDto.getClass();
+
+        assertThrows(
+                BadLockIdentifierException.class,
+                () -> {
+                    redissonLockAop.generateDynamicKey(
+                            "이상한식별자", testArgs, paramClassType, parameterNames);
+                });
+
+        assertThrows(
+                BadLockIdentifierException.class,
+                () -> {
+                    redissonLockAop.generateDynamicKey(
+                            "이상한식별자", testArgs, Object.class, parameterNames);
+                });
+    }
 }


### PR DESCRIPTION
## 개요
- close #40 

## 작업사항
```java
@Transactional
    @RedissonLock(LockName = "유저탈퇴", identifier = "userId")
    public void withDrawUser(Long userId) {
        User user = userAdaptor.queryUser(userId);
        user.withDrawUser();
    }
```

```java
@Transactional
    @RedissonLock(LockName = "유저등록", identifier = "oid", paramClassType = OauthInfo.class)
    public User registerUser(Profile profile, OauthInfo oauthInfo) {
        validUserCanRegister(oauthInfo);
        User newUser = User.builder().profile(profile).oauthInfo(oauthInfo).build();
        userRepository.save(newUser);
        return newUser;
    }
```

두방식 모두 가능하게끔 해놨습니다
 - 첫번째 방법은 userId 매개변수 이름으로 락을 설정하는 방법입니다.
 - 두번째 방법은 OauthInfo 클래스 안에 oid 필드를 구분자로 선언하는 방식입니다.

키 값은 LockName + identifier로 가져온 값 이 됩니다.
유저탈퇴:5   <-키값
유저등록:203049585.  <- oid 키값

이런형식입니다.
락걸때 키값을 잘 걸어줘야 유저 5번이 유저 6번의 작업을 방해하지않기때문에!
이거꼭 명심해주세요 락걸때 키캆 설정 잘해줘야해요!!

- 테스트코드도 작성해놨습니다
- 2번째 방식에선 리플랙션 사용해서 다이나믹 매소드로 private final 로 선언된 부분을 게터로 가져옵니다.

## 변경로직
- 내용을 적어주세요.