### PR TITLE
feat : 결제 취소 관련 기능 개발 (#70)

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartItemResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartItemResponse.java
@@ -1,6 +1,7 @@
 package band.gosrock.api.cart.model.dto.response;
 
 
+import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.common.vo.OptionAnswerVo;
 import band.gosrock.domain.domains.cart.domain.CartLineItem;
 import java.util.List;
@@ -16,15 +17,15 @@ public class CartItemResponse {
     // 응답 목록
     private List<OptionAnswerVo> answers;
 
-    private String itemPrice;
-    private String cartLinePrice;
+    private Money itemPrice;
+    private Money cartLinePrice;
 
     public static CartItemResponse of(String name, CartLineItem cartLineItem) {
         return CartItemResponse.builder()
                 .answers(cartLineItem.getOptionAnswerVos())
                 .name(name)
-                .cartLinePrice(cartLineItem.getTotalCartLinePrice().toString())
-                .itemPrice(cartLineItem.getItemPrice().toString())
+                .cartLinePrice(cartLineItem.getTotalCartLinePrice())
+                .itemPrice(cartLineItem.getItemPrice())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartItemResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartItemResponse.java
@@ -2,6 +2,7 @@ package band.gosrock.api.cart.model.dto.response;
 
 
 import band.gosrock.domain.common.vo.OptionAnswerVo;
+import band.gosrock.domain.domains.cart.domain.CartLineItem;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +16,15 @@ public class CartItemResponse {
     // 응답 목록
     private List<OptionAnswerVo> answers;
 
-    public static CartItemResponse of(String name, List<OptionAnswerVo> optionAnswerVos) {
-        return CartItemResponse.builder().answers(optionAnswerVos).name(name).build();
+    private String itemPrice;
+    private String cartLinePrice;
+
+    public static CartItemResponse of(String name, CartLineItem cartLineItem) {
+        return CartItemResponse.builder()
+                .answers(cartLineItem.getOptionAnswerVos())
+                .name(name)
+                .cartLinePrice(cartLineItem.getTotalCartLinePrice().toString())
+                .itemPrice(cartLineItem.getItemPrice().toString())
+                .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CreateCartResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CreateCartResponse.java
@@ -1,6 +1,7 @@
 package band.gosrock.api.cart.model.dto.response;
 
 
+import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.cart.domain.Cart;
 import java.util.List;
 import lombok.Builder;
@@ -15,7 +16,7 @@ public class CreateCartResponse {
     private final List<CartItemResponse> items;
 
     // 금액
-    private final String totalPrice;
+    private final Money totalPrice;
 
     private final Long cartId;
 
@@ -24,7 +25,7 @@ public class CreateCartResponse {
     public static CreateCartResponse of(List<CartItemResponse> cartItemResponses, Cart cart) {
         return CreateCartResponse.builder()
                 .items(cartItemResponses)
-                .totalPrice(cart.getTotalPrice().toString())
+                .totalPrice(cart.getTotalPrice())
                 .cartId(cart.getId())
                 .title(cart.getCartName())
                 .totalQuantity(cart.getTotalQuantity())

--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CreateCartResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CreateCartResponse.java
@@ -19,12 +19,15 @@ public class CreateCartResponse {
 
     private final Long cartId;
 
+    private final Long totalQuantity;
+
     public static CreateCartResponse of(List<CartItemResponse> cartItemResponses, Cart cart) {
         return CreateCartResponse.builder()
                 .items(cartItemResponses)
                 .totalPrice(cart.getTotalPrice().toString())
                 .cartId(cart.getId())
                 .title(cart.getCartName())
+                .totalQuantity(cart.getTotalQuantity())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/service/CreateCartUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/service/CreateCartUseCase.java
@@ -106,7 +106,7 @@ public class CreateCartUseCase {
             cartItemResponses.add(
                     CartItemResponse.of(
                             generateCartLineName(cartLineItem, startNum, totalQuantity),
-                            cartLineItem.getOptionAnswerVos()));
+                            cartLineItem));
             startNum += cartLineItem.getQuantity();
         }
 

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
@@ -43,9 +43,9 @@ public class OrderController {
 
     @Operation(summary = "토스페이먼츠에서 주문서를 생성합니다.(테스트용)")
     @DevelopOnlyApi
-    @PostMapping("/testToss/{order_id}")
-    public PaymentsResponse createTossOrderUseCase(@PathVariable("order_id") String orderId) {
-        return createTossOrderUseCase.execute(orderId);
+    @PostMapping("/testToss/{order_uuid}")
+    public PaymentsResponse createTossOrderUseCase(@PathVariable("order_uuid") String orderUuid) {
+        return createTossOrderUseCase.execute(orderUuid);
     }
 
     // TODO : 승인 결제 방식 도입하면서 좀더 이쁘게 만들 예정
@@ -57,28 +57,28 @@ public class OrderController {
     }
 
     @Operation(summary = "결제 승인요청 . successUrl 로 돌아온 웹페이지에서 query 로 받은 응답값을 서버로 보냅니당.")
-    @PostMapping("/{order_id}/confirm")
+    @PostMapping("/{order_uuid}/confirm")
     public OrderResponse confirmOrder(
-            @PathVariable("order_id") String orderId,
+            @PathVariable("order_uuid") String orderUuid,
             @RequestBody ConfirmOrderRequest confirmOrderRequest) {
-        return confirmOrderUseCase.execute(orderId, confirmOrderRequest);
+        return confirmOrderUseCase.execute(orderUuid, confirmOrderRequest);
     }
 
     @Operation(summary = "결제 취소요청. 호스트 관리자가 결제를 취소 시킵니다.! (호스트 관리자용(관리자쪽에서 사용))")
-    @PostMapping("/{order_id}/cancel")
-    public void cancelOrder(@PathVariable("order_id") String orderId) {
-        cancelOrderUseCase.execute(orderId);
+    @PostMapping("/{order_uuid}/cancel")
+    public void cancelOrder(@PathVariable("order_uuid") String orderUuid) {
+        cancelOrderUseCase.execute(orderUuid);
     }
 
     @Operation(summary = "결제 환불요청. 본인이 구매한 오더를 환불 시킵니다.! (본인 용)")
-    @PostMapping("/{order_id}/refund")
-    public void refundOrder(@PathVariable("order_id") String orderId) {
-        refundOrderUseCase.execute(orderId);
+    @PostMapping("/{order_uuid}/refund")
+    public void refundOrder(@PathVariable("order_uuid") String orderUuid) {
+        refundOrderUseCase.execute(orderUuid);
     }
 
     @Operation(summary = "결제 조회. 결제 조회 권한은 주문 본인,  호스트 관리자.")
-    @GetMapping("/{order_id}")
-    public OrderResponse readOrder(@PathVariable("order_id") String orderId) {
-        return readOrderUseCase.execute(orderId);
+    @GetMapping("/{order_uuid}")
+    public OrderResponse readOrder(@PathVariable("order_uuid") String orderUuid) {
+        return readOrderUseCase.execute(orderUuid);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
@@ -66,14 +66,14 @@ public class OrderController {
 
     @Operation(summary = "결제 취소요청. 호스트 관리자가 결제를 취소 시킵니다.! (호스트 관리자용(관리자쪽에서 사용))")
     @PostMapping("/{order_uuid}/cancel")
-    public void cancelOrder(@PathVariable("order_uuid") String orderUuid) {
-        cancelOrderUseCase.execute(orderUuid);
+    public OrderResponse cancelOrder(@PathVariable("order_uuid") String orderUuid) {
+        return cancelOrderUseCase.execute(orderUuid);
     }
 
     @Operation(summary = "결제 환불요청. 본인이 구매한 오더를 환불 시킵니다.! (본인 용)")
     @PostMapping("/{order_uuid}/refund")
-    public void refundOrder(@PathVariable("order_uuid") String orderUuid) {
-        refundOrderUseCase.execute(orderUuid);
+    public OrderResponse refundOrder(@PathVariable("order_uuid") String orderUuid) {
+        return refundOrderUseCase.execute(orderUuid);
     }
 
     @Operation(summary = "결제 조회. 결제 조회 권한은 주문 본인,  호스트 관리자.")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
@@ -10,6 +10,7 @@ import band.gosrock.api.order.service.ConfirmOrderUseCase;
 import band.gosrock.api.order.service.CreateOrderUseCase;
 import band.gosrock.api.order.service.CreateTossOrderUseCase;
 import band.gosrock.api.order.service.ReadOrderUseCase;
+import band.gosrock.api.order.service.RefundOrderUseCase;
 import band.gosrock.common.annotation.DevelopOnlyApi;
 import band.gosrock.infrastructure.outer.api.tossPayments.dto.response.PaymentsResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,6 +35,8 @@ public class OrderController {
     private final CreateOrderUseCase createOrderUseCase;
     private final ConfirmOrderUseCase confirmOrderUseCase;
     private final CancelOrderUseCase cancelOrderUseCase;
+
+    private final RefundOrderUseCase refundOrderUseCase;
     private final ReadOrderUseCase readOrderUseCase;
 
     private final CreateTossOrderUseCase createTossOrderUseCase;
@@ -61,10 +64,16 @@ public class OrderController {
         return confirmOrderUseCase.execute(orderId, confirmOrderRequest);
     }
 
-    @Operation(summary = "결제 취소요청. 취소 요청의 주체는 주문 본인, 호스트 관리자.")
+    @Operation(summary = "결제 취소요청. 호스트 관리자가 결제를 취소 시킵니다.! (호스트 관리자용(관리자쪽에서 사용))")
     @PostMapping("/{order_id}/cancel")
     public void cancelOrder(@PathVariable("order_id") String orderId) {
-        cancelOrderUseCase.execute();
+        cancelOrderUseCase.execute(orderId);
+    }
+
+    @Operation(summary = "결제 환불요청. 본인이 구매한 오더를 환불 시킵니다.! (본인 용)")
+    @PostMapping("/{order_id}/refund")
+    public void refundOrder(@PathVariable("order_id") String orderId) {
+        refundOrderUseCase.execute(orderId);
     }
 
     @Operation(summary = "결제 조회. 결제 조회 권한은 주문 본인,  호스트 관리자.")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/mapper/OrderMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/mapper/OrderMapper.java
@@ -1,0 +1,60 @@
+package band.gosrock.api.order.mapper;
+
+
+import band.gosrock.api.config.security.SecurityUtils;
+import band.gosrock.api.order.model.dto.response.OrderLineTicketResponse;
+import band.gosrock.api.order.model.dto.response.OrderResponse;
+import band.gosrock.common.annotation.Mapper;
+import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
+import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
+import band.gosrock.domain.domains.user.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@Mapper
+@RequiredArgsConstructor
+public class OrderMapper {
+    private final OrderAdaptor orderAdaptor;
+    private final UserAdaptor userAdaptor;
+    private final IssuedTicketAdaptor issuedTicketAdaptor;
+
+    @Transactional(readOnly = true)
+    public OrderResponse toOrderResponse(String orderUuid) {
+        Long currentUserId = SecurityUtils.getCurrentUserId();
+        Order order = orderAdaptor.findByOrderUuid(orderUuid);
+        User user = userAdaptor.queryUser(currentUserId);
+        String name = user.getProfile().getName();
+        List<OrderLineTicketResponse> orderLineTicketResponses =
+                order.getOrderLineItems().stream()
+                        .map(
+                                orderLineItem ->
+                                        OrderLineTicketResponse.of(
+                                                order,
+                                                orderLineItem,
+                                                name,
+                                                getTicketNoName(orderLineItem.getId())))
+                        .toList();
+
+        return OrderResponse.of(order, orderLineTicketResponses);
+    }
+
+    private String getTicketNoName(Long orderLineItemId) {
+        List<String> issuedTicketNos =
+                issuedTicketAdaptor.findAllByOrderLineId(orderLineItemId).stream()
+                        .map(IssuedTicket::getIssuedTicketNo)
+                        .toList();
+        Integer size = issuedTicketNos.size();
+        // 없을 경우긴 함 테스트를 위해서
+        if (issuedTicketNos.isEmpty()) return "";
+        else if (size.equals(1)) {
+            return String.format("%s (%d매)", issuedTicketNos.get(0), size);
+        } else {
+            return String.format(
+                    "%s ~ %s (%d매)", issuedTicketNos.get(0), issuedTicketNos.get(size - 1), size);
+        }
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
@@ -1,6 +1,7 @@
 package band.gosrock.api.order.model.dto.response;
 
 
+import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.user.domain.Profile;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -23,7 +24,7 @@ public class CreateOrderResponse {
     private final String customerName;
 
     @Schema(description = "결제금액")
-    private final Long amount;
+    private final Money amount;
 
     public static CreateOrderResponse from(Order order, Profile profile) {
         return CreateOrderResponse.builder()
@@ -31,7 +32,7 @@ public class CreateOrderResponse {
                 .customerName(profile.getName())
                 .orderName(order.getOrderName())
                 .orderId(order.getUuid())
-                .amount(order.getTotalPaymentPrice().longValue())
+                .amount(order.getTotalPaymentPrice())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
@@ -12,12 +12,16 @@ import lombok.Getter;
 public class CreateOrderResponse {
     @Schema(description = "UUId")
     private final String orderId;
+
     @Schema(description = "상품명")
     private final String orderName;
+
     @Schema(description = "고객이메일")
     private final String customerEmail;
+
     @Schema(description = "고객이름")
     private final String customerName;
+
     @Schema(description = "결제금액")
     private final Long amount;
 

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
@@ -3,16 +3,22 @@ package band.gosrock.api.order.model.dto.response;
 
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.user.domain.Profile;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class CreateOrderResponse {
+    @Schema(description = "UUId")
     private final String orderId;
+    @Schema(description = "상품명")
     private final String orderName;
+    @Schema(description = "고객이메일")
     private final String customerEmail;
+    @Schema(description = "고객이름")
     private final String customerName;
+    @Schema(description = "결제금액")
     private final Long amount;
 
     public static CreateOrderResponse from(Order order, Profile profile) {

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderLineTicketResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderLineTicketResponse.java
@@ -13,20 +13,27 @@ import lombok.Getter;
 @Getter
 @Builder
 public class OrderLineTicketResponse {
-    @Schema(description = "티켓명" ,defaultValue = "일반티켓")
+    @Schema(description = "티켓명", defaultValue = "일반티켓")
     private final String ticketName;
-    @Schema(description = "예매 번호" ,defaultValue = "R1000001-123")
+
+    @Schema(description = "예매 번호", defaultValue = "R1000001-123")
     private final String orderNo;
-    @Schema(description = "티켓 번호" ,defaultValue = "T1000001 ~ T1000002 (2매)")
+
+    @Schema(description = "티켓 번호", defaultValue = "T1000001 ~ T1000002 (2매)")
     private final String ticketNos;
+
     @Schema(description = "구매 일시")
     private final LocalDateTime paymentAt;
+
     @Schema(description = "유저이름")
     private final String userName;
+
     @Schema(description = "금액")
-    private final String supplyAmount;
+    private final String orderLinePrice;
+
     @Schema(description = "구매수량")
     private final Long purchaseQuantity;
+
     @Schema(description = "옵션의 응답 목록")
     private List<OptionAnswerVo> answers;
 
@@ -39,8 +46,8 @@ public class OrderLineTicketResponse {
                 .ticketName(orderLineItem.getProductName())
                 .paymentAt(order.getApprovedAt())
                 .userName(userName)
-            .supplyAmount(orderLineItem.getTotalOrderLinePrice().toString())
-            .purchaseQuantity(orderLineItem.getQuantity())
+                .orderLinePrice(orderLineItem.getTotalOrderLinePrice().toString())
+                .purchaseQuantity(orderLineItem.getQuantity())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderLineTicketResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderLineTicketResponse.java
@@ -1,6 +1,7 @@
 package band.gosrock.api.order.model.dto.response;
 
 
+import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.common.vo.OptionAnswerVo;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderLineItem;
@@ -29,7 +30,7 @@ public class OrderLineTicketResponse {
     private final String userName;
 
     @Schema(description = "금액")
-    private final String orderLinePrice;
+    private final Money orderLinePrice;
 
     @Schema(description = "구매수량")
     private final Long purchaseQuantity;
@@ -46,7 +47,7 @@ public class OrderLineTicketResponse {
                 .ticketName(orderLineItem.getProductName())
                 .paymentAt(order.getApprovedAt())
                 .userName(userName)
-                .orderLinePrice(orderLineItem.getTotalOrderLinePrice().toString())
+                .orderLinePrice(orderLineItem.getTotalOrderLinePrice())
                 .purchaseQuantity(orderLineItem.getQuantity())
                 .build();
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderLineTicketResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderLineTicketResponse.java
@@ -24,13 +24,14 @@ public class OrderLineTicketResponse {
     @Schema(description = "유저이름")
     private final String userName;
     @Schema(description = "금액")
-    private final Long supplyAmount;
+    private final String supplyAmount;
+    @Schema(description = "구매수량")
+    private final Long purchaseQuantity;
     @Schema(description = "옵션의 응답 목록")
     private List<OptionAnswerVo> answers;
 
     public static OrderLineTicketResponse of(
             Order order, OrderLineItem orderLineItem, String userName, String ticketNos) {
-//        orderLineItem.getTotalOrderLinePrice()
         return OrderLineTicketResponse.builder()
                 .answers(orderLineItem.getOptionAnswerVos())
                 .orderNo(order.getOrderNo() + "-" + orderLineItem.getId())
@@ -38,7 +39,8 @@ public class OrderLineTicketResponse {
                 .ticketName(orderLineItem.getProductName())
                 .paymentAt(order.getApprovedAt())
                 .userName(userName)
-                .supplyAmount(orderLineItem.getQuantity())
+            .supplyAmount(orderLineItem.getTotalOrderLinePrice().toString())
+            .purchaseQuantity(orderLineItem.getQuantity())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderLineTicketResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderLineTicketResponse.java
@@ -4,6 +4,7 @@ package band.gosrock.api.order.model.dto.response;
 import band.gosrock.domain.common.vo.OptionAnswerVo;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderLineItem;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
@@ -12,17 +13,24 @@ import lombok.Getter;
 @Getter
 @Builder
 public class OrderLineTicketResponse {
+    @Schema(description = "티켓명" ,defaultValue = "일반티켓")
     private final String ticketName;
+    @Schema(description = "예매 번호" ,defaultValue = "R1000001-123")
     private final String orderNo;
+    @Schema(description = "티켓 번호" ,defaultValue = "T1000001 ~ T1000002 (2매)")
     private final String ticketNos;
+    @Schema(description = "구매 일시")
     private final LocalDateTime paymentAt;
+    @Schema(description = "유저이름")
     private final String userName;
-
+    @Schema(description = "금액")
     private final Long supplyAmount;
+    @Schema(description = "옵션의 응답 목록")
     private List<OptionAnswerVo> answers;
 
     public static OrderLineTicketResponse of(
             Order order, OrderLineItem orderLineItem, String userName, String ticketNos) {
+//        orderLineItem.getTotalOrderLinePrice()
         return OrderLineTicketResponse.builder()
                 .answers(orderLineItem.getOptionAnswerVos())
                 .orderNo(order.getOrderNo() + "-" + orderLineItem.getId())

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderPaymentResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderPaymentResponse.java
@@ -12,21 +12,28 @@ import lombok.Getter;
 @Getter
 @Builder
 public class OrderPaymentResponse {
-    @Schema(description = "결제 수단" , defaultValue = "간편결제")
+    @Schema(description = "결제 수단", defaultValue = "간편결제")
     private final PaymentMethod paymentMethod;
-    @Schema(description = "공급자" , defaultValue = "카카오페이")
+
+    @Schema(description = "공급자", defaultValue = "카카오페이")
     private final String provider;
-    @Schema(description = "공급가액 (금액)" , defaultValue = "12000원")
+
+    @Schema(description = "공급가액 (금액)", defaultValue = "12000원")
     private final String supplyAmount;
-    @Schema(description = "할인 금액" , defaultValue = "1000원")
+
+    @Schema(description = "할인 금액", defaultValue = "1000원")
     private final String discountAmount;
-    @Schema(description = "할인쿠폰 이름" , defaultValue = "사용하지 않음")
+
+    @Schema(description = "할인쿠폰 이름", defaultValue = "사용하지 않음")
     private final String couponName;
-    @Schema(description = "총 결제 금액" , defaultValue = "11000원")
+
+    @Schema(description = "총 결제 금액", defaultValue = "11000원")
     private final String totalAmount;
-    @Schema(description = "결제 상태" , defaultValue = "결제 완료")
+
+    @Schema(description = "결제 상태", defaultValue = "결제 완료")
     private final OrderStatus orderStatus;
-    @Schema(description = "영수증 주소" , defaultValue = "영수증주소")
+
+    @Schema(description = "영수증 주소", defaultValue = "영수증주소")
     private final String receiptUrl;
 
     public static OrderPaymentResponse from(Order order) {
@@ -40,7 +47,7 @@ public class OrderPaymentResponse {
                 .totalAmount(totalPaymentInfo.getPaymentAmount().toString())
                 .couponName(order.getCouponName())
                 .orderStatus(order.getOrderStatus())
-            .receiptUrl(order.getReceiptUrl())
+                .receiptUrl(order.getReceiptUrl())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderPaymentResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderPaymentResponse.java
@@ -2,30 +2,42 @@ package band.gosrock.api.order.model.dto.response;
 
 
 import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.domain.domains.order.domain.OrderStatus;
 import band.gosrock.domain.domains.order.domain.PaymentInfo;
+import band.gosrock.domain.domains.order.domain.PaymentMethod;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class OrderPaymentResponse {
-    private final String paymentMethod;
+    @Schema(description = "결제 수단" , defaultValue = "간편결제")
+    private final PaymentMethod paymentMethod;
+    @Schema(description = "공급자" , defaultValue = "카카오페이")
+    private final String provider;
+    @Schema(description = "공급가액 (금액)" , defaultValue = "12000원")
     private final String supplyAmount;
+    @Schema(description = "할인 금액" , defaultValue = "1000원")
     private final String discountAmount;
+    @Schema(description = "할인쿠폰 이름" , defaultValue = "사용하지 않음")
     private final String couponName;
+    @Schema(description = "총 결제 금액" , defaultValue = "11000원")
     private final String totalAmount;
-    private final String orderStatus;
+    @Schema(description = "결제 상태" , defaultValue = "결제 완료")
+    private final OrderStatus orderStatus;
 
     public static OrderPaymentResponse from(Order order) {
         PaymentInfo totalPaymentInfo = order.getTotalPaymentInfo();
 
         return OrderPaymentResponse.builder()
-                .paymentMethod(order.getPaymentMethod().toString())
+                .paymentMethod(order.getPaymentMethod())
+                .provider(order.getPaymentProvider())
                 .discountAmount(totalPaymentInfo.getDiscountAmount().toString())
                 .supplyAmount(totalPaymentInfo.getSupplyAmount().toString())
                 .totalAmount(totalPaymentInfo.getPaymentAmount().toString())
                 .couponName(order.getCouponName())
-                .orderStatus(order.getOrderStatus().toString())
+                .orderStatus(order.getOrderStatus())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderPaymentResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderPaymentResponse.java
@@ -26,6 +26,8 @@ public class OrderPaymentResponse {
     private final String totalAmount;
     @Schema(description = "결제 상태" , defaultValue = "결제 완료")
     private final OrderStatus orderStatus;
+    @Schema(description = "영수증 주소" , defaultValue = "영수증주소")
+    private final String receiptUrl;
 
     public static OrderPaymentResponse from(Order order) {
         PaymentInfo totalPaymentInfo = order.getTotalPaymentInfo();
@@ -38,6 +40,7 @@ public class OrderPaymentResponse {
                 .totalAmount(totalPaymentInfo.getPaymentAmount().toString())
                 .couponName(order.getCouponName())
                 .orderStatus(order.getOrderStatus())
+            .receiptUrl(order.getReceiptUrl())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderPaymentResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderPaymentResponse.java
@@ -1,6 +1,7 @@
 package band.gosrock.api.order.model.dto.response;
 
 
+import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderStatus;
 import band.gosrock.domain.domains.order.domain.PaymentInfo;
@@ -19,16 +20,16 @@ public class OrderPaymentResponse {
     private final String provider;
 
     @Schema(description = "공급가액 (금액)", defaultValue = "12000원")
-    private final String supplyAmount;
+    private final Money supplyAmount;
 
     @Schema(description = "할인 금액", defaultValue = "1000원")
-    private final String discountAmount;
+    private final Money discountAmount;
 
     @Schema(description = "할인쿠폰 이름", defaultValue = "사용하지 않음")
     private final String couponName;
 
     @Schema(description = "총 결제 금액", defaultValue = "11000원")
-    private final String totalAmount;
+    private final Money totalAmount;
 
     @Schema(description = "결제 상태", defaultValue = "결제 완료")
     private final OrderStatus orderStatus;
@@ -42,9 +43,9 @@ public class OrderPaymentResponse {
         return OrderPaymentResponse.builder()
                 .paymentMethod(order.getPaymentMethod())
                 .provider(order.getPaymentProvider())
-                .discountAmount(totalPaymentInfo.getDiscountAmount().toString())
-                .supplyAmount(totalPaymentInfo.getSupplyAmount().toString())
-                .totalAmount(totalPaymentInfo.getPaymentAmount().toString())
+                .discountAmount(totalPaymentInfo.getDiscountAmount())
+                .supplyAmount(totalPaymentInfo.getSupplyAmount())
+                .totalAmount(totalPaymentInfo.getPaymentAmount())
                 .couponName(order.getCouponName())
                 .orderStatus(order.getOrderStatus())
                 .receiptUrl(order.getReceiptUrl())

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderResponse.java
@@ -3,6 +3,7 @@ package band.gosrock.api.order.model.dto.response;
 
 import band.gosrock.domain.common.vo.RefundInfoVo;
 import band.gosrock.domain.domains.order.domain.Order;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,11 +13,13 @@ import lombok.Getter;
 public class OrderResponse {
 
     // 총 결제 정보
+    @Schema(description = "결제 정보")
     private final OrderPaymentResponse paymentInfo;
-
+    @Schema(description = "예매 정보( 티켓 목록 )")
     private final List<OrderLineTicketResponse> tickets;
 
     // 예매 취소 정보
+    @Schema(description = "예매 취소 정보")
     private final RefundInfoVo refundInfo;
 
     public static OrderResponse of(Order order, List<OrderLineTicketResponse> tickets) {

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderResponse.java
@@ -15,6 +15,7 @@ public class OrderResponse {
     // 총 결제 정보
     @Schema(description = "결제 정보")
     private final OrderPaymentResponse paymentInfo;
+
     @Schema(description = "예매 정보( 티켓 목록 )")
     private final List<OrderLineTicketResponse> tickets;
 

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderResponse.java
@@ -23,11 +23,19 @@ public class OrderResponse {
     @Schema(description = "예매 취소 정보")
     private final RefundInfoVo refundInfo;
 
+    @Schema(description = "주문 고유 uuid")
+    private final String orderUuid;
+
+    @Schema(description = "주문 id")
+    private final Long orderId;
+
     public static OrderResponse of(Order order, List<OrderLineTicketResponse> tickets) {
         return OrderResponse.builder()
                 .refundInfo(order.getTotalRefundInfo())
                 .paymentInfo(OrderPaymentResponse.from(order))
                 .tickets(tickets)
+                .orderUuid(order.getUuid())
+                .orderId(order.getId())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CancelOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CancelOrderUseCase.java
@@ -6,5 +6,5 @@ import band.gosrock.common.annotation.UseCase;
 @UseCase
 public class CancelOrderUseCase {
 
-    public void execute(String orderId) {}
+    public void execute(String orderUuid) {}
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CancelOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CancelOrderUseCase.java
@@ -1,10 +1,24 @@
 package band.gosrock.api.order.service;
 
 
+import band.gosrock.api.config.security.SecurityUtils;
+import band.gosrock.api.order.mapper.OrderMapper;
+import band.gosrock.api.order.model.dto.response.OrderResponse;
 import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.order.service.WithdrawOrderService;
+import lombok.RequiredArgsConstructor;
 
 @UseCase
+@RequiredArgsConstructor
 public class CancelOrderUseCase {
 
-    public void execute(String orderUuid) {}
+    private final WithdrawOrderService withdrawOrderService;
+
+    private final OrderMapper orderMapper;
+
+    public OrderResponse execute(String orderUuid) {
+        Long currentUserId = SecurityUtils.getCurrentUserId();
+        withdrawOrderService.cancelOrder(orderUuid, currentUserId);
+        return orderMapper.toOrderResponse(orderUuid);
+    }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ConfirmOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ConfirmOrderUseCase.java
@@ -2,99 +2,32 @@ package band.gosrock.api.order.service;
 
 
 import band.gosrock.api.config.security.SecurityUtils;
+import band.gosrock.api.order.mapper.OrderMapper;
 import band.gosrock.api.order.model.dto.request.ConfirmOrderRequest;
-import band.gosrock.api.order.model.dto.response.OrderLineTicketResponse;
 import band.gosrock.api.order.model.dto.response.OrderResponse;
 import band.gosrock.common.annotation.UseCase;
-import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
-import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
-import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.service.OrderConfirmService;
-import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
-import band.gosrock.domain.domains.user.domain.User;
 import band.gosrock.infrastructure.outer.api.tossPayments.dto.request.ConfirmPaymentsRequest;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationContext;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class ConfirmOrderUseCase {
 
     private final OrderConfirmService orderConfirmService;
-    private final OrderAdaptor orderAdaptor;
-    private final UserAdaptor userAdaptor;
-    private final IssuedTicketAdaptor issuedTicketAdaptor;
-    private final ApplicationContext applicationContext;
 
-    // https://stackoverflow.com/questions/3037006/starting-new-transaction-in-spring-bean
-    private ConfirmOrderUseCase getSpringProxy() {
-        return applicationContext.getBean(this.getClass());
-    }
-
-    private OrderResponse getOrderResponseWithNewTransaction(
-            Long confirmedOrderId, String userName) {
-        return getSpringProxy().getOrderResponse(confirmedOrderId, userName);
-    }
+    private final OrderMapper orderMapper;
 
     public OrderResponse execute(String orderUuid, ConfirmOrderRequest confirmOrderRequest) {
         Long currentUserId = SecurityUtils.getCurrentUserId();
-        User user = userAdaptor.queryUser(currentUserId);
         ConfirmPaymentsRequest confirmPaymentsRequest =
                 ConfirmPaymentsRequest.builder()
                         .paymentKey(confirmOrderRequest.getPaymentKey())
                         .amount(confirmOrderRequest.getAmount())
                         .orderId(orderUuid)
                         .build();
-        Long confirmedOrderId = orderConfirmService.execute(confirmPaymentsRequest, currentUserId);
-        return getOrderResponseWithNewTransaction(confirmedOrderId, user.getProfile().getName());
-    }
-
-    /**
-     * 트랜잭션이 클래스 래벨에서 시작해서 레디스 락도 트랜잭션을 격리성 보장하기위해서 새로시작하는데 레디슨 락 끝나고 커밋된후에 데이타가 안읽힘. 왜냐면 클래스 레벨
-     * 트랜잭션이 레디슨 락보다 먼저 시작했기때문 (Read_commited) 그래서 새로운 트랜잭션 만들어서 반영 근데 이거 그냥 lazy 로딩 때문에 그런거지 쿼리
-     * 짜야되는거임!
-     *
-     * @param confirmedOrderId
-     * @param userName
-     * @return
-     */
-    // TODO : 쿼리만들기
-    @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
-    public OrderResponse getOrderResponse(Long confirmedOrderId, String userName) {
-        Order order = orderAdaptor.findById(confirmedOrderId);
-
-        List<OrderLineTicketResponse> orderLineTicketResponses =
-                order.getOrderLineItems().stream()
-                        .map(
-                                orderLineItem ->
-                                        OrderLineTicketResponse.of(
-                                                order,
-                                                orderLineItem,
-                                                userName,
-                                                getTicketNoName(orderLineItem.getId())))
-                        .toList();
-
-        return OrderResponse.of(order, orderLineTicketResponses);
-    }
-
-    private String getTicketNoName(Long orderLineItemId) {
-        List<String> issuedTicketNos =
-                issuedTicketAdaptor.findAllByOrderLineId(orderLineItemId).stream()
-                        .map(IssuedTicket::getIssuedTicketNo)
-                        .toList();
-        Integer size = issuedTicketNos.size();
-        // 없을 경우긴 함 테스트를 위해서
-        if (issuedTicketNos.isEmpty()) return "";
-        else if (size.equals(1)) {
-            return String.format("%s (%d매)", issuedTicketNos.get(0), size);
-        } else {
-            return String.format(
-                    "%s ~ %s (%d매)", issuedTicketNos.get(0), issuedTicketNos.get(size - 1), size);
-        }
+        String confirmOrderUuid =
+                orderConfirmService.execute(confirmPaymentsRequest, currentUserId);
+        return orderMapper.toOrderResponse(confirmOrderUuid);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ConfirmOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ConfirmOrderUseCase.java
@@ -41,14 +41,14 @@ public class ConfirmOrderUseCase {
         return getSpringProxy().getOrderResponse(confirmedOrderId, userName);
     }
 
-    public OrderResponse execute(String orderId, ConfirmOrderRequest confirmOrderRequest) {
+    public OrderResponse execute(String orderUuid, ConfirmOrderRequest confirmOrderRequest) {
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = userAdaptor.queryUser(currentUserId);
         ConfirmPaymentsRequest confirmPaymentsRequest =
                 ConfirmPaymentsRequest.builder()
                         .paymentKey(confirmOrderRequest.getPaymentKey())
                         .amount(confirmOrderRequest.getAmount())
-                        .orderId(orderId)
+                        .orderId(orderUuid)
                         .build();
         Long confirmedOrderId = orderConfirmService.execute(confirmPaymentsRequest, currentUserId);
         return getOrderResponseWithNewTransaction(confirmedOrderId, user.getProfile().getName());

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CreateTossOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CreateTossOrderUseCase.java
@@ -19,13 +19,13 @@ public class CreateTossOrderUseCase {
 
     private final OrderAdaptor orderAdaptor;
 
-    public PaymentsResponse execute(String orderId) {
-        Order order = orderAdaptor.findByOrderUuid(orderId);
+    public PaymentsResponse execute(String orderUuid) {
+        Order order = orderAdaptor.findByOrderUuid(orderUuid);
         CreatePaymentsRequest createPaymentsRequest =
                 CreatePaymentsRequest.builder()
                         .method("카드")
                         .orderName(order.getOrderName())
-                        .orderId(orderId)
+                        .orderId(orderUuid)
                         .failUrl("http://localhost:8080/failurl")
                         .successUrl("http://localhost:8080/successUrl")
                         .amount(order.getTotalPaymentPrice().longValue())

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ReadOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ReadOrderUseCase.java
@@ -23,8 +23,8 @@ public class ReadOrderUseCase {
     private final UserAdaptor userAdaptor;
     private final IssuedTicketAdaptor issuedTicketAdaptor;
 
-    public OrderResponse execute(String orderId) {
-        Order order = orderAdaptor.findByOrderUuid(orderId);
+    public OrderResponse execute(String orderUuid) {
+        Order order = orderAdaptor.findByOrderUuid(orderUuid);
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = userAdaptor.queryUser(currentUserId);
         List<OrderLineTicketResponse> orderLineTicketResponses =

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ReadOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ReadOrderUseCase.java
@@ -1,17 +1,9 @@
 package band.gosrock.api.order.service;
 
 
-import band.gosrock.api.config.security.SecurityUtils;
-import band.gosrock.api.order.model.dto.response.OrderLineTicketResponse;
+import band.gosrock.api.order.mapper.OrderMapper;
 import band.gosrock.api.order.model.dto.response.OrderResponse;
 import band.gosrock.common.annotation.UseCase;
-import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
-import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
-import band.gosrock.domain.domains.order.domain.Order;
-import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
-import band.gosrock.domain.domains.user.domain.User;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,42 +11,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReadOrderUseCase {
-    private final OrderAdaptor orderAdaptor;
-    private final UserAdaptor userAdaptor;
-    private final IssuedTicketAdaptor issuedTicketAdaptor;
+    private final OrderMapper orderMapper;
 
     public OrderResponse execute(String orderUuid) {
-        Order order = orderAdaptor.findByOrderUuid(orderUuid);
-        Long currentUserId = SecurityUtils.getCurrentUserId();
-        User user = userAdaptor.queryUser(currentUserId);
-        List<OrderLineTicketResponse> orderLineTicketResponses =
-                order.getOrderLineItems().stream()
-                        .map(
-                                orderLineItem ->
-                                        OrderLineTicketResponse.of(
-                                                order,
-                                                orderLineItem,
-                                                user.getProfile().getName(),
-                                                getTicketNoName(orderLineItem.getId())))
-                        .toList();
-
-        return OrderResponse.of(order, orderLineTicketResponses);
-    }
-
-    // TODO : 리팩 예정
-    private String getTicketNoName(Long orderLineItemId) {
-        List<String> issuedTicketNos =
-                issuedTicketAdaptor.findAllByOrderLineId(orderLineItemId).stream()
-                        .map(IssuedTicket::getIssuedTicketNo)
-                        .toList();
-        Integer size = issuedTicketNos.size();
-        // 없을 경우긴 함 테스트를 위해서
-        if (issuedTicketNos.isEmpty()) return "";
-        else if (size.equals(1)) {
-            return String.format("%s (%d매)", issuedTicketNos.get(0), size);
-        } else {
-            return String.format(
-                    "%s ~ %s (%d매)", issuedTicketNos.get(0), issuedTicketNos.get(size - 1), size);
-        }
+        return orderMapper.toOrderResponse(orderUuid);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/RefundOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/RefundOrderUseCase.java
@@ -1,10 +1,24 @@
 package band.gosrock.api.order.service;
 
 
+import band.gosrock.api.config.security.SecurityUtils;
+import band.gosrock.api.order.mapper.OrderMapper;
+import band.gosrock.api.order.model.dto.response.OrderResponse;
 import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.order.service.WithdrawOrderService;
+import lombok.RequiredArgsConstructor;
 
+/** 환불을 위함 환불이라 함은, 사용자가 직접 구매한 물품을 취소시킴 */
 @UseCase
+@RequiredArgsConstructor
 public class RefundOrderUseCase {
+    private final WithdrawOrderService withdrawOrderService;
 
-    public void execute(String orderUuid) {}
+    private final OrderMapper orderMapper;
+
+    public OrderResponse execute(String orderUuid) {
+        Long currentUserId = SecurityUtils.getCurrentUserId();
+        withdrawOrderService.refundOrder(orderUuid, currentUserId);
+        return orderMapper.toOrderResponse(orderUuid);
+    }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/RefundOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/RefundOrderUseCase.java
@@ -6,5 +6,5 @@ import band.gosrock.common.annotation.UseCase;
 @UseCase
 public class RefundOrderUseCase {
 
-    public void execute(String orderId) {}
+    public void execute(String orderUuid) {}
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/RefundOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/RefundOrderUseCase.java
@@ -4,7 +4,7 @@ package band.gosrock.api.order.service;
 import band.gosrock.common.annotation.UseCase;
 
 @UseCase
-public class CancelOrderUseCase {
+public class RefundOrderUseCase {
 
     public void execute(String orderId) {}
 }

--- a/DuDoong-Common/src/main/java/band/gosrock/common/annotation/Mapper.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/annotation/Mapper.java
@@ -1,0 +1,19 @@
+package band.gosrock.common.annotation;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface Mapper {
+    @AliasFor(annotation = Component.class)
+    String value() default "";
+}

--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
@@ -47,7 +47,8 @@ public enum ErrorCode implements BaseErrorCode {
     ORDER_LINE_NOT_FOUND(BAD_REQUEST, "Order-404-2", "Order Line Not Fount"),
     ISSUED_TICKET_NOT_FOUND(NOT_FOUND, "IssuedTicket-404-1", "IssuedTicket Not Found"),
     ISSUED_TICKET_NOT_MATCHED_USER(
-            FORBIDDEN, "IssuedTicket-403-1", "IssuedTicket User Not Matched");
+            FORBIDDEN, "IssuedTicket-403-1", "IssuedTicket User Not Matched"),
+    TOSS_PAYMENTS_ENUM_NOT_MATCH(INTERNAL_SERVER, "INFRA-500-1", "토스페이먼츠 이넘값 관련 매칭 안된 문제입니다.");
     private int status;
     private String code;
     private String reason;

--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
@@ -48,7 +48,9 @@ public enum ErrorCode implements BaseErrorCode {
     ISSUED_TICKET_NOT_FOUND(NOT_FOUND, "IssuedTicket-404-1", "IssuedTicket Not Found"),
     ISSUED_TICKET_NOT_MATCHED_USER(
             FORBIDDEN, "IssuedTicket-403-1", "IssuedTicket User Not Matched"),
-    TOSS_PAYMENTS_ENUM_NOT_MATCH(INTERNAL_SERVER, "INFRA-500-1", "토스페이먼츠 이넘값 관련 매칭 안된 문제입니다.");
+    TOSS_PAYMENTS_ENUM_NOT_MATCH(INTERNAL_SERVER, "INFRA-500-1", "토스페이먼츠 이넘값 관련 매칭 안된 문제입니다."),
+    ORDER_CANNOT_CANCEL(BAD_REQUEST, "Order-404-3", "주문을 취소할 수 없는 상태입니다."),
+    ORDER_CANNOT_REFUND(BAD_REQUEST, "Order-404-4", "주문을 환불할 수 없는 상태입니다.");
     private int status;
     private String code;
     private String reason;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/Money.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/Money.java
@@ -2,6 +2,7 @@ package band.gosrock.domain.common.vo;
 
 
 import band.gosrock.domain.common.converter.BigDecimalScale6WithBankersRoundingConverter;
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Objects;
@@ -97,6 +98,7 @@ public class Money {
         return Objects.hashCode(amount);
     }
 
+    @JsonValue
     public String toString() {
         return amount.longValue() + "원";
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/RefundInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/RefundInfoVo.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 /** 상품 취소 가능 여부를 반환합니다. */
 @Getter
 public class RefundInfoVo {
+
     private final LocalDateTime endAt;
     private final Boolean availAble;
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartLineItem.java
@@ -80,4 +80,8 @@ public class CartLineItem extends BaseTimeEntity {
     public List<OptionAnswerVo> getOptionAnswerVos() {
         return cartOptionAnswers.stream().map(CartOptionAnswer::getOptionAnswerVo).toList();
     }
+
+    public Money getItemPrice() {
+        return ticketItem.getPrice();
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -227,4 +227,10 @@ public class Order extends BaseTimeEntity {
         }
         return "사용하지 않음";
     }
+
+    public void validPgAndOrderAmountIsEqual(Money pgAmount) {
+        if (!pgAmount.equals(getTotalPaymentPrice())) {
+            throw InvalidOrderException.EXCEPTION;
+        }
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -67,6 +67,9 @@ public class Order extends BaseTimeEntity {
     // 결제 공급자 정보 ex 카카오페이
     private String paymentProvider;
 
+    // 영수증 주소
+    private String receiptUrl;
+
     // 세금
     @Embedded
     @AttributeOverride(name = "amount", column = @Column(name = "vat_amount"))
@@ -198,11 +201,12 @@ public class Order extends BaseTimeEntity {
      * @param vat
      */
     public void afterPaymentAddInfo(
-            LocalDateTime approvedAt, PaymentMethod paymentMethod, Money vat,String provider) {
+            LocalDateTime approvedAt, PaymentMethod paymentMethod, Money vat,String provider,String receiptUrl) {
         this.approvedAt = approvedAt;
         this.paymentMethod = paymentMethod;
         this.vat = vat;
         this.paymentProvider = provider;
+        this.receiptUrl = receiptUrl;
     }
 
     /**

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -8,8 +8,7 @@ import band.gosrock.domain.common.vo.RefundInfoVo;
 import band.gosrock.domain.domains.cart.domain.Cart;
 import band.gosrock.domain.domains.coupon.domain.IssuedCoupon;
 import band.gosrock.domain.domains.order.exception.InvalidOrderException;
-import band.gosrock.domain.domains.order.exception.NotMyOrderException;
-import band.gosrock.domain.domains.order.exception.NotPendingOrderException;
+import band.gosrock.domain.domains.order.exception.NotOwnerOrderException;
 import band.gosrock.domain.domains.order.exception.OrderLineNotFountException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -61,16 +60,17 @@ public class Order extends BaseTimeEntity {
     // 결제 방식 ( 토스 승인 이후 저장 )
     @Enumerated(EnumType.STRING)
     private PaymentMethod paymentMethod = PaymentMethod.DEFAULT;
-    // 토스 결제 승인후 결제 긁힌 시간
+    // 토스 결제 승인후 결제 긁힌 시간 ( 토스 승인 이후 저장 )
     private LocalDateTime approvedAt;
 
-    // 결제 공급자 정보 ex 카카오페이
+    // 결제 공급자 정보 ex 카카오페이 ( 토스 승인 이후 저장 )
     private String paymentProvider;
 
-    // 영수증 주소
+    // 영수증 주소 ( 토스 승인 이후 저장 )
     private String receiptUrl;
-
-    // 세금
+    // 승인된 거래키 ( 취소 때 사용 )
+    private String paymentKey;
+    // 세금 ( 토스 승인 이후 저장 )
     @Embedded
     @AttributeOverride(name = "amount", column = @Column(name = "vat_amount"))
     private Money vat;
@@ -81,7 +81,7 @@ public class Order extends BaseTimeEntity {
     // 주문 상태
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private OrderStatus orderStatus = OrderStatus.PENDING;
+    private OrderStatus orderStatus = OrderStatus.READY;
 
     // 발급된 쿠폰 정보
     @JoinColumn(name = "issued_coupon_id", updatable = false)
@@ -173,24 +173,21 @@ public class Order extends BaseTimeEntity {
                         .build();
     }
 
-    /**
-     * 오더의 결제를 승인 합니다.
-     *
-     * @param currentUserId
-     * @param requestAmount
-     */
-    public void confirmPaymentOrder(Long currentUserId, Money requestAmount) {
-        if (!userId.equals(currentUserId)) {
-            throw NotMyOrderException.EXCEPTION;
-        }
+    /** 오더의 결제를 승인 합니다. */
+    public void confirmPaymentOrder(Money requestAmount) {
+
         if (!getTotalPaymentPrice().equals(requestAmount)) {
             throw InvalidOrderException.EXCEPTION;
         }
-        if (!orderStatus.equals(OrderStatus.PENDING_PAYMENT)) {
-            throw NotPendingOrderException.EXCEPTION;
-        }
+        orderStatus.validCanOrder();
         // TODO: 재고량 비교 필요?
         orderStatus = OrderStatus.CONFIRM;
+    }
+
+    public void validOwner(Long currentUserId) {
+        if (!userId.equals(currentUserId)) {
+            throw NotOwnerOrderException.EXCEPTION;
+        }
     }
 
     /**
@@ -205,12 +202,14 @@ public class Order extends BaseTimeEntity {
             PaymentMethod paymentMethod,
             Money vat,
             String provider,
-            String receiptUrl) {
+            String receiptUrl,
+            String paymentKey) {
         this.approvedAt = approvedAt;
         this.paymentMethod = paymentMethod;
         this.vat = vat;
         this.paymentProvider = provider;
         this.receiptUrl = receiptUrl;
+        this.paymentKey = paymentKey;
     }
 
     /**
@@ -244,5 +243,15 @@ public class Order extends BaseTimeEntity {
         if (!pgAmount.equals(getTotalPaymentPrice())) {
             throw InvalidOrderException.EXCEPTION;
         }
+    }
+
+    public void cancel() {
+        orderStatus.validCanCancel();
+        this.orderStatus = OrderStatus.CANCELED;
+    }
+
+    public void refund() {
+        orderStatus.validCanRefund();
+        this.orderStatus = OrderStatus.REFUND;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -201,7 +201,11 @@ public class Order extends BaseTimeEntity {
      * @param vat
      */
     public void afterPaymentAddInfo(
-            LocalDateTime approvedAt, PaymentMethod paymentMethod, Money vat,String provider,String receiptUrl) {
+            LocalDateTime approvedAt,
+            PaymentMethod paymentMethod,
+            Money vat,
+            String provider,
+            String receiptUrl) {
         this.approvedAt = approvedAt;
         this.paymentMethod = paymentMethod;
         this.vat = vat;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -64,6 +64,9 @@ public class Order extends BaseTimeEntity {
     // 토스 결제 승인후 결제 긁힌 시간
     private LocalDateTime approvedAt;
 
+    // 결제 공급자 정보 ex 카카오페이
+    private String paymentProvider;
+
     // 세금
     @Embedded
     @AttributeOverride(name = "amount", column = @Column(name = "vat_amount"))
@@ -194,11 +197,12 @@ public class Order extends BaseTimeEntity {
      * @param paymentMethod
      * @param vat
      */
-    public void updatePaymentInfo(
-            LocalDateTime approvedAt, PaymentMethod paymentMethod, Money vat) {
+    public void afterPaymentAddInfo(
+            LocalDateTime approvedAt, PaymentMethod paymentMethod, Money vat,String provider) {
         this.approvedAt = approvedAt;
         this.paymentMethod = paymentMethod;
         this.vat = vat;
+        this.paymentProvider = provider;
     }
 
     /**

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
@@ -75,8 +75,11 @@ public class OrderLineItem extends BaseTimeEntity {
     }
 
     public Money getTotalOrderLinePrice() {
-        Money itemPrice = ticketItem.getPrice();
-        return itemPrice.plus(getTotalOptionAnswersPrice()).times(quantity);
+        return getItemPrice().plus(getTotalOptionAnswersPrice()).times(quantity);
+    }
+
+    public Money getItemPrice() {
+        return ticketItem.getPrice();
     }
 
     public RefundInfoVo getRefundInfo() {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
@@ -74,7 +74,7 @@ public class OrderLineItem extends BaseTimeEntity {
                 .reduce(Money.ZERO, Money::plus);
     }
 
-    protected Money getTotalOrderLinePrice() {
+    public Money getTotalOrderLinePrice() {
         Money itemPrice = ticketItem.getPrice();
         return itemPrice.plus(getTotalOptionAnswersPrice()).times(quantity);
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderStatus.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderStatus.java
@@ -9,21 +9,20 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum OrderStatus {
     // 최초 상태
-    PENDING("PENDING","주문 생성상태"),
+    PENDING("PENDING", "주문 생성상태"),
     // 결제 대기중
-    PENDING_PAYMENT("PENDING_PAYMENT","결제 대기중"),
+    PENDING_PAYMENT("PENDING_PAYMENT", "결제 대기중"),
     // 승인 대기중 ( 승인 결제 시 )
-    PENDING_APPROVE("PENDING_APPROVE","승인 대기중"),
+    PENDING_APPROVE("PENDING_APPROVE", "승인 대기중"),
     // 만료 ( 주문 대기후 결제가 장기간 이뤄지지 않았을 때 )
-    OUTDATED("OUTDATED","결제 시간 만료"),
+    OUTDATED("OUTDATED", "결제 시간 만료"),
     // 결제 승인
-    CONFIRM("CONFIRM","결제 완료"),
+    CONFIRM("CONFIRM", "결제 완료"),
     // 환불
-    REFUND("REFUND","환불 완료"),
+    REFUND("REFUND", "환불 완료"),
     // 토스 결제 실패시
-    FAILED("FAILED","결제 실패");
+    FAILED("FAILED", "결제 실패");
     private String value;
 
-    @JsonValue
-    private String kr;
+    @JsonValue private String kr;
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderStatus.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderStatus.java
@@ -1,6 +1,9 @@
 package band.gosrock.domain.domains.order.domain;
 
 
+import band.gosrock.domain.domains.order.exception.CanNotCancelOrderException;
+import band.gosrock.domain.domains.order.exception.CanNotRefundOrderException;
+import band.gosrock.domain.domains.order.exception.NotPendingOrderException;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,7 +12,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum OrderStatus {
     // 최초 상태
-    PENDING("PENDING", "주문 생성상태"),
+    READY("READY", "주문 생성상태"),
     // 결제 대기중
     PENDING_PAYMENT("PENDING_PAYMENT", "결제 대기중"),
     // 승인 대기중 ( 승인 결제 시 )
@@ -18,11 +21,32 @@ public enum OrderStatus {
     OUTDATED("OUTDATED", "결제 시간 만료"),
     // 결제 승인
     CONFIRM("CONFIRM", "결제 완료"),
-    // 환불
+    // 사용자가 환불
     REFUND("REFUND", "환불 완료"),
+
+    // 취소된 결제
+    CANCELED("CANCELED", "취소된 결제"),
     // 토스 결제 실패시
     FAILED("FAILED", "결제 실패");
     private String value;
 
     @JsonValue private String kr;
+
+    public void validCanCancel() {
+        if (!this.equals(OrderStatus.CONFIRM)) {
+            throw CanNotCancelOrderException.EXCEPTION;
+        }
+    }
+
+    public void validCanRefund() {
+        if (!this.equals(OrderStatus.CONFIRM)) {
+            throw CanNotRefundOrderException.EXCEPTION;
+        }
+    }
+
+    public void validCanOrder() {
+        if (!this.equals(OrderStatus.PENDING_PAYMENT)) {
+            throw NotPendingOrderException.EXCEPTION;
+        }
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderStatus.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderStatus.java
@@ -1,6 +1,7 @@
 package band.gosrock.domain.domains.order.domain;
 
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,31 +9,21 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum OrderStatus {
     // 최초 상태
-    PENDING("PENDING"),
+    PENDING("PENDING","주문 생성상태"),
     // 결제 대기중
-    PENDING_PAYMENT("PENDING_PAYMENT"),
+    PENDING_PAYMENT("PENDING_PAYMENT","결제 대기중"),
     // 승인 대기중 ( 승인 결제 시 )
-    PENDING_APPROVE("PENDING_APPROVE"),
+    PENDING_APPROVE("PENDING_APPROVE","승인 대기중"),
     // 만료 ( 주문 대기후 결제가 장기간 이뤄지지 않았을 때 )
-    OUTDATED("OUTDATED"),
+    OUTDATED("OUTDATED","결제 시간 만료"),
     // 결제 승인
-    CONFIRM("CONFIRM"),
+    CONFIRM("CONFIRM","결제 완료"),
     // 환불
-    REFUND("REFUND"),
+    REFUND("REFUND","환불 완료"),
     // 토스 결제 실패시
-    FAILED("FAILED");
+    FAILED("FAILED","결제 실패");
     private String value;
 
-    @Override
-    public String toString() {
-        return switch (this) {
-            case PENDING -> "주문 생성상태";
-            case PENDING_PAYMENT -> "결제 대기중";
-            case PENDING_APPROVE -> "승인 대기중";
-            case OUTDATED -> "결제 시간 만료";
-            case CONFIRM -> "결제 완료";
-            case REFUND -> "환불 완료";
-            case FAILED -> "결제 실패";
-        };
-    }
+    @JsonValue
+    private String kr;
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/PaymentMethod.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/PaymentMethod.java
@@ -3,6 +3,7 @@ package band.gosrock.domain.domains.order.domain;
 
 import band.gosrock.domain.domains.order.exception.NotSupportedOrderMethodException;
 import band.gosrock.infrastructure.outer.api.tossPayments.dto.response.TossPaymentMethod;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,24 +11,17 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum PaymentMethod {
     // 간편결제
-    EASYPAY("EASYPAY"),
+    EASYPAY("EASYPAY","간편 결제"),
     // 카드결제
-    CARD("CARD"),
+    CARD("CARD","카드 결제"),
     // 승인결제
-    APPROVAL("APPROVAL"),
+    APPROVAL("APPROVAL","승인 결제"),
     // 결제방식 미지정상태
-    DEFAULT("DEFAULT");
+    DEFAULT("DEFAULT","결제 방식 미지정");
     private String value;
 
-    @Override
-    public String toString() {
-        return switch (this) {
-            case EASYPAY -> "간편 결제";
-            case CARD -> "카드 결제";
-            case APPROVAL -> "승인 결제";
-            case DEFAULT -> "결제 방식 미지정";
-        };
-    }
+    @JsonValue
+    private String kr;
 
     public static PaymentMethod from(TossPaymentMethod tossPaymentMethod) {
         try {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/PaymentMethod.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/PaymentMethod.java
@@ -1,6 +1,8 @@
 package band.gosrock.domain.domains.order.domain;
 
 
+import band.gosrock.domain.domains.order.exception.NotSupportedOrderMethodException;
+import band.gosrock.infrastructure.outer.api.tossPayments.dto.response.TossPaymentMethod;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -25,5 +27,13 @@ public enum PaymentMethod {
             case APPROVAL -> "승인 결제";
             case DEFAULT -> "결제 방식 미지정";
         };
+    }
+
+    public static PaymentMethod from(TossPaymentMethod tossPaymentMethod) {
+        try {
+            return PaymentMethod.valueOf(tossPaymentMethod.name());
+        } catch (IllegalArgumentException illegalArgumentException) {
+            throw NotSupportedOrderMethodException.EXCEPTION;
+        }
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/PaymentMethod.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/PaymentMethod.java
@@ -11,17 +11,16 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum PaymentMethod {
     // 간편결제
-    EASYPAY("EASYPAY","간편 결제"),
+    EASYPAY("EASYPAY", "간편 결제"),
     // 카드결제
-    CARD("CARD","카드 결제"),
+    CARD("CARD", "카드 결제"),
     // 승인결제
-    APPROVAL("APPROVAL","승인 결제"),
+    APPROVAL("APPROVAL", "승인 결제"),
     // 결제방식 미지정상태
-    DEFAULT("DEFAULT","결제 방식 미지정");
+    DEFAULT("DEFAULT", "결제 방식 미지정");
     private String value;
 
-    @JsonValue
-    private String kr;
+    @JsonValue private String kr;
 
     public static PaymentMethod from(TossPaymentMethod tossPaymentMethod) {
         try {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/CanNotCancelOrderException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/CanNotCancelOrderException.java
@@ -1,0 +1,14 @@
+package band.gosrock.domain.domains.order.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+import band.gosrock.common.exception.ErrorCode;
+
+public class CanNotCancelOrderException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new CanNotCancelOrderException();
+
+    private CanNotCancelOrderException() {
+        super(ErrorCode.ORDER_CANNOT_CANCEL);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/CanNotRefundOrderException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/CanNotRefundOrderException.java
@@ -1,0 +1,14 @@
+package band.gosrock.domain.domains.order.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+import band.gosrock.common.exception.ErrorCode;
+
+public class CanNotRefundOrderException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new CanNotRefundOrderException();
+
+    private CanNotRefundOrderException() {
+        super(ErrorCode.ORDER_CANNOT_REFUND);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/NotOwnerOrderException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/NotOwnerOrderException.java
@@ -4,11 +4,11 @@ package band.gosrock.domain.domains.order.exception;
 import band.gosrock.common.exception.DuDoongCodeException;
 import band.gosrock.common.exception.ErrorCode;
 
-public class NotMyOrderException extends DuDoongCodeException {
+public class NotOwnerOrderException extends DuDoongCodeException {
 
-    public static final DuDoongCodeException EXCEPTION = new NotMyOrderException();
+    public static final DuDoongCodeException EXCEPTION = new NotOwnerOrderException();
 
-    private NotMyOrderException() {
+    private NotOwnerOrderException() {
         super(ErrorCode.ORDER_NOT_MINE);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CancelPaymentService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CancelPaymentService.java
@@ -1,5 +1,6 @@
 package band.gosrock.domain.domains.order.service;
 
+
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.infrastructure.outer.api.tossPayments.client.PaymentsCancelClient;
 import band.gosrock.infrastructure.outer.api.tossPayments.dto.request.CancelPaymentsRequest;
@@ -15,10 +16,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class CancelPaymentService {
     private final PaymentsCancelClient paymentsCancelClient;
 
-
-    public PaymentsResponse cancelPayment(String orderUuid ,String paymentKey , String reason){
-        log.info("환불처리 " +orderUuid +" : "+ paymentKey);
-        return paymentsCancelClient.execute(orderUuid,
-            paymentKey, CancelPaymentsRequest.builder().cancelReason(reason).build());
+    public PaymentsResponse cancelPayment(String orderUuid, String paymentKey, String reason) {
+        log.info("환불처리 " + orderUuid + " : " + paymentKey);
+        return paymentsCancelClient.execute(
+                orderUuid,
+                paymentKey,
+                CancelPaymentsRequest.builder().cancelReason(reason).build());
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CancelPaymentService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CancelPaymentService.java
@@ -1,0 +1,24 @@
+package band.gosrock.domain.domains.order.service;
+
+import band.gosrock.common.annotation.DomainService;
+import band.gosrock.infrastructure.outer.api.tossPayments.client.PaymentsCancelClient;
+import band.gosrock.infrastructure.outer.api.tossPayments.dto.request.CancelPaymentsRequest;
+import band.gosrock.infrastructure.outer.api.tossPayments.dto.response.PaymentsResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@DomainService
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class CancelPaymentService {
+    private final PaymentsCancelClient paymentsCancelClient;
+
+
+    public PaymentsResponse cancelPayment(String orderUuid ,String paymentKey , String reason){
+        log.info("환불처리 " +orderUuid +" : "+ paymentKey);
+        return paymentsCancelClient.execute(orderUuid,
+            paymentKey, CancelPaymentsRequest.builder().cancelReason(reason).build());
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderConfirmService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderConfirmService.java
@@ -42,7 +42,7 @@ public class OrderConfirmService {
                     paymentsResponse.getApprovedAt().toLocalDateTime(),
                     PaymentMethod.from(paymentsResponse.getMethod()),
                     Money.wons(paymentsResponse.getVat()),
-                    paymentsResponse.
+                    paymentsResponse.getProviderName()
                 );
             return order.getId();
         } catch (Exception exception) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderConfirmService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderConfirmService.java
@@ -42,7 +42,8 @@ public class OrderConfirmService {
                     paymentsResponse.getApprovedAt().toLocalDateTime(),
                     PaymentMethod.from(paymentsResponse.getMethod()),
                     Money.wons(paymentsResponse.getVat()),
-                    paymentsResponse.getProviderName()
+                    paymentsResponse.getProviderName(),
+                    paymentsResponse.getReceipt().getUrl()
                 );
             return order.getId();
         } catch (Exception exception) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderConfirmService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderConfirmService.java
@@ -7,12 +7,9 @@ import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.PaymentMethod;
-import band.gosrock.domain.domains.order.exception.InvalidOrderException;
-import band.gosrock.domain.domains.order.exception.NotSupportedOrderMethodException;
 import band.gosrock.infrastructure.outer.api.tossPayments.client.PaymentsConfirmClient;
 import band.gosrock.infrastructure.outer.api.tossPayments.dto.request.ConfirmPaymentsRequest;
 import band.gosrock.infrastructure.outer.api.tossPayments.dto.response.PaymentsResponse;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,30 +33,23 @@ public class OrderConfirmService {
         order.confirmPaymentOrder(currentUserId, Money.wons(confirmPaymentsRequest.getAmount()));
         // 결제 승인요청
         PaymentsResponse paymentsResponse = paymentsConfirmClient.execute(confirmPaymentsRequest);
-        // TODO : 이넘화 예정
         // TODO : 요청 보내고 난뒤에 도메인 로직 내부에서 실패하면 결제 강제 취소 로직 AOP로 개발 예정
         try {
             // 실제 거래된 금액이 다를때
             order.validPgAndOrderAmountIsEqual(Money.wons(paymentsResponse.getTotalAmount()));
-            // 수정필요
-            LocalDateTime approveAt = paymentsResponse.getApprovedAt().toLocalDateTime();
-            Money vat = Money.wons(paymentsResponse.getVat());
-            PaymentMethod paymentMethod;
-            if (paymentsResponse.getMethod().equals("카드")) {
-                paymentMethod = PaymentMethod.CARD;
-            } else if (paymentsResponse.getMethod().equals("간편결제")) {
-                paymentMethod = PaymentMethod.EASYPAY;
-            } else {
-                throw NotSupportedOrderMethodException.EXCEPTION;
-            }
             // 결제 후처리 정보 업데이트
-            order.updatePaymentInfo(approveAt, paymentMethod, vat);
+            order.afterPaymentAddInfo(
+                    paymentsResponse.getApprovedAt().toLocalDateTime(),
+                    PaymentMethod.from(paymentsResponse.getMethod()),
+                    Money.wons(paymentsResponse.getVat()),
+                    paymentsResponse.
+                );
             return order.getId();
-        } catch (Exception e) {
+        } catch (Exception exception) {
             // 내부오류시 결제 강제 취소
             cancelPaymentService.cancelPayment(
                     order.getUuid(), confirmPaymentsRequest.getPaymentKey(), "서버 오류로 인한 환불");
-            throw InvalidOrderException.EXCEPTION;
+            throw exception;
         }
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderConfirmService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderConfirmService.java
@@ -43,8 +43,7 @@ public class OrderConfirmService {
                     PaymentMethod.from(paymentsResponse.getMethod()),
                     Money.wons(paymentsResponse.getVat()),
                     paymentsResponse.getProviderName(),
-                    paymentsResponse.getReceipt().getUrl()
-                );
+                    paymentsResponse.getReceipt().getUrl());
             return order.getId();
         } catch (Exception exception) {
             // 내부오류시 결제 강제 취소

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/WithdrawOrderService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/WithdrawOrderService.java
@@ -22,7 +22,7 @@ public class WithdrawOrderService {
     @RedissonLock(LockName = "결제취소", identifier = "orderUuid")
     public String cancelOrder(String orderUuid, Long userId) {
         Order order = orderAdaptor.findByOrderUuid(orderUuid);
-
+        // TODO : 관리자 권환으로 치환.
         order.validOwner(userId);
         order.cancel();
         PaymentsResponse paymentsResponse =

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/WithdrawOrderService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/WithdrawOrderService.java
@@ -1,0 +1,47 @@
+package band.gosrock.domain.domains.order.service;
+
+
+import band.gosrock.common.annotation.DomainService;
+import band.gosrock.domain.common.aop.redissonLock.RedissonLock;
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
+import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.infrastructure.outer.api.tossPayments.dto.response.PaymentsResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@DomainService
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class WithdrawOrderService {
+
+    private final OrderAdaptor orderAdaptor;
+    private final WithdrawPaymentService withdrawPaymentService;
+
+    @RedissonLock(LockName = "결제취소", identifier = "orderUuid")
+    public String cancelOrder(String orderUuid, Long userId) {
+        Order order = orderAdaptor.findByOrderUuid(orderUuid);
+
+        order.validOwner(userId);
+        order.cancel();
+        PaymentsResponse paymentsResponse =
+                withdrawPaymentService.execute(
+                        order.getUuid(), order.getPaymentKey(), "이벤트 관리자에 의한 취소");
+
+        return orderUuid;
+    }
+
+    @RedissonLock(LockName = "결제취소", identifier = "orderUuid")
+    public String refundOrder(String orderUuid, Long userId) {
+        Order order = orderAdaptor.findByOrderUuid(orderUuid);
+        order.validOwner(userId);
+        order.refund();
+
+        PaymentsResponse paymentsResponse =
+                withdrawPaymentService.execute(
+                        order.getUuid(), order.getPaymentKey(), "구매자에의한 환불 요청");
+
+        return orderUuid;
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/WithdrawPaymentService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/WithdrawPaymentService.java
@@ -13,11 +13,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Slf4j
-public class CancelPaymentService {
+public class WithdrawPaymentService {
     private final PaymentsCancelClient paymentsCancelClient;
 
-    public PaymentsResponse cancelPayment(String orderUuid, String paymentKey, String reason) {
-        log.info("환불처리 " + orderUuid + " : " + paymentKey);
+    public PaymentsResponse execute(String orderUuid, String paymentKey, String reason) {
+        log.info("취소처리 " + orderUuid + " : " + paymentKey + reason);
         return paymentsCancelClient.execute(
                 orderUuid,
                 paymentKey,

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/OptionGroupType.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/OptionGroupType.java
@@ -9,13 +9,12 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum OptionGroupType {
     // T/F
-    TRUE_FALSE("TRUE_FALSE","Y/N"),
+    TRUE_FALSE("TRUE_FALSE", "Y/N"),
     //
-    MULTIPLE_CHOICE("MULTIPLE_CHOICE","객관식"),
+    MULTIPLE_CHOICE("MULTIPLE_CHOICE", "객관식"),
     //
-    SUBJECTIVE("SUBJECTIVE","주관식");
+    SUBJECTIVE("SUBJECTIVE", "주관식");
     private String value;
 
-    @JsonValue
-    private String name;
+    @JsonValue private String name;
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/OptionGroupType.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/OptionGroupType.java
@@ -1,6 +1,7 @@
 package band.gosrock.domain.domains.ticket_item.domain;
 
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,10 +9,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum OptionGroupType {
     // T/F
-    TRUE_FALSE("TRUE_FALSE"),
+    TRUE_FALSE("TRUE_FALSE","Y/N"),
     //
-    MULTIPLE_CHOICE("MULTIPLE_CHOICE"),
+    MULTIPLE_CHOICE("MULTIPLE_CHOICE","객관식"),
     //
-    SUBJECTIVE("SUBJECTIVE");
+    SUBJECTIVE("SUBJECTIVE","주관식");
     private String value;
+
+    @JsonValue
+    private String name;
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/client/PaymentsCancelClient.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/client/PaymentsCancelClient.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface PaymentsCancelClient {
     @PostMapping("/v1/payments/{paymentKey}/cancel")
     PaymentsResponse execute(
-        @RequestHeader("Idempotency-Key") String idempotencyKey,
+            @RequestHeader("Idempotency-Key") String idempotencyKey,
             @PathVariable("paymentKey") String paymentKey,
             @RequestBody CancelPaymentsRequest cancelPaymentsRequest);
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/client/PaymentsCancelClient.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/client/PaymentsCancelClient.java
@@ -8,15 +8,16 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(
         name = "PaymentsCancelClient",
         url = "https://api.tosspayments.com",
         configuration = {PaymentsCancelConfig.class})
 public interface PaymentsCancelClient {
-    // TODO : 멱등키 구현
     @PostMapping("/v1/payments/{paymentKey}/cancel")
     PaymentsResponse execute(
+        @RequestHeader("Idempotency-Key") String idempotencyKey,
             @PathVariable("paymentKey") String paymentKey,
             @RequestBody CancelPaymentsRequest cancelPaymentsRequest);
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/CardAcquireStatus.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/CardAcquireStatus.java
@@ -1,0 +1,25 @@
+package band.gosrock.infrastructure.outer.api.tossPayments.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CardAcquireStatus {
+    //- READY: 아직 매입 요청이 안 된 상태입니다.
+    //
+    //- REQUESTED: 매입이 요청된 상태입니다.
+    //
+    //- COMPLETED: 요청된 매입이 완료된 상태입니다.
+    //
+    //- CANCEL_REQUESTED: 매입 취소가 요청된 상태입니다.
+    //
+    //- CANCELED: 요청된 매입 취소가 완료된 상태입니다.
+    READY("READY"),
+    REQUESTED("REQUESTED"),
+    COMPLETED("COMPLETED"),
+    CANCEL_REQUESTED("CANCEL_REQUESTED"),
+    CANCELED("CANCELED");
+
+    private String value;
+}

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/CardAcquireStatus.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/CardAcquireStatus.java
@@ -1,20 +1,21 @@
 package band.gosrock.infrastructure.outer.api.tossPayments.dto.response;
 
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum CardAcquireStatus {
-    //- READY: 아직 매입 요청이 안 된 상태입니다.
+    // - READY: 아직 매입 요청이 안 된 상태입니다.
     //
-    //- REQUESTED: 매입이 요청된 상태입니다.
+    // - REQUESTED: 매입이 요청된 상태입니다.
     //
-    //- COMPLETED: 요청된 매입이 완료된 상태입니다.
+    // - COMPLETED: 요청된 매입이 완료된 상태입니다.
     //
-    //- CANCEL_REQUESTED: 매입 취소가 요청된 상태입니다.
+    // - CANCEL_REQUESTED: 매입 취소가 요청된 상태입니다.
     //
-    //- CANCELED: 요청된 매입 취소가 완료된 상태입니다.
+    // - CANCELED: 요청된 매입 취소가 완료된 상태입니다.
     READY("READY"),
     REQUESTED("REQUESTED"),
     COMPLETED("COMPLETED"),

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/CardCode.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/CardCode.java
@@ -1,0 +1,47 @@
+package band.gosrock.infrastructure.outer.api.tossPayments.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CardCode {
+    IBK_BC("3K", "기업비씨", "IBK_BC", "기업 비씨"),
+    GWANGJUBANK("46", "광주", "GWANGJUBANK", "광주은행"),
+    LOTTE("71", "롯데", "LOTTE", "롯데카드"),
+    KDBBANK("30", "산업", "KDBBANK", "KDB산업은행"),
+
+    BC("31", "", "BC", "비씨카드"),
+    SAMSUNG("51", "삼성", "SAMSUNG", "삼성카드"),
+    SAEMAUL("38", "새마을", "SAEMAUL", "새마을금고"),
+    SHINHAN("41", "신한", "SHINHAN", "신한카드"),
+    SHINHYEOP("62", "신협", "SHINHYEOP", "신협"),
+    CITI("36", "씨티", "CITI", "씨티카드"),
+    WOORI("33", "우리", "WOORI", "우리카드"),
+    POST("37", "우체국", "POST", "우체국예금보험"),
+    SAVINGBANK("39", "저축", "SAVINGBANK", "저축은행중앙회"),
+    JEONBUKBANK("35", "전북", "JEONBUKBANK", "전북은행"),
+    JEJUBANK("42", "제주", "JEJUBANK", "제주은행"),
+    KAKAOBANK("15", "카카오뱅크", "KAKAOBANK", "카카오뱅크"),
+    KBANK("3A", "케이뱅크", "KBANK", "케이뱅크"),
+    TOSSBANK("24", "토스뱅크", "TOSSBANK", "토스뱅크"),
+    HANA("21", "하나", "HANA", "하나카드"),
+    HYUNDAI("61", "현대", "HYUNDAI", "현대카드"),
+    KOOKMIN("11", "국민", "KOOKMIN", "KB국민카드"),
+    NONGHYEOP("91", "농협", "NONGHYEOP", "NH농협카드"),
+    SUHYEOP("34", "수협", "SUHYEOP", "Sh수협은행"),
+    // 해외
+    DINERS("6D", "다이너스", "DINERS", "다이너스 클럽"),
+    DISCOVER("6I", "디스커버", "DISCOVER", "디스커버"),
+    MASTER("4M", "마스터", "MASTER", "마스터카드"),
+    UNIONPAY("3C", "유니온페이", "UNIONPAY", "유니온페이"),
+    AMEX("7A", "", "AMEX", "아메리칸 익스프레스"),
+    JCB("4J", "", "JCB", "JCB"),
+    VISA("4V", "비자", "VISA", "VISA");
+
+    private String code;
+    private String kr;
+    private String en;
+    private String cardCompanyName;
+}

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/CardCode.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/CardCode.java
@@ -1,6 +1,9 @@
 package band.gosrock.infrastructure.outer.api.tossPayments.dto.response;
 
 
+import band.gosrock.infrastructure.outer.api.tossPayments.exception.PaymentsEnumNotMatchException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -44,4 +47,12 @@ public enum CardCode {
     private String kr;
     private String en;
     private String cardCompanyName;
+
+    @JsonCreator
+    static CardCode findValue(String code) {
+        return Arrays.stream(CardCode.values())
+                .filter(cardCode -> cardCode.getCode().equals(code))
+                .findFirst()
+                .orElseThrow(() -> PaymentsEnumNotMatchException.EXCEPTION);
+    }
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/EasyPayCode.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/EasyPayCode.java
@@ -1,6 +1,9 @@
 package band.gosrock.infrastructure.outer.api.tossPayments.dto.response;
 
 
+import band.gosrock.infrastructure.outer.api.tossPayments.exception.PaymentsEnumNotMatchException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -18,4 +21,12 @@ public enum EasyPayCode {
 
     private String kr;
     private String en;
+
+    @JsonCreator
+    static EasyPayCode findValue(String code) {
+        return Arrays.stream(EasyPayCode.values())
+                .filter(EasyPayCode -> EasyPayCode.getKr().equals(code))
+                .findFirst()
+                .orElseThrow(() -> PaymentsEnumNotMatchException.EXCEPTION);
+    }
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/EasyPayCode.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/EasyPayCode.java
@@ -1,0 +1,21 @@
+package band.gosrock.infrastructure.outer.api.tossPayments.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EasyPayCode {
+    TOSSPAY("토스페이", "TOSSPAY"),
+    NAVERPAY("네이버페이", "NAVERPAY"),
+    SAMSUNGPAY("삼성페이", "SAMSUNGPAY"),
+    LPAY("엘페이", "LPAY"),
+    KAKAOPAY("카카오페이", "KAKAOPAY"),
+    PAYCO("페이코", "PAYCO"),
+    LGPAY("LG페이", "LGPAY"),
+    SSG("SSG페이", "SSG");
+
+    private String kr;
+    private String en;
+}

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentEasyPay.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentEasyPay.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class PaymentEasyPay {
-    private String provider;
+    private EasyPayCode provider;
     private Long amount;
     private Long discountAmount;
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentMethod.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentMethod.java
@@ -1,0 +1,17 @@
+package band.gosrock.infrastructure.outer.api.tossPayments.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentMethod {
+    CARD("카드"),
+    VIRTUAL_ACCOUNT("가상계좌"),
+    EASY_PAY("간편결제"),
+    MOBILE_PAY("휴대폰"),
+    BANK_TRANSFER("계좌이체"),
+    GIFT_CARD("상품권");
+
+    private String kr;
+}

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentMethod.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentMethod.java
@@ -1,5 +1,9 @@
 package band.gosrock.infrastructure.outer.api.tossPayments.dto.response;
 
+
+import band.gosrock.infrastructure.outer.api.tossPayments.exception.PaymentsEnumNotMatchException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -14,4 +18,12 @@ public enum PaymentMethod {
     GIFT_CARD("상품권");
 
     private String kr;
+
+    @JsonCreator
+    static PaymentMethod findValue(String code) {
+        return Arrays.stream(PaymentMethod.values())
+                .filter(PaymentMethod -> PaymentMethod.getKr().equals(code))
+                .findFirst()
+                .orElseThrow(() -> PaymentsEnumNotMatchException.EXCEPTION);
+    }
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentStatus.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentStatus.java
@@ -1,5 +1,6 @@
 package band.gosrock.infrastructure.outer.api.tossPayments.dto.response;
 
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentStatus.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentStatus.java
@@ -1,0 +1,35 @@
+package band.gosrock.infrastructure.outer.api.tossPayments.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentStatus {
+    // 결제 처리 상태
+    // - READY: 결제를 생성하면 가지게 되는 초기 상태 입니다. 인증 전까지는 READY 상태를 유지합니다.
+    //
+    // - IN_PROGRESS: 결제 수단 정보와 해당 결제 수단의 소유자가 맞는지 인증을 마친 상태입니다. 결제 승인 API를 호출하면 결제가 완료됩니다.
+    //
+    // - WAITING_FOR_DEPOSIT: 가상계좌 결제 흐름에만 있는 상태로, 결제 고객이 발급된 가상계좌에 입금하는 것을 기다리고 있는 상태입니다.
+    //
+    // - DONE: 인증된 결제 수단 정보, 고객 정보로 요청한 결제가 승인된 상태입니다.
+    //
+    // - CANCELED: 승인된 결제가 취소된 상태입니다.
+    //
+    // - PARTIAL_CANCELED: 승인된 결제가 부분 취소된 상태입니다.
+    //
+    // - ABORTED: 결제 승인이 실패했거나, 결제 고객이 창을 닫아서 결제를 취소한 상태입니다.
+    //
+    // - EXPIRED: 결제 유효 시간 30분이 지나 거래가 취소된 상태입니다. IN_PROGRESS 상태에서 결제 승인 API를 호출하지 않으면 EXPIRED가 됩니다
+    READY("READY"),
+    IN_PROGRESS("IN_PROGRESS"),
+    WAITING_FOR_DEPOSIT("WAITING_FOR_DEPOSIT"),
+    DONE("DONE"),
+    CANCELED("CANCELED"),
+    PARTIAL_CANCELED("PARTIAL_CANCELED"),
+    ABORTED("ABORTED"),
+    EXPIRED("EXPIRED");
+
+    private String value;
+}

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsCard.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsCard.java
@@ -8,8 +8,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class PaymentsCard {
     private Long amount;
-    private String issuerCode;
-    private String acquirerCode;
+    private CardCode issuerCode;
+    private CardCode acquirerCode;
     private String number;
     private Long installmentPlanMonths;
     private String approveNo;

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsCard.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsCard.java
@@ -16,7 +16,7 @@ public class PaymentsCard {
     private Boolean useCardPoint;
     private String cardType;
     private String ownerType;
-    private String acquireStatus;
+    private CardAcquireStatus acquireStatus;
 
     private Boolean isInterestFree;
     private String interestPayer;

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsResponse.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsResponse.java
@@ -26,7 +26,7 @@ public class PaymentsResponse {
     // 통화 단위 원화 'KRW' 기본값
     private String currency;
     // 결제할 때 사용한 결제수단 카드, 가상계좌, 간편결제, 휴대폰, 계좌이체, 상품권(문화상품권, 도서문화상품권, 게임문화상품권)
-    private PaymentMethod method;
+    private TossPaymentMethod method;
     // 총 결제 금액
     private Long totalAmount;
     // 취소할 수 있는 금액(잔고)
@@ -75,4 +75,13 @@ public class PaymentsResponse {
     private PaymentsCashReceipt cashReceipt;
     // 카드 프로모션 적용시. 적용안할듯
     private PaymentsCardPromotion discount;
+
+    public String getProviderName(){
+        if(TossPaymentMethod.CARD.equals(this.method)){
+            this.card.getIssuerCode().get
+        }else if(TossPaymentMethod.EASYPAY.equals(this.method)){
+
+        }
+
+    }
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsResponse.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsResponse.java
@@ -31,23 +31,8 @@ public class PaymentsResponse {
     private Long totalAmount;
     // 취소할 수 있는 금액(잔고)
     private Long balanceAmount;
-    // 결제 처리 상태
-    // - READY: 결제를 생성하면 가지게 되는 초기 상태 입니다. 인증 전까지는 READY 상태를 유지합니다.
-    //
-    // - IN_PROGRESS: 결제 수단 정보와 해당 결제 수단의 소유자가 맞는지 인증을 마친 상태입니다. 결제 승인 API를 호출하면 결제가 완료됩니다.
-    //
-    // - WAITING_FOR_DEPOSIT: 가상계좌 결제 흐름에만 있는 상태로, 결제 고객이 발급된 가상계좌에 입금하는 것을 기다리고 있는 상태입니다.
-    //
-    // - DONE: 인증된 결제 수단 정보, 고객 정보로 요청한 결제가 승인된 상태입니다.
-    //
-    // - CANCELED: 승인된 결제가 취소된 상태입니다.
-    //
-    // - PARTIAL_CANCELED: 승인된 결제가 부분 취소된 상태입니다.
-    //
-    // - ABORTED: 결제 승인이 실패했거나, 결제 고객이 창을 닫아서 결제를 취소한 상태입니다.
-    //
-    // - EXPIRED: 결제 유효 시간 30분이 지나 거래가 취소된 상태입니다. IN_PROGRESS 상태에서 결제 승인 API를 호출하지 않으면 EXPIRED가 됩니다
-    private String status;
+
+    private PaymentStatus status;
 
     // 결제 일어난 시간정보
     private ZonedDateTime requestedAt;

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsResponse.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsResponse.java
@@ -78,10 +78,10 @@ public class PaymentsResponse {
 
     public String getProviderName(){
         if(TossPaymentMethod.CARD.equals(this.method)){
-            this.card.getIssuerCode().get
+            return this.card.getIssuerCode().getKr();
         }else if(TossPaymentMethod.EASYPAY.equals(this.method)){
-
+            return this.easyPay.getProvider().getKr();
         }
-
+        return "";
     }
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsResponse.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsResponse.java
@@ -26,7 +26,7 @@ public class PaymentsResponse {
     // 통화 단위 원화 'KRW' 기본값
     private String currency;
     // 결제할 때 사용한 결제수단 카드, 가상계좌, 간편결제, 휴대폰, 계좌이체, 상품권(문화상품권, 도서문화상품권, 게임문화상품권)
-    private String method;
+    private PaymentMethod method;
     // 총 결제 금액
     private Long totalAmount;
     // 취소할 수 있는 금액(잔고)

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsResponse.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/PaymentsResponse.java
@@ -76,10 +76,10 @@ public class PaymentsResponse {
     // 카드 프로모션 적용시. 적용안할듯
     private PaymentsCardPromotion discount;
 
-    public String getProviderName(){
-        if(TossPaymentMethod.CARD.equals(this.method)){
+    public String getProviderName() {
+        if (TossPaymentMethod.CARD.equals(this.method)) {
             return this.card.getIssuerCode().getKr();
-        }else if(TossPaymentMethod.EASYPAY.equals(this.method)){
+        } else if (TossPaymentMethod.EASYPAY.equals(this.method)) {
             return this.easyPay.getProvider().getKr();
         }
         return "";

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/TossPaymentMethod.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/dto/response/TossPaymentMethod.java
@@ -9,10 +9,10 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum PaymentMethod {
+public enum TossPaymentMethod {
     CARD("카드"),
     VIRTUAL_ACCOUNT("가상계좌"),
-    EASY_PAY("간편결제"),
+    EASYPAY("간편결제"),
     MOBILE_PAY("휴대폰"),
     BANK_TRANSFER("계좌이체"),
     GIFT_CARD("상품권");
@@ -20,8 +20,8 @@ public enum PaymentMethod {
     private String kr;
 
     @JsonCreator
-    static PaymentMethod findValue(String code) {
-        return Arrays.stream(PaymentMethod.values())
+    static TossPaymentMethod findValue(String code) {
+        return Arrays.stream(TossPaymentMethod.values())
                 .filter(PaymentMethod -> PaymentMethod.getKr().equals(code))
                 .findFirst()
                 .orElseThrow(() -> PaymentsEnumNotMatchException.EXCEPTION);

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/exception/PaymentsEnumNotMatchException.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/tossPayments/exception/PaymentsEnumNotMatchException.java
@@ -1,0 +1,13 @@
+package band.gosrock.infrastructure.outer.api.tossPayments.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+import band.gosrock.common.exception.ErrorCode;
+
+public class PaymentsEnumNotMatchException extends DuDoongCodeException {
+    public static final DuDoongCodeException EXCEPTION = new PaymentsEnumNotMatchException();
+
+    private PaymentsEnumNotMatchException() {
+        super(ErrorCode.TOSS_PAYMENTS_ENUM_NOT_MATCH);
+    }
+}


### PR DESCRIPTION
## 개요
- close #70 

## 작업사항
- 결제 취소 기능을 개발했습니다.
- 사용자가 직접 처리하는 환불.
- 관리자(호스트)가 취소해버리는 취소. 로 두가지로 나눴습니다.
- 관리자 취소는 권한 아직 냅뒀습니다.

관리자 취소일경우 event_id 가 필요한데
민준이처럼
/api/v1/admin/events/{event_id}/order/{order_id}/cancel

뭐이렇게 url가져가고 useCase 만 저길로 옮기면되니깐!
괜찮을것같긴하네요

- orderResponse 를 좀더 정보를 더주기로했습니다.
- orderMapper를 냅둬서 어제 회의시간에 공유했었던 트랜잭션 read_commit 관련 문제를 없애버렸습니다.
- 오더맵퍼... 아마 보통 쓰는 컨벤션있는것같던데 맞춰가시쥬!


```json
{
  "success": true,
  "status": 200,
  "data": {
    "paymentInfo": {
      "paymentMethod": "간편 결제",
      "provider": "토스페이",
      "supplyAmount": "15000원",
      "discountAmount": "0원",
      "couponName": "사용하지 않음",
      "totalAmount": "15000원",
      "orderStatus": "환불 완료",
      "receiptUrl": "https://dashboard.tosspayments.com/sales-slip?transactionId=c12bjcpoyt6SKKAvoeLDysw5JVY9XTR3lpv7dANK2Z5%2B6qX3IdFZQ627sFhlQoUn&ref=PX"
    },
    "tickets": [
      {
        "ticketName": "계좌이체티켓",
        "orderNo": "R1000028-54",
        "ticketNos": "",
        "paymentAt": "2023-01-12T03:32:04",
        "userName": "이찬진",
        "orderLinePrice": "12000원",
        "purchaseQuantity": 3,
        "answers": [
          {
            "optionGroupType": "Y/N",
            "questionName": "뒷풀이 참석 여부 조사",
            "questionDescription": "오케이포차 조사입니다.",
            "answer": "네",
            "additionalPrice": "1000원"
          },
          {
            "optionGroupType": "Y/N",
            "questionName": "신한은행(110- )으로 3000원 입금 바랍니다.",
            "questionDescription": "계좌이체 확인후 티켓을 발급해드립니다 ( 승인 결제 )",
            "answer": "안갈꺼에요",
            "additionalPrice": "0원"
          }
        ]
      },
      {
        "ticketName": "계좌이체티켓",
        "orderNo": "R1000028-55",
        "ticketNos": "",
        "paymentAt": "2023-01-12T03:32:04",
        "userName": "이찬진",
        "orderLinePrice": "3000원",
        "purchaseQuantity": 1,
        "answers": [
          {
            "optionGroupType": "Y/N",
            "questionName": "뒷풀이 참석 여부 조사",
            "questionDescription": "오케이포차 조사입니다.",
            "answer": "아니오",
            "additionalPrice": "0원"
          },
          {
            "optionGroupType": "Y/N",
            "questionName": "신한은행(110- )으로 3000원 입금 바랍니다.",
            "questionDescription": "계좌이체 확인후 티켓을 발급해드립니다 ( 승인 결제 )",
            "answer": "갈게요 ㅋㅋ",
            "additionalPrice": "0원"
          }
        ]
      }
    ],
    "refundInfo": {
      "endAt": "2023-01-12T18:10:51",
      "availAble": true
    },
    "orderUuid": "e411b070-7e33-48b6-a3f7-d4fd4da9deb8",
    "orderId": 28
  },
  "timeStamp": "2023-01-12T03:34:30.60648"
}

```


## 변경로직
- 응답값에 Money 타입이 가능하도록 수정했습니다.
- 편하게 머니는 Money 타입으로 리턴하세요 알아서 toString으로 바꿔줍니다 ㅎㅎ
- 이외에도 이넘값들에 JsonValue 어노테이션 달아줘서 클라이언트 편하게 한글값 기준으로 내려주도록 해놨습니다.
