### PR TITLE
refactor(api) : kakao link 클라이언트용 발급

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/controller/AuthController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/controller/AuthController.java
@@ -17,8 +17,6 @@ import band.gosrock.infrastructure.outer.api.oauth.dto.OauthTokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.io.IOException;
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,35 +46,26 @@ public class AuthController {
     private final WithDrawUseCase withDrawUseCase;
     private final LogoutUseCase logoutUseCase;
 
-    @Operation(summary = "kakao oauth 링크발급", description = "kakao 링크를 받아볼수 있습니다.")
+    @Operation(summary = "kakao oauth 링크발급 (백엔드용 )", description = "kakao 링크를 받아볼수 있습니다.")
+    @Tag(name = "카카오 oauth")
+    @GetMapping("/oauth/kakao/link/test")
+    public OauthLoginLinkResponse getKakaoOauthLinkTest() {
+        return registerUseCase.getKaKaoOauthLinkTest();
+    }
+
+    @Operation(summary = "kakao oauth 링크발급 (클라이언트용)", description = "kakao 링크를 받아볼수 있습니다.")
     @Tag(name = "카카오 oauth")
     @GetMapping("/oauth/kakao/link")
-    public OauthLoginLinkResponse getKakaoOauthLink() {
-        return registerUseCase.getKaKaoOauthLink();
+    public OauthLoginLinkResponse getKakaoOauthLink(
+            @RequestHeader(value = "referer", required = false) String referer) {
+        return registerUseCase.getKaKaoOauthLink(referer);
     }
 
     @Operation(summary = "code 요청받는 핸들러 클라이언트가 몰라도됩니다.", deprecated = true)
     @Tag(name = "카카오 oauth")
     @GetMapping("/oauth/kakao")
-    public void getCredentialFromKaKao(
-            @RequestParam("code") String code,
-            @RequestHeader(value = "referer", required = false) String referer,
-            @RequestHeader(value = "host", required = false) String host,
-            HttpServletResponse response)
-            throws IOException {
-        OauthTokenResponse credentialFromKaKao = registerUseCase.getCredentialFromKaKao(code);
-        log.info(referer);
-        String queryString =
-                String.format(
-                        "?idToken=%s&accessToken=%s&refreshToken=%s",
-                        credentialFromKaKao.getIdToken(),
-                        credentialFromKaKao.getAccessToken(),
-                        credentialFromKaKao.getRefreshToken());
-        if (referer != null) {
-            response.sendRedirect(referer + "/kakao/callback" + queryString);
-        } else {
-            response.sendRedirect("https://" + host + "/kakao/callback" + queryString);
-        }
+    public OauthTokenResponse getCredentialFromKaKao(@RequestParam("code") String code) {
+        return registerUseCase.getCredentialFromKaKao(code);
     }
 
     @Operation(summary = "개발용 회원가입입니다 클라이언트가 몰라도 됩니다.", deprecated = true)

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/RegisterUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/RegisterUseCase.java
@@ -24,8 +24,12 @@ public class RegisterUseCase {
     private final UserDomainService userDomainService;
     private final TokenGenerateHelper tokenGenerateHelper;
 
-    public OauthLoginLinkResponse getKaKaoOauthLink() {
-        return new OauthLoginLinkResponse(kakaoOauthHelper.getKaKaoOauthLink());
+    public OauthLoginLinkResponse getKaKaoOauthLinkTest() {
+        return new OauthLoginLinkResponse(kakaoOauthHelper.getKaKaoOauthLinkTest());
+    }
+
+    public OauthLoginLinkResponse getKaKaoOauthLink(String referer) {
+        return new OauthLoginLinkResponse(kakaoOauthHelper.getKaKaoOauthLink(referer));
     }
 
     /**

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/KakaoOauthHelper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/KakaoOauthHelper.java
@@ -27,12 +27,20 @@ public class KakaoOauthHelper {
 
     private final OauthOIDCHelper oauthOIDCHelper;
 
-    public String getKaKaoOauthLink() {
+    public String getKaKaoOauthLinkTest() {
         return oauthProperties.getKakaoBaseUrl()
                 + String.format(
                         KAKAO_OAUTH_QUERY_STRING,
                         oauthProperties.getKakaoClientId(),
                         oauthProperties.getKakaoRedirectUrl());
+    }
+
+    public String getKaKaoOauthLink(String referer) {
+        return oauthProperties.getKakaoBaseUrl()
+                + String.format(
+                        KAKAO_OAUTH_QUERY_STRING,
+                        oauthProperties.getKakaoClientId(),
+                        referer + "kakao/callback");
     }
 
     public OauthTokenResponse getOauthToken(String code) {


### PR DESCRIPTION
## 개요
- close #86 

## 작업사항
- 백엔드분들은 인증토큰 /oauth/kakao/link/test 로 눌러서 받으시면 됩니다!!!!
- 클라와 이야기해서
- 코드는 클라쪽에서 받은걸로 협의봤습니다
- 대신 링크발급은 레퍼럴 헤더 기준으로 발급하기로 했습니다!

## 변경로직
- 내용을 적어주세요.