### PR TITLE
refactor(api) : 토큰 응답시 쿠키 설정 (#96)

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/model/dto/response/TokenAndUserResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/model/dto/response/TokenAndUserResponse.java
@@ -12,8 +12,12 @@ public class TokenAndUserResponse {
     @Schema(description = "어세스 토큰")
     private final String accessToken;
 
+    private final Long accessTokenAge;
+
     @Schema(description = "리프레쉬 토큰")
     private final String refreshToken;
+
+    private final Long refreshTokenAge;
 
     private final ProfileViewDto userProfile;
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/CookieGenerateHelper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/CookieGenerateHelper.java
@@ -1,0 +1,45 @@
+package band.gosrock.api.auth.service.helper;
+
+
+import band.gosrock.api.auth.model.dto.response.TokenAndUserResponse;
+import band.gosrock.common.annotation.Helper;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+@Helper
+@RequiredArgsConstructor
+public class CookieGenerateHelper {
+    private final Environment env;
+
+    public HttpHeaders getTokenCookies(TokenAndUserResponse tokenAndUserResponse) {
+        String[] activeProfiles = env.getActiveProfiles();
+        String sameSite = "None";
+
+        if (Arrays.stream(activeProfiles).toList().contains("prod")) {
+            sameSite = "Strict";
+        }
+        ResponseCookie accessToken =
+                ResponseCookie.from("accessToken", tokenAndUserResponse.getAccessToken())
+                        .path("/")
+                        .maxAge(tokenAndUserResponse.getAccessTokenAge())
+                        .sameSite(sameSite)
+                        .httpOnly(true)
+                        .secure(true)
+                        .build();
+        ResponseCookie refreshToken =
+                ResponseCookie.from("refreshToken", tokenAndUserResponse.getRefreshToken())
+                        .path("/")
+                        .maxAge(tokenAndUserResponse.getRefreshTokenAge())
+                        .sameSite(sameSite)
+                        .httpOnly(true)
+                        .secure(true)
+                        .build();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add(HttpHeaders.SET_COOKIE, accessToken.toString());
+        httpHeaders.add(HttpHeaders.SET_COOKIE, refreshToken.toString());
+        return httpHeaders;
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/TokenGenerateHelper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/auth/service/helper/TokenGenerateHelper.java
@@ -35,6 +35,8 @@ public class TokenGenerateHelper {
         return TokenAndUserResponse.builder()
                 .userProfile(ProfileViewDto.from(user))
                 .accessToken(newAccessToken)
+                .accessTokenAge(jwtTokenProvider.getAccessTokenTTlSecond())
+                .refreshTokenAge(jwtTokenProvider.getRefreshTokenTTlSecond())
                 .refreshToken(newRefreshToken)
                 .build();
     }

--- a/DuDoong-Common/src/main/java/band/gosrock/common/jwt/JwtTokenProvider.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/jwt/JwtTokenProvider.java
@@ -113,4 +113,8 @@ public class JwtTokenProvider {
     public Long getRefreshTokenTTlSecond() {
         return jwtProperties.getRefreshExp();
     }
+
+    public Long getAccessTokenTTlSecond() {
+        return jwtProperties.getAccessExp();
+    }
 }


### PR DESCRIPTION
## 개요
- close #96 

## 작업사항
- 프론트 next js 면...
- 쿠키를 설정해야 리덕스같이 상태관리 init 할때 쿠키같이보내서 상태설정할수 있다고 합니다.
- 원래 로컬스토릿지 이용했었는데 안된다구 하네요!

쿠기 두개 설정해놨습니다

## 변경로직
- 내용을 적어주세요.