### PR TITLE
feat : 스웨거 동적 예시값 생성 (#99)

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/config/ExampleHolder.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/config/ExampleHolder.java
@@ -1,0 +1,13 @@
+package band.gosrock.api.config;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ExampleHolder {
+    private Example holder;
+    private String name;
+    private int code;
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/config/ExampleHolder.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/config/ExampleHolder.java
@@ -1,5 +1,6 @@
 package band.gosrock.api.config;
 
+
 import io.swagger.v3.oas.models.examples.Example;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/config/SwaggerConfig.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/config/SwaggerConfig.java
@@ -1,6 +1,7 @@
 package band.gosrock.api.config;
 
 
+import band.gosrock.api.auth.model.dto.response.OauthLoginLinkResponse;
 import band.gosrock.common.annotation.DisableSwaggerSecurity;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.core.jackson.ModelResolver;
@@ -8,8 +9,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.In;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
@@ -78,9 +86,30 @@ public class SwaggerConfig {
             if (!tags.isEmpty()) {
                 operation.setTags(Collections.singletonList(tags.get(0)));
             }
+
+            generateErrorResponseExample(operation);
+
             return operation;
         };
     }
+
+    private void generateErrorResponseExample(Operation operation) {
+        ApiResponses responses = operation.getResponses();
+        Content content = new Content();
+        MediaType mediaType = new MediaType();
+        ApiResponse apiResponse = new ApiResponse();
+        OauthLoginLinkResponse oauthLoginLinkResponse = new OauthLoginLinkResponse("테스트");
+
+        new OauthLoginLinkResponse("테스트");
+        Example example = new Example();
+        example.setValue(oauthLoginLinkResponse);
+        mediaType.addExamples("example",example);
+
+        content.addMediaType("application/json",mediaType);
+        apiResponse.setContent(content);
+        responses.addApiResponse("400",apiResponse);
+    }
+
 
     private static List<String> getTags(HandlerMethod handlerMethod) {
         List<String> tags = new ArrayList<>();

--- a/DuDoong-Api/src/main/java/band/gosrock/api/config/SwaggerConfig.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/config/SwaggerConfig.java
@@ -4,6 +4,7 @@ package band.gosrock.api.config;
 import band.gosrock.api.auth.model.dto.response.OauthLoginLinkResponse;
 import band.gosrock.api.example.docs.ExampleExceptionDocs;
 import band.gosrock.common.annotation.DisableSwaggerSecurity;
+import band.gosrock.common.annotation.ExplainError;
 import band.gosrock.common.dto.ErrorReason;
 import band.gosrock.common.dto.ErrorResponse;
 import band.gosrock.common.exception.ErrorCode;
@@ -113,14 +114,28 @@ public class SwaggerConfig {
         ExampleExceptionDocs bean = applicationContext.getBean(ExampleExceptionDocs.class);
         ErrorReason errorReason = UserNotFoundException.EXCEPTION.getErrorCode().getErrorReason();
         ErrorResponse errorResponse = new ErrorResponse(errorReason, "요청시 패스정보입니다.");
-        Field[] declaredFields = bean.getClass().getDeclaredFields();
-        Example example = new Example();
-        example.setValue(errorResponse);
-        mediaType.addExamples(UserNotFoundException.class.getSimpleName(),example);
+
+        for (Field field: bean.getClass().getDeclaredFields()) {
+            ExplainError explainError = field.getAnnotation(ExplainError.class);
+            if(explainError != null){
+                Example example = new Example();
+                example.description(explainError.value());
+                example.setValue(errorResponse);
+                mediaType.addExamples(UserNotFoundException.class.getSimpleName(),example);
+
+                Example example2 = new Example();
+                example2.description(explainError.value());
+                example2.setValue(errorResponse);
+                mediaType.addExamples("다른 에러",example);
+            }
+        }
+
 
         // -------------------------- 콘텐츠 세팅
         content.addMediaType("application/json",mediaType);
         apiResponse.setContent(content);
+
+
         responses.addApiResponse("400",apiResponse);
     }
 

--- a/DuDoong-Api/src/main/java/band/gosrock/api/config/SwaggerConfig.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/config/SwaggerConfig.java
@@ -1,13 +1,15 @@
 package band.gosrock.api.config;
 
 
-import band.gosrock.api.auth.model.dto.response.OauthLoginLinkResponse;
+import static java.util.stream.Collectors.groupingBy;
+
 import band.gosrock.api.example.docs.ExampleExceptionDocs;
 import band.gosrock.common.annotation.DisableSwaggerSecurity;
 import band.gosrock.common.annotation.ExplainError;
 import band.gosrock.common.dto.ErrorReason;
 import band.gosrock.common.dto.ErrorResponse;
-import band.gosrock.common.exception.ErrorCode;
+import band.gosrock.common.exception.DuDoongCodeException;
+import band.gosrock.domain.domains.order.exception.OrderNotFoundException;
 import band.gosrock.domain.domains.user.exception.UserNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.core.jackson.ModelResolver;
@@ -18,10 +20,8 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
-import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
-import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityScheme;
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 import javax.servlet.ServletContext;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.customizers.OperationCustomizer;
-import org.springframework.boot.SpringApplication;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -104,39 +103,46 @@ public class SwaggerConfig {
         };
     }
 
+
     private void generateErrorResponseExample(Operation operation) {
         ApiResponses responses = operation.getResponses();
-        Content content = new Content();
-        MediaType mediaType = new MediaType();
-        ApiResponse apiResponse = new ApiResponse();
+
         //----------------생성
 
         ExampleExceptionDocs bean = applicationContext.getBean(ExampleExceptionDocs.class);
-        ErrorReason errorReason = UserNotFoundException.EXCEPTION.getErrorCode().getErrorReason();
-        ErrorResponse errorResponse = new ErrorResponse(errorReason, "요청시 패스정보입니다.");
+        Field[] declaredFields = bean.getClass().getDeclaredFields();
+        Map<Integer, List<ExampleHolder>> stringListMap = Arrays.stream(declaredFields)
+            .filter(field -> field.getAnnotation(ExplainError.class) != null)
+            .filter(field -> field.getType() == DuDoongCodeException.class)
+            .map(field -> {
+                try {
+                    DuDoongCodeException exception = (DuDoongCodeException) field.get(
+                        bean);
+                    ExplainError annotation = field.getAnnotation(ExplainError.class);
+                    String value = annotation.value();
+                    ErrorReason errorReason = exception.getErrorCode().getErrorReason();
+                    ErrorResponse errorResponse = new ErrorResponse(errorReason, "요청시 패스정보입니다.");
+                    Example example = new Example();
+                    example.description(value);
+                    example.setValue(errorResponse);
+                    return new ExampleHolder(example, field.getName(), errorReason.getStatus());
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            }).collect(groupingBy(ExampleHolder::getCode));
 
-        for (Field field: bean.getClass().getDeclaredFields()) {
-            ExplainError explainError = field.getAnnotation(ExplainError.class);
-            if(explainError != null){
-                Example example = new Example();
-                example.description(explainError.value());
-                example.setValue(errorResponse);
-                mediaType.addExamples(UserNotFoundException.class.getSimpleName(),example);
-
-                Example example2 = new Example();
-                example2.description(explainError.value());
-                example2.setValue(errorResponse);
-                mediaType.addExamples("다른 에러",example);
-            }
-        }
-
-
-        // -------------------------- 콘텐츠 세팅
-        content.addMediaType("application/json",mediaType);
-        apiResponse.setContent(content);
-
-
-        responses.addApiResponse("400",apiResponse);
+        // -------------------------- 콘텐츠 세팅 코드별로 진행
+        stringListMap.forEach((status,v)->{
+            Content content = new Content();
+            MediaType mediaType = new MediaType();
+            ApiResponse apiResponse = new ApiResponse();
+            v.forEach(exampleHolder ->{
+                mediaType.addExamples(exampleHolder.getName(),exampleHolder.getHolder());
+            });
+            content.addMediaType("application/json",mediaType);
+            apiResponse.setContent(content);
+            responses.addApiResponse(status.toString(),apiResponse);
+        });
     }
 
 

--- a/DuDoong-Api/src/main/java/band/gosrock/api/example/controller/ExampleController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/example/controller/ExampleController.java
@@ -1,8 +1,11 @@
 package band.gosrock.api.example.controller;
 
 
+import band.gosrock.api.example.docs.ExampleException2Docs;
+import band.gosrock.api.example.docs.ExampleExceptionDocs;
 import band.gosrock.api.example.dto.ExampleResponse;
 import band.gosrock.api.example.service.ExampleApiService;
+import band.gosrock.common.annotation.ApiErrorExample;
 import band.gosrock.common.annotation.DevelopOnlyApi;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
@@ -21,11 +24,13 @@ public class ExampleController {
 
     @GetMapping
     @DevelopOnlyApi
+    @ApiErrorExample(ExampleExceptionDocs.class)
     public ExampleResponse get() {
         return exampleApiService.getExample();
     }
 
     @PostMapping
+    @ApiErrorExample(ExampleException2Docs.class)
     public ExampleResponse create() {
         return exampleApiService.createExample();
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/example/docs/ExampleException2Docs.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/example/docs/ExampleException2Docs.java
@@ -3,16 +3,16 @@ package band.gosrock.api.example.docs;
 import band.gosrock.common.annotation.ExceptionDoc;
 import band.gosrock.common.annotation.ExplainError;
 import band.gosrock.common.exception.DuDoongCodeException;
+import band.gosrock.common.exception.InvalidTokenException;
 import band.gosrock.domain.domains.order.exception.InvalidOrderException;
 import band.gosrock.domain.domains.order.exception.OrderNotFoundException;
 import band.gosrock.domain.domains.user.exception.UserNotFoundException;
-import org.springframework.stereotype.Component;
 
 @ExceptionDoc
-public class ExampleExceptionDocs {
+public class ExampleException2Docs {
 
-    @ExplainError("유저검색시에 안나올 때 나오는 에러입니다.")
-    public DuDoongCodeException 유저없을때 = UserNotFoundException.EXCEPTION;
+    @ExplainError("어쩌구 저쩌구")
+    public DuDoongCodeException 유저없을때 = InvalidTokenException.EXCEPTION;
 
     @ExplainError("오더 낫파운드")
     public DuDoongCodeException 한글도된다 = OrderNotFoundException.EXCEPTION;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/example/docs/ExampleException2Docs.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/example/docs/ExampleException2Docs.java
@@ -1,12 +1,12 @@
 package band.gosrock.api.example.docs;
 
+
 import band.gosrock.common.annotation.ExceptionDoc;
 import band.gosrock.common.annotation.ExplainError;
 import band.gosrock.common.exception.DuDoongCodeException;
 import band.gosrock.common.exception.InvalidTokenException;
 import band.gosrock.domain.domains.order.exception.InvalidOrderException;
 import band.gosrock.domain.domains.order.exception.OrderNotFoundException;
-import band.gosrock.domain.domains.user.exception.UserNotFoundException;
 
 @ExceptionDoc
 public class ExampleException2Docs {

--- a/DuDoong-Api/src/main/java/band/gosrock/api/example/docs/ExampleExceptionDocs.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/example/docs/ExampleExceptionDocs.java
@@ -2,6 +2,8 @@ package band.gosrock.api.example.docs;
 
 import band.gosrock.common.annotation.ExplainError;
 import band.gosrock.common.exception.DuDoongCodeException;
+import band.gosrock.domain.domains.order.exception.InvalidOrderException;
+import band.gosrock.domain.domains.order.exception.OrderNotFoundException;
 import band.gosrock.domain.domains.user.exception.UserNotFoundException;
 import org.springframework.stereotype.Component;
 
@@ -9,5 +11,11 @@ import org.springframework.stereotype.Component;
 public class ExampleExceptionDocs {
 
     @ExplainError("유저검색시에 안나올 때 나오는 에러입니다.")
-    private final DuDoongCodeException userNotFoundException = UserNotFoundException.EXCEPTION;
+    public DuDoongCodeException 유저없을때 = UserNotFoundException.EXCEPTION;
+
+    @ExplainError("오더 낫파운드")
+    public DuDoongCodeException 한글도된다 = OrderNotFoundException.EXCEPTION;
+
+    @ExplainError("인밸리드 오더")
+    public DuDoongCodeException 오류가났을때 = InvalidOrderException.EXCEPTION;
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/example/docs/ExampleExceptionDocs.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/example/docs/ExampleExceptionDocs.java
@@ -1,12 +1,12 @@
 package band.gosrock.api.example.docs;
 
+
 import band.gosrock.common.annotation.ExceptionDoc;
 import band.gosrock.common.annotation.ExplainError;
 import band.gosrock.common.exception.DuDoongCodeException;
 import band.gosrock.domain.domains.order.exception.InvalidOrderException;
 import band.gosrock.domain.domains.order.exception.OrderNotFoundException;
 import band.gosrock.domain.domains.user.exception.UserNotFoundException;
-import org.springframework.stereotype.Component;
 
 @ExceptionDoc
 public class ExampleExceptionDocs {

--- a/DuDoong-Api/src/main/java/band/gosrock/api/example/docs/ExampleExceptionDocs.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/example/docs/ExampleExceptionDocs.java
@@ -1,0 +1,13 @@
+package band.gosrock.api.example.docs;
+
+import band.gosrock.common.annotation.ExplainError;
+import band.gosrock.common.exception.DuDoongCodeException;
+import band.gosrock.domain.domains.user.exception.UserNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExampleExceptionDocs {
+
+    @ExplainError("유저검색시에 안나올 때 나오는 에러입니다.")
+    private final DuDoongCodeException userNotFoundException = UserNotFoundException.EXCEPTION;
+}

--- a/DuDoong-Common/src/main/java/band/gosrock/common/annotation/ApiErrorExample.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/annotation/ApiErrorExample.java
@@ -5,10 +5,9 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.concurrent.TimeUnit;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiErrorExample {
-    Class<?> value() ;
+    Class<?> value();
 }

--- a/DuDoong-Common/src/main/java/band/gosrock/common/annotation/ApiErrorExample.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/annotation/ApiErrorExample.java
@@ -1,0 +1,14 @@
+package band.gosrock.common.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorExample {
+    Class<?> value() ;
+}

--- a/DuDoong-Common/src/main/java/band/gosrock/common/annotation/ExceptionDoc.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/annotation/ExceptionDoc.java
@@ -1,0 +1,19 @@
+package band.gosrock.common.annotation;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface ExceptionDoc {
+    @AliasFor(annotation = Component.class)
+    String value() default "";
+}

--- a/DuDoong-Common/src/main/java/band/gosrock/common/annotation/ExplainError.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/annotation/ExplainError.java
@@ -1,0 +1,18 @@
+package band.gosrock.common.annotation;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface ExplainError {
+    String value() default "";
+}

--- a/DuDoong-Common/src/main/java/band/gosrock/common/annotation/ExplainError.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/annotation/ExplainError.java
@@ -6,7 +6,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;
 
 @Target({ElementType.FIELD})


### PR DESCRIPTION
## 개요
- close #99 
![무제](https://user-images.githubusercontent.com/13329304/212046083-2615dd56-0855-4a63-9d19-c08e766d807c.jpg)

요런걸 없앴슴니다
## 작업사항
- 동적으로 스웨거 응답값 생성 하도록 지정했습니다.
- 원래 예시값 적을때 json 형식으로 말도안되게 귀찮게 하는데 그런걸 없앴씁니다
![무제](https://user-images.githubusercontent.com/13329304/212044749-d3e649d6-8fcd-4b8b-a3c4-d9a1edfb4698.jpg)

 - api 하나마다 ( 적어주고싶은 중요한 에러가 있을시 )
```java
@ExceptionDoc
public class ExampleExceptionDocs {

    @ExplainError("유저검색시에 안나올 때 나오는 에러입니다.")
    public DuDoongCodeException 유저없을때 = UserNotFoundException.EXCEPTION;

    @ExplainError("오더 낫파운드")
    public DuDoongCodeException 한글도된다 = OrderNotFoundException.EXCEPTION;

    @ExplainError("인밸리드 오더")
    public DuDoongCodeException 오류가났을때 = InvalidOrderException.EXCEPTION;
}
```

```java
@GetMapping
    @DevelopOnlyApi
    @ApiErrorExample(ExampleExceptionDocs.class)
    public ExampleResponse get() {
        return exampleApiService.getExample();
    }
```

위와같은방법으로 ApiErrorExample 에 타입정도 넘기시면 자동으로 예시값 생성됩니다.
ExplainError 어노테이션으로 추가부가설명을 적을 수있습니다.
어떠어떠할때 오류가 생성된다~ 그런식으로 기술하면됩니다~


## 변경로직
- 내용을 적어주세요.