### PR TITLE
refactor(api) : 발급 티켓 API 관련 리팩토링

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/controller/AdminIssuedTicketController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/controller/AdminIssuedTicketController.java
@@ -26,7 +26,8 @@ public class AdminIssuedTicketController {
     public RetrieveIssuedTicketListResponse getIssuedTickets(
             @RequestParam Long page,
             @RequestParam Long eventId,
-            @RequestParam(required = false) String userName) {
-        return readIssuedTicketsUseCase.execute(page, eventId, userName);
+            @RequestParam(required = false) String userName,
+            @RequestParam(required = false) String phoneNumber) {
+        return readIssuedTicketsUseCase.execute(page, eventId, userName, phoneNumber);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/dto/response/RetrieveIssuedTicketDTO.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/dto/response/RetrieveIssuedTicketDTO.java
@@ -15,7 +15,7 @@ public class RetrieveIssuedTicketDTO {
     private final UserInfoVo userInfo;
 
     public RetrieveIssuedTicketDTO(IssuedTicket issuedTicket, User user) {
-        this.issuedTicketInfo = new IssuedTicketInfoVo(issuedTicket);
-        this.userInfo = new UserInfoVo(user);
+        this.issuedTicketInfo = issuedTicket.toIssuedTicketInfoVo(issuedTicket);
+        this.userInfo = user.toUserInfoVo(user);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/service/ReadIssuedTicketsUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/service/ReadIssuedTicketsUseCase.java
@@ -26,12 +26,14 @@ public class ReadIssuedTicketsUseCase {
      * 로직이 너무 복잡해짐 => 일단 연관관계 매핑 걸어두고 나중에 QueryDsl 설정 들어오면 바꿔야 할 듯
      */
     @Transactional(readOnly = true)
-    public RetrieveIssuedTicketListResponse execute(Long page, Long eventId, String userName) {
+    public RetrieveIssuedTicketListResponse execute(
+            Long page, Long eventId, String userName, String phoneNumber) {
         Long currentUserId = SecurityUtils.getCurrentUserId();
         // 조회 유저 권한 인증
         eventService.checkEventHost(currentUserId, eventId);
         Page<IssuedTicket> issuedTickets =
-                issuedTicketDomainService.retrieveIssuedTickets(page, eventId, userName);
+                issuedTicketDomainService.retrieveIssuedTickets(
+                        page, eventId, userName, phoneNumber);
         return new RetrieveIssuedTicketListResponse(
                 page,
                 (long) issuedTickets.getTotalPages(),

--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
@@ -49,7 +49,7 @@ public enum ErrorCode implements BaseErrorCode {
     ISSUED_TICKET_NOT_MATCHED_USER(
             FORBIDDEN, "IssuedTicket-403-1", "IssuedTicket User Not Matched"),
     EVENT_NOT_FOUND(NOT_FOUND, "Event-404-1", "Event Not Found"),
-    Host_NOT_AUTH_EVENT(FORBIDDEN, "Event-403-1", "Host Not Auth Event");
+    HOST_NOT_AUTH_EVENT(FORBIDDEN, "Event-403-1", "Host Not Auth Event");
     private int status;
     private String code;
     private String reason;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/IssuedTicketInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/IssuedTicketInfoVo.java
@@ -5,9 +5,11 @@ import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class IssuedTicketInfoVo {
 
     /*
@@ -54,14 +56,4 @@ public class IssuedTicketInfoVo {
      */
     private final Money optionPrice;
 
-    public IssuedTicketInfoVo(IssuedTicket issuedTicket) {
-        this.issuedTicketId = issuedTicket.getId();
-        this.issuedTicketNo = issuedTicket.getIssuedTicketNo();
-        this.uuid = issuedTicket.getUuid();
-        this.ticketName = issuedTicket.getTicketItem().getName();
-        this.ticketPrice = issuedTicket.getTicketItem().getPrice();
-        this.createdAt = issuedTicket.getCreatedAt();
-        this.issuedTicketStatus = issuedTicket.getIssuedTicketStatus();
-        this.optionPrice = issuedTicket.sumOptionPrice();
-    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/IssuedTicketInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/IssuedTicketInfoVo.java
@@ -1,6 +1,7 @@
 package band.gosrock.domain.common.vo;
 
 
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
@@ -54,4 +55,17 @@ public class IssuedTicketInfoVo {
     발급 티켓 옵션 금액 합계
      */
     private final Money optionPrice;
+
+    public static IssuedTicketInfoVo from(IssuedTicket issuedTicket) {
+        return IssuedTicketInfoVo.builder()
+                .issuedTicketId(issuedTicket.getId())
+                .issuedTicketNo(issuedTicket.getIssuedTicketNo())
+                .uuid(issuedTicket.getUuid())
+                .ticketName(issuedTicket.getTicketItem().getName())
+                .ticketPrice(issuedTicket.getPrice())
+                .createdAt(issuedTicket.getCreatedAt())
+                .issuedTicketStatus(issuedTicket.getIssuedTicketStatus())
+                .optionPrice(issuedTicket.sumOptionPrice())
+                .build();
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/IssuedTicketInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/IssuedTicketInfoVo.java
@@ -1,7 +1,6 @@
 package band.gosrock.domain.common.vo;
 
 
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
@@ -55,5 +54,4 @@ public class IssuedTicketInfoVo {
     발급 티켓 옵션 금액 합계
      */
     private final Money optionPrice;
-
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserInfoVo.java
@@ -1,8 +1,6 @@
 package band.gosrock.domain.common.vo;
 
 
-import band.gosrock.domain.domains.user.domain.User;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,5 +17,4 @@ public class UserInfoVo {
     private final String phoneNumber;
 
     private final String profileImage;
-
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserInfoVo.java
@@ -1,6 +1,7 @@
 package band.gosrock.domain.common.vo;
 
 
+import band.gosrock.domain.domains.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,4 +18,14 @@ public class UserInfoVo {
     private final String phoneNumber;
 
     private final String profileImage;
+
+    public static UserInfoVo from(User user) {
+        return UserInfoVo.builder()
+                .userId(user.getId())
+                .userName(user.getProfile().getName())
+                .email(user.getProfile().getEmail())
+                .profileImage(user.getProfile().getProfileImage())
+                .phoneNumber(user.getProfile().getPhoneNumber())
+                .build();
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserInfoVo.java
@@ -2,9 +2,12 @@ package band.gosrock.domain.common.vo;
 
 
 import band.gosrock.domain.domains.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class UserInfoVo {
 
     private final Long userId;
@@ -15,10 +18,6 @@ public class UserInfoVo {
 
     private final String phoneNumber;
 
-    public UserInfoVo(User user) {
-        this.userId = user.getId();
-        this.userName = user.getProfile().getName();
-        this.email = user.getProfile().getEmail();
-        this.phoneNumber = user.getProfile().getPhoneNumber();
-    }
+    private final String profileImage;
+
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/Event.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/Event.java
@@ -2,7 +2,6 @@ package band.gosrock.domain.domains.event.domain;
 
 
 import band.gosrock.domain.common.model.BaseTimeEntity;
-import band.gosrock.domain.common.vo.EventInfoVo;
 import band.gosrock.domain.common.vo.RefundInfoVo;
 import java.time.LocalDateTime;
 import javax.persistence.*;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/Event.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/Event.java
@@ -2,6 +2,7 @@ package band.gosrock.domain.domains.event.domain;
 
 
 import band.gosrock.domain.common.model.BaseTimeEntity;
+import band.gosrock.domain.common.vo.EventInfoVo;
 import band.gosrock.domain.common.vo.RefundInfoVo;
 import java.time.LocalDateTime;
 import javax.persistence.*;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/HostNotAuthEventException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/HostNotAuthEventException.java
@@ -9,6 +9,6 @@ public class HostNotAuthEventException extends DuDoongCodeException {
     public static final DuDoongCodeException EXCEPTION = new HostNotAuthEventException();
 
     private HostNotAuthEventException() {
-        super(ErrorCode.Host_NOT_AUTH_EVENT);
+        super(ErrorCode.HOST_NOT_AUTH_EVENT);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/service/EventService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/service/EventService.java
@@ -19,7 +19,7 @@ public class EventService {
 
     public void checkEventHost(Long hostId, Long eventId) {
         Event event = eventAdaptor.findById(eventId);
-        if (!Objects.equals(event.getHostId(), hostId)) {
+        if (!event.getHostId().equals(hostId)) {
             throw HostNotAuthEventException.EXCEPTION;
         }
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/service/EventService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/service/EventService.java
@@ -6,7 +6,6 @@ import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.event.exception.HostNotAuthEventException;
 import band.gosrock.domain.domains.event.repository.EventRepository;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptor.java
@@ -20,6 +20,10 @@ public class IssuedTicketAdaptor {
         return issuedTicketRepository.save(issuedTicket);
     }
 
+    public void saveAll(List<IssuedTicket> issuedTickets) {
+        issuedTicketRepository.saveAll(issuedTickets);
+    }
+
     public List<IssuedTicket> findAllByOrderLineId(Long orderLineId) {
         return issuedTicketRepository.findAllByOrderLineId(orderLineId);
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptor.java
@@ -43,4 +43,10 @@ public class IssuedTicketAdaptor {
         return issuedTicketRepository.findAllByEvent_IdAndUser_Profile_NameContaining(
                 eventId, userName, pageRequest);
     }
+
+    public Page<IssuedTicket> findAllByEventAndUserPhoneNumber(
+            PageRequest pageRequest, Long eventId, String phoneNumber) {
+        return issuedTicketRepository.findAllByEvent_IdAndUser_Profile_PhoneNumberContaining(
+                eventId, phoneNumber, pageRequest);
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
@@ -155,32 +155,38 @@ public class IssuedTicket extends BaseTimeEntity {
     }
 
     public IssuedTicketInfoVo toIssuedTicketInfoVo(IssuedTicket issuedTicket) {
-        return IssuedTicketInfoVo.builder().issuedTicketId(issuedTicket.getId())
-            .issuedTicketNo(issuedTicket.getIssuedTicketNo()).uuid(issuedTicket.getUuid())
-            .ticketName(issuedTicket.getTicketItem().getName()).ticketPrice(issuedTicket.getPrice())
-            .createdAt(issuedTicket.getCreatedAt())
-            .issuedTicketStatus(issuedTicket.getIssuedTicketStatus())
-            .optionPrice(issuedTicket.sumOptionPrice()).build();
+        return IssuedTicketInfoVo.builder()
+                .issuedTicketId(issuedTicket.getId())
+                .issuedTicketNo(issuedTicket.getIssuedTicketNo())
+                .uuid(issuedTicket.getUuid())
+                .ticketName(issuedTicket.getTicketItem().getName())
+                .ticketPrice(issuedTicket.getPrice())
+                .createdAt(issuedTicket.getCreatedAt())
+                .issuedTicketStatus(issuedTicket.getIssuedTicketStatus())
+                .optionPrice(issuedTicket.sumOptionPrice())
+                .build();
     }
 
-    public static CreateIssuedTicketResponse orderLineItemToIssuedTickets(CreateIssuedTicketDTO dto) {
+    public static CreateIssuedTicketResponse orderLineItemToIssuedTickets(
+            CreateIssuedTicketDTO dto) {
         long quantity = dto.getOrderLineItem().getQuantity();
         List<IssuedTicket> createIssuedTickets = new ArrayList<>();
-        List<IssuedTicketOptionAnswer> issuedTicketOptionAnswers = dto.getOrderLineItem()
-            .getOrderOptionAnswer().stream().map(
-                IssuedTicketOptionAnswer::orderOptionAnswerToIssuedTicketOptionAnswer).toList();
-        for (long i = 1 ; i<=quantity; i++) {
+        List<IssuedTicketOptionAnswer> issuedTicketOptionAnswers =
+                dto.getOrderLineItem().getOrderOptionAnswer().stream()
+                        .map(IssuedTicketOptionAnswer::orderOptionAnswerToIssuedTicketOptionAnswer)
+                        .toList();
+        for (long i = 1; i <= quantity; i++) {
             createIssuedTickets.add(
-                IssuedTicket.builder().event(dto.getOrderLineItem().getTicketItem().getEvent())
-                    .orderLineId(dto.getOrderLineItem()
-                        .getId()).user(dto.getUser())
-                    .price(dto.getOrderLineItem().getTicketItem().getPrice())
-                    .ticketItem(dto.getOrderLineItem()
-                        .getTicketItem()).issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
-                    .issuedTicketOptionAnswers(issuedTicketOptionAnswers)
-                    .build());
+                    IssuedTicket.builder()
+                            .event(dto.getOrderLineItem().getTicketItem().getEvent())
+                            .orderLineId(dto.getOrderLineItem().getId())
+                            .user(dto.getUser())
+                            .price(dto.getOrderLineItem().getTicketItem().getPrice())
+                            .ticketItem(dto.getOrderLineItem().getTicketItem())
+                            .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
+                            .issuedTicketOptionAnswers(issuedTicketOptionAnswers)
+                            .build());
         }
         return new CreateIssuedTicketResponse(createIssuedTickets, issuedTicketOptionAnswers);
     }
-
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
@@ -5,7 +5,9 @@ import band.gosrock.domain.common.model.BaseTimeEntity;
 import band.gosrock.domain.common.vo.IssuedTicketInfoVo;
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.event.domain.Event;
+import band.gosrock.domain.domains.issuedTicket.dto.request.CreateIssuedTicketDTO;
 import band.gosrock.domain.domains.issuedTicket.dto.request.CreateIssuedTicketRequest;
+import band.gosrock.domain.domains.issuedTicket.dto.response.CreateIssuedTicketResponse;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
 import band.gosrock.domain.domains.user.domain.User;
 import java.util.ArrayList;
@@ -159,6 +161,26 @@ public class IssuedTicket extends BaseTimeEntity {
             .createdAt(issuedTicket.getCreatedAt())
             .issuedTicketStatus(issuedTicket.getIssuedTicketStatus())
             .optionPrice(issuedTicket.sumOptionPrice()).build();
+    }
+
+    public static CreateIssuedTicketResponse orderLineItemToIssuedTickets(CreateIssuedTicketDTO dto) {
+        long quantity = dto.getOrderLineItem().getQuantity();
+        List<IssuedTicket> createIssuedTickets = new ArrayList<>();
+        List<IssuedTicketOptionAnswer> issuedTicketOptionAnswers = dto.getOrderLineItem()
+            .getOrderOptionAnswer().stream().map(
+                IssuedTicketOptionAnswer::orderOptionAnswerToIssuedTicketOptionAnswer).toList();
+        for (long i = 1 ; i<=quantity; i++) {
+            createIssuedTickets.add(
+                IssuedTicket.builder().event(dto.getOrderLineItem().getTicketItem().getEvent())
+                    .orderLineId(dto.getOrderLineItem()
+                        .getId()).user(dto.getUser())
+                    .price(dto.getOrderLineItem().getTicketItem().getPrice())
+                    .ticketItem(dto.getOrderLineItem()
+                        .getTicketItem()).issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
+                    .issuedTicketOptionAnswers(issuedTicketOptionAnswers)
+                    .build());
+        }
+        return new CreateIssuedTicketResponse(createIssuedTickets, issuedTicketOptionAnswers);
     }
 
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
@@ -155,16 +155,7 @@ public class IssuedTicket extends BaseTimeEntity {
     }
 
     public IssuedTicketInfoVo toIssuedTicketInfoVo(IssuedTicket issuedTicket) {
-        return IssuedTicketInfoVo.builder()
-                .issuedTicketId(issuedTicket.getId())
-                .issuedTicketNo(issuedTicket.getIssuedTicketNo())
-                .uuid(issuedTicket.getUuid())
-                .ticketName(issuedTicket.getTicketItem().getName())
-                .ticketPrice(issuedTicket.getPrice())
-                .createdAt(issuedTicket.getCreatedAt())
-                .issuedTicketStatus(issuedTicket.getIssuedTicketStatus())
-                .optionPrice(issuedTicket.sumOptionPrice())
-                .build();
+        return IssuedTicketInfoVo.from(issuedTicket);
     }
 
     public static CreateIssuedTicketResponse orderLineItemToIssuedTickets(

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
@@ -2,6 +2,7 @@ package band.gosrock.domain.domains.issuedTicket.domain;
 
 
 import band.gosrock.domain.common.model.BaseTimeEntity;
+import band.gosrock.domain.common.vo.IssuedTicketInfoVo;
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.issuedTicket.dto.request.CreateIssuedTicketRequest;
@@ -87,7 +88,7 @@ public class IssuedTicket extends BaseTimeEntity {
     /*
     발급 티켓 가격
      */
-    private Long price;
+    private Money price;
 
     /*
     상태
@@ -105,7 +106,7 @@ public class IssuedTicket extends BaseTimeEntity {
             User user,
             Long orderLineId,
             TicketItem ticketItem,
-            Long price,
+            Money price,
             IssuedTicketStatus issuedTicketStatus,
             List<IssuedTicketOptionAnswer> issuedTicketOptionAnswers) {
         this.event = event;
@@ -139,7 +140,6 @@ public class IssuedTicket extends BaseTimeEntity {
         this.issuedTicketNo = "T" + this.id;
     }
 
-    // todo: 옵션 정리
     public Money sumOptionPrice() {
         //        issuedTicketOptionAnswers.forEach(issuedTicketOptionAnswer -> {
         //            this.optionPrice = this.optionPrice.plus(issuedTicketOptionAnswer.getOption()
@@ -151,4 +151,14 @@ public class IssuedTicket extends BaseTimeEntity {
                                 issuedTicketOptionAnswer.getOption().getAdditionalPrice())
                 .reduce(Money.ZERO, Money::plus);
     }
+
+    public IssuedTicketInfoVo toIssuedTicketInfoVo(IssuedTicket issuedTicket) {
+        return IssuedTicketInfoVo.builder().issuedTicketId(issuedTicket.getId())
+            .issuedTicketNo(issuedTicket.getIssuedTicketNo()).uuid(issuedTicket.getUuid())
+            .ticketName(issuedTicket.getTicketItem().getName()).ticketPrice(issuedTicket.getPrice())
+            .createdAt(issuedTicket.getCreatedAt())
+            .issuedTicketStatus(issuedTicket.getIssuedTicketStatus())
+            .optionPrice(issuedTicket.sumOptionPrice()).build();
+    }
+
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/request/CreateIssuedTicketDTO.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/request/CreateIssuedTicketDTO.java
@@ -1,0 +1,18 @@
+package band.gosrock.domain.domains.issuedTicket.dto.request;
+
+import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.domain.domains.order.domain.OrderLineItem;
+import band.gosrock.domain.domains.user.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateIssuedTicketDTO {
+
+    private final Order order;
+
+    private final OrderLineItem orderLineItem;
+
+    private final User user;
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/request/CreateIssuedTicketDTO.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/request/CreateIssuedTicketDTO.java
@@ -1,5 +1,6 @@
 package band.gosrock.domain.domains.issuedTicket.dto.request;
 
+
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderLineItem;
 import band.gosrock.domain.domains.user.domain.User;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/request/CreateIssuedTicketRequest.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/request/CreateIssuedTicketRequest.java
@@ -1,6 +1,7 @@
 package band.gosrock.domain.domains.issuedTicket.dto.request;
 
 
+import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.order.domain.OrderOptionAnswer;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
@@ -31,7 +32,7 @@ public class CreateIssuedTicketRequest {
     /*
     발급 티켓 가격
      */
-    private final Long price;
+    private final Money price;
 
     /*
     발급 티켓의 티켓 itemId (발급 티켓의 종류)

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/request/CreateIssuedTicketRequest.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/request/CreateIssuedTicketRequest.java
@@ -22,7 +22,7 @@ public class CreateIssuedTicketRequest {
     /*
     발급 티켓의 orderline id
      */
-    private Long orderLineId;
+    private final Long orderLineId;
 
     /*
     티켓 발급한 유저 id

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/response/CreateIssuedTicketResponse.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/response/CreateIssuedTicketResponse.java
@@ -13,8 +13,9 @@ public class CreateIssuedTicketResponse {
 
     private final List<IssuedTicketOptionAnswer> issuedTicketOptionAnswers;
 
-    public CreateIssuedTicketResponse(List<IssuedTicket> issuedTickets,
-        List<IssuedTicketOptionAnswer> issuedTicketOptionAnswers) {
+    public CreateIssuedTicketResponse(
+            List<IssuedTicket> issuedTickets,
+            List<IssuedTicketOptionAnswer> issuedTicketOptionAnswers) {
         this.issuedTickets = issuedTickets;
         this.issuedTicketOptionAnswers = issuedTicketOptionAnswers;
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/response/CreateIssuedTicketResponse.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/response/CreateIssuedTicketResponse.java
@@ -1,15 +1,21 @@
 package band.gosrock.domain.domains.issuedTicket.dto.response;
 
 
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketOptionAnswer;
 import java.util.List;
 import lombok.Getter;
 
 @Getter
 public class CreateIssuedTicketResponse {
 
-    private final List<IssuedTicketDTO> issuedTickets;
+    private final List<IssuedTicket> issuedTickets;
 
-    public CreateIssuedTicketResponse(List<IssuedTicketDTO> issuedTickets) {
+    private final List<IssuedTicketOptionAnswer> issuedTicketOptionAnswers;
+
+    public CreateIssuedTicketResponse(List<IssuedTicket> issuedTickets,
+        List<IssuedTicketOptionAnswer> issuedTicketOptionAnswers) {
         this.issuedTickets = issuedTickets;
+        this.issuedTicketOptionAnswers = issuedTicketOptionAnswers;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/response/IssuedTicketDTO.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/dto/response/IssuedTicketDTO.java
@@ -14,7 +14,7 @@ public class IssuedTicketDTO {
     private final EventInfoVo eventInfo;
 
     public IssuedTicketDTO(IssuedTicket issuedTicket) {
-        this.issuedTicketInfo = new IssuedTicketInfoVo(issuedTicket);
+        this.issuedTicketInfo = issuedTicket.toIssuedTicketInfoVo(issuedTicket);
         this.eventInfo = new EventInfoVo(issuedTicket.getEvent());
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/repository/IssuedTicketRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/repository/IssuedTicketRepository.java
@@ -16,4 +16,7 @@ public interface IssuedTicketRepository
 
     Page<IssuedTicket> findAllByEvent_IdAndUser_Profile_NameContaining(
             Long eventId, String userName, Pageable pageable);
+
+    Page<IssuedTicket> findAllByEvent_IdAndUser_Profile_PhoneNumberContaining(
+            Long eventId, String phoneNumber, Pageable pageable);
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -6,6 +6,7 @@ import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
 import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketOptionAnswerAdaptor;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketOptionAnswer;
+import band.gosrock.domain.domains.issuedTicket.dto.request.CreateIssuedTicketDTO;
 import band.gosrock.domain.domains.issuedTicket.dto.request.CreateIssuedTicketRequestDTOs;
 import band.gosrock.domain.domains.issuedTicket.dto.response.CreateIssuedTicketResponse;
 import band.gosrock.domain.domains.issuedTicket.dto.response.IssuedTicketDTO;
@@ -29,7 +30,7 @@ public class IssuedTicketDomainService {
     private final IssuedTicketOptionAnswerAdaptor issuedTicketOptionAnswerAdaptor;
 
     @Transactional
-    public CreateIssuedTicketResponse createIssuedTicket(
+    public void createIssuedTicket(
             CreateIssuedTicketRequestDTOs createIssuedTicketRequestDTOs) {
         List<IssuedTicketDTO> issuedTickets =
                 createIssuedTicketRequestDTOs.getCreateIssuedTicketRequests().stream()
@@ -57,7 +58,17 @@ public class IssuedTicketDomainService {
                                     return new IssuedTicketDTO(saveIssuedTicket);
                                 })
                         .toList();
-        return new CreateIssuedTicketResponse(issuedTickets);
+//        return new CreateIssuedTicketResponse(issuedTickets);
+    }
+
+    @Transactional
+    public void createIssuedTicket2(List<CreateIssuedTicketDTO> createIssuedTicketDTOs) {
+        createIssuedTicketDTOs.forEach(dto -> {
+            CreateIssuedTicketResponse responseDTO = IssuedTicket.orderLineItemToIssuedTickets(
+                dto);
+            issuedTicketAdaptor.saveAll(responseDTO.getIssuedTickets());
+            issuedTicketOptionAnswerAdaptor.saveAll(responseDTO.getIssuedTicketOptionAnswers());
+        });
     }
 
     /**

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -5,9 +5,7 @@ import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
 import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketOptionAnswerAdaptor;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketOptionAnswer;
 import band.gosrock.domain.domains.issuedTicket.dto.request.CreateIssuedTicketDTO;
-import band.gosrock.domain.domains.issuedTicket.dto.request.CreateIssuedTicketRequestDTOs;
 import band.gosrock.domain.domains.issuedTicket.dto.response.CreateIssuedTicketResponse;
 import band.gosrock.domain.domains.issuedTicket.dto.response.IssuedTicketDTO;
 import band.gosrock.domain.domains.issuedTicket.exception.IssuedTicketUserNotMatchedException;
@@ -29,39 +27,42 @@ public class IssuedTicketDomainService {
     private final IssuedTicketAdaptor issuedTicketAdaptor;
     private final IssuedTicketOptionAnswerAdaptor issuedTicketOptionAnswerAdaptor;
 
-    @Transactional
-    public void createIssuedTicket(CreateIssuedTicketRequestDTOs createIssuedTicketRequestDTOs) {
-        List<IssuedTicketDTO> issuedTickets =
-                createIssuedTicketRequestDTOs.getCreateIssuedTicketRequests().stream()
-                        .map(
-                                createIssuedTicketRequest -> {
-                                    IssuedTicket issuedTicket =
-                                            IssuedTicket.create(createIssuedTicketRequest);
-                                    /*
-                                    티켓 옵션 답변 저장
-                                     */
-                                    List<IssuedTicketOptionAnswer> issuedTicketOptionAnswers =
-                                            createIssuedTicketRequest.getOptionAnswers().stream()
-                                                    .map(
-                                                            IssuedTicketOptionAnswer
-                                                                    ::orderOptionAnswerToIssuedTicketOptionAnswer)
-                                                    .toList();
-                                    /*
-                                    티켓 옵션 답변 매핑
-                                     */
-                                    issuedTicket.addOptionAnswers(issuedTicketOptionAnswers);
-                                    IssuedTicket saveIssuedTicket =
-                                            issuedTicketAdaptor.save(issuedTicket);
-                                    issuedTicketOptionAnswerAdaptor.saveAll(
-                                            issuedTicketOptionAnswers);
-                                    return new IssuedTicketDTO(saveIssuedTicket);
-                                })
-                        .toList();
-        //        return new CreateIssuedTicketResponse(issuedTickets);
-    }
+    // Todo 둘 중 어떤 로직이 더 나은지 비교해주세요
+    //    @Transactional
+    //    public void createIssuedTicket(CreateIssuedTicketRequestDTOs
+    // createIssuedTicketRequestDTOs) {
+    //        List<IssuedTicketDTO> issuedTickets =
+    //                createIssuedTicketRequestDTOs.getCreateIssuedTicketRequests().stream()
+    //                        .map(
+    //                                createIssuedTicketRequest -> {
+    //                                    IssuedTicket issuedTicket =
+    //                                            IssuedTicket.create(createIssuedTicketRequest);
+    //                                    /*
+    //                                    티켓 옵션 답변 저장
+    //                                     */
+    //                                    List<IssuedTicketOptionAnswer> issuedTicketOptionAnswers =
+    //
+    // createIssuedTicketRequest.getOptionAnswers().stream()
+    //                                                    .map(
+    //                                                            IssuedTicketOptionAnswer
+    //
+    // ::orderOptionAnswerToIssuedTicketOptionAnswer)
+    //                                                    .toList();
+    //                                    /*
+    //                                    티켓 옵션 답변 매핑
+    //                                     */
+    //                                    issuedTicket.addOptionAnswers(issuedTicketOptionAnswers);
+    //                                    IssuedTicket saveIssuedTicket =
+    //                                            issuedTicketAdaptor.save(issuedTicket);
+    //                                    issuedTicketOptionAnswerAdaptor.saveAll(
+    //                                            issuedTicketOptionAnswers);
+    //                                    return new IssuedTicketDTO(saveIssuedTicket);
+    //                                })
+    //                        .toList();
+    //    }
 
     @Transactional
-    public void createIssuedTicket2(List<CreateIssuedTicketDTO> createIssuedTicketDTOs) {
+    public void createIssuedTicket(List<CreateIssuedTicketDTO> createIssuedTicketDTOs) {
         createIssuedTicketDTOs.forEach(
                 dto -> {
                     CreateIssuedTicketResponse responseDTO =
@@ -97,13 +98,17 @@ public class IssuedTicketDomainService {
      * @return Page<IssuedTicket>
      */
     @Transactional(readOnly = true)
-    public Page<IssuedTicket> retrieveIssuedTickets(Long page, Long eventId, String userName) {
+    public Page<IssuedTicket> retrieveIssuedTickets(
+            Long page, Long eventId, String userName, String phoneNumber) {
         PageRequest pageRequest =
                 PageRequest.of(Math.toIntExact(page - 1), 10, Sort.by("id").descending());
-        if (userName == null) {
+        if (userName == null && phoneNumber == null) {
             return issuedTicketAdaptor.findAllByEvent(pageRequest, eventId);
-        } else {
+        } else if (userName != null) {
             return issuedTicketAdaptor.findAllByEventAndUserName(pageRequest, eventId, userName);
+        } else {
+            return issuedTicketAdaptor.findAllByEventAndUserPhoneNumber(
+                    pageRequest, eventId, phoneNumber);
         }
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -30,8 +30,7 @@ public class IssuedTicketDomainService {
     private final IssuedTicketOptionAnswerAdaptor issuedTicketOptionAnswerAdaptor;
 
     @Transactional
-    public void createIssuedTicket(
-            CreateIssuedTicketRequestDTOs createIssuedTicketRequestDTOs) {
+    public void createIssuedTicket(CreateIssuedTicketRequestDTOs createIssuedTicketRequestDTOs) {
         List<IssuedTicketDTO> issuedTickets =
                 createIssuedTicketRequestDTOs.getCreateIssuedTicketRequests().stream()
                         .map(
@@ -58,17 +57,19 @@ public class IssuedTicketDomainService {
                                     return new IssuedTicketDTO(saveIssuedTicket);
                                 })
                         .toList();
-//        return new CreateIssuedTicketResponse(issuedTickets);
+        //        return new CreateIssuedTicketResponse(issuedTickets);
     }
 
     @Transactional
     public void createIssuedTicket2(List<CreateIssuedTicketDTO> createIssuedTicketDTOs) {
-        createIssuedTicketDTOs.forEach(dto -> {
-            CreateIssuedTicketResponse responseDTO = IssuedTicket.orderLineItemToIssuedTickets(
-                dto);
-            issuedTicketAdaptor.saveAll(responseDTO.getIssuedTickets());
-            issuedTicketOptionAnswerAdaptor.saveAll(responseDTO.getIssuedTicketOptionAnswers());
-        });
+        createIssuedTicketDTOs.forEach(
+                dto -> {
+                    CreateIssuedTicketResponse responseDTO =
+                            IssuedTicket.orderLineItemToIssuedTickets(dto);
+                    issuedTicketAdaptor.saveAll(responseDTO.getIssuedTickets());
+                    issuedTicketOptionAnswerAdaptor.saveAll(
+                            responseDTO.getIssuedTicketOptionAnswers());
+                });
     }
 
     /**

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
@@ -75,9 +75,12 @@ public class User extends BaseTimeEntity {
     }
 
     public UserInfoVo toUserInfoVo(User user) {
-        return UserInfoVo.builder().userId(user.getId()).userName(user.getProfile().getName())
-            .email(user.getProfile().getEmail()).phoneNumber(user.getProfile().getPhoneNumber())
-            .profileImage(user.getProfile().getProfileImage()).build();
+        return UserInfoVo.builder()
+                .userId(user.getId())
+                .userName(user.getProfile().getName())
+                .email(user.getProfile().getEmail())
+                .phoneNumber(user.getProfile().getPhoneNumber())
+                .profileImage(user.getProfile().getProfileImage())
+                .build();
     }
-
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
@@ -75,12 +75,6 @@ public class User extends BaseTimeEntity {
     }
 
     public UserInfoVo toUserInfoVo(User user) {
-        return UserInfoVo.builder()
-                .userId(user.getId())
-                .userName(user.getProfile().getName())
-                .email(user.getProfile().getEmail())
-                .phoneNumber(user.getProfile().getPhoneNumber())
-                .profileImage(user.getProfile().getProfileImage())
-                .build();
+        return UserInfoVo.from(user);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
@@ -4,6 +4,7 @@ package band.gosrock.domain.domains.user.domain;
 import band.gosrock.domain.common.aop.domainEvent.Events;
 import band.gosrock.domain.common.events.user.UserRegisterEvent;
 import band.gosrock.domain.common.model.BaseTimeEntity;
+import band.gosrock.domain.common.vo.UserInfoVo;
 import band.gosrock.domain.domains.user.exception.AlreadyDeletedUserException;
 import band.gosrock.domain.domains.user.exception.ForbiddenUserException;
 import javax.persistence.Column;
@@ -72,4 +73,11 @@ public class User extends BaseTimeEntity {
             throw ForbiddenUserException.EXCEPTION;
         }
     }
+
+    public UserInfoVo toUserInfoVo(User user) {
+        return UserInfoVo.builder().userId(user.getId()).userName(user.getProfile().getName())
+            .email(user.getProfile().getEmail()).phoneNumber(user.getProfile().getPhoneNumber())
+            .profileImage(user.getProfile().getProfileImage()).build();
+    }
+
 }


### PR DESCRIPTION
## 개요
- close #98 

## 작업사항
- 도메인 VO들을 각 도메인 내 메서드를 통해 생성하는 로직으로 변경했습니다.
- 자잘한 코드들 수정했습니다.
- 티켓 생성 로직을 전면 수정했습니다.
   - 기존 방식 : RequestDTO처럼 새로운 매핑 객체를 받아서 생성
   - 바뀐 방식 : order + orderLineItem 객체 리스트 (DTO)로 받아옴 => orderLineItem의 quantity를 통해 티켓 생성 (해당 티켓은 옵션에 대한 답변이 동일하므로 for문으로 생성 == 맘에안듦. 더 생각해보자.)
   - 찬진이를 편하게 해주려고 바꾼 로직인데 상당히 마음에 안듭니다. 일단 저질러놓고 리팩토링하자 라는 생각으로 작업했습니다.
- 발급 티켓 리스트 API에 전화번호로 검색을 추가했습니다. => QueryDsl 시급 (주말중으로 작업하겠습니다.)
- 질문 : 티켓 번호나 티켓 이름으로 검색같은 기능은 필요 없을까요??

## 변경로직
- 내용을 적어주세요.