### PR TITLE
feature : 승인 방식 주문 개발 (#84)

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartItemResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartItemResponse.java
@@ -4,6 +4,7 @@ package band.gosrock.api.cart.model.dto.response;
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.common.vo.OptionAnswerVo;
 import band.gosrock.domain.domains.cart.domain.CartLineItem;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,12 +14,21 @@ import lombok.Getter;
 public class CartItemResponse {
 
     // 일반티켓(1/3) - 4000원
+    @Schema(description = "카트라인의 이름입니다.", defaultValue = "일반티켓(1/3) - 4000원")
     private String name;
     // 응답 목록
     private List<OptionAnswerVo> answers;
 
+    @Schema(description = "아이템 공급가액입니다.", defaultValue = "3000원")
     private Money itemPrice;
+
+    @Schema(
+            description = "카트 라인의 총 가격입니다. 옵션등을 통해서 공급가액에 합산되는 형식입니다. (아이템가격 + 옵션가) * 아이템 개수",
+            defaultValue = "4000원")
     private Money cartLinePrice;
+
+    @Schema(description = "담은 상품의 개수입니다.", defaultValue = "1")
+    private Long packedQuantity;
 
     public static CartItemResponse of(String name, CartLineItem cartLineItem) {
         return CartItemResponse.builder()
@@ -26,6 +36,7 @@ public class CartItemResponse {
                 .name(name)
                 .cartLinePrice(cartLineItem.getTotalCartLinePrice())
                 .itemPrice(cartLineItem.getItemPrice())
+                .packedQuantity(cartLineItem.getQuantity())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CreateCartResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CreateCartResponse.java
@@ -35,6 +35,7 @@ public class CreateCartResponse {
                 .totalPrice(cart.getTotalPrice())
                 .cartId(cart.getId())
                 .title(cart.getCartName())
+                .isNeedPayment(cart.isNeedPayment())
                 .totalQuantity(cart.getTotalQuantity())
                 .build();
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CreateCartResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CreateCartResponse.java
@@ -3,6 +3,7 @@ package band.gosrock.api.cart.model.dto.response;
 
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.cart.domain.Cart;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,17 +11,23 @@ import lombok.Getter;
 @Getter
 @Builder
 public class CreateCartResponse {
-
+    @Schema(description = "장바구니명 입니다.", defaultValue = "")
     private final String title;
     // 내티켓 확인하기
     private final List<CartItemResponse> items;
 
     // 금액
+    @Schema(description = "카트라인들의 총 결제금액을 합한 금액입니다", defaultValue = "15000원")
     private final Money totalPrice;
 
+    @Schema(description = "생성한 장바구니의 아이디입니다", defaultValue = "30")
     private final Long cartId;
 
+    @Schema(description = "전체 아이템 수량을 의미합니다", defaultValue = "3")
     private final Long totalQuantity;
+
+    @Schema(description = "결제가 필요한지에 대한 여부를 결정합니다. 필요한 true면 결제창 띄우시면됩니다.", defaultValue = "true")
+    private final Boolean isNeedPayment;
 
     public static CreateCartResponse of(List<CartItemResponse> cartItemResponses, Cart cart) {
         return CreateCartResponse.builder()

--- a/DuDoong-Api/src/main/java/band/gosrock/api/eventHandlers/OrderEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/eventHandlers/OrderEventHandler.java
@@ -3,7 +3,6 @@ package band.gosrock.api.eventHandlers;
 
 import band.gosrock.domain.common.events.order.DoneOrderEvent;
 import band.gosrock.domain.common.events.order.WithDrawOrderEvent;
-import band.gosrock.domain.common.events.user.UserRegisterEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -26,8 +25,8 @@ public class OrderEventHandler {
 
     @Async
     @TransactionalEventListener(
-        classes = WithDrawOrderEvent.class,
-        phase = TransactionPhase.AFTER_COMMIT)
+            classes = WithDrawOrderEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
     public void handleRegisterUserEvent(WithDrawOrderEvent withDrawOrderEvent) {
         log.info(withDrawOrderEvent.getUuid() + "주문 상태 철회 , 티켓 제거 필요");
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/eventHandlers/OrderEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/eventHandlers/OrderEventHandler.java
@@ -1,0 +1,34 @@
+package band.gosrock.api.eventHandlers;
+
+
+import band.gosrock.domain.common.events.order.DoneOrderEvent;
+import band.gosrock.domain.common.events.order.WithDrawOrderEvent;
+import band.gosrock.domain.common.events.user.UserRegisterEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderEventHandler {
+
+    @Async
+    @TransactionalEventListener(
+            classes = DoneOrderEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDoneOrderEvent(DoneOrderEvent doneOrderEvent) {
+        log.info(doneOrderEvent.getUuid() + "주문 상태 완료, 티켓 생성필요");
+    }
+
+    @Async
+    @TransactionalEventListener(
+        classes = WithDrawOrderEvent.class,
+        phase = TransactionPhase.AFTER_COMMIT)
+    public void handleRegisterUserEvent(WithDrawOrderEvent withDrawOrderEvent) {
+        log.info(withDrawOrderEvent.getUuid() + "주문 상태 철회 , 티켓 제거 필요");
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
@@ -49,8 +49,8 @@ public class OrderController {
     }
 
     // TODO : 승인 결제 방식 도입하면서 좀더 이쁘게 만들 예정
-    @Operation(summary = "카드 주문을 생성합니다. 쿠폰없을때 쿠폰아이디 null 로 보내주세염!")
-    @PostMapping("/card")
+    @Operation(summary = "주문을 생성합니다. 장바구니 아이디를 주문서로 변환하는 작업을 합니다.")
+    @PostMapping("/")
     public CreateOrderResponse createOrder(
             @RequestBody @Valid CreateOrderRequest createOrderRequest) {
         return createOrderUseCase.execute(createOrderRequest);

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
@@ -5,6 +5,7 @@ import band.gosrock.api.order.model.dto.request.ConfirmOrderRequest;
 import band.gosrock.api.order.model.dto.request.CreateOrderRequest;
 import band.gosrock.api.order.model.dto.response.CreateOrderResponse;
 import band.gosrock.api.order.model.dto.response.OrderResponse;
+import band.gosrock.api.order.service.ApproveOrderUseCase;
 import band.gosrock.api.order.service.CancelOrderUseCase;
 import band.gosrock.api.order.service.ConfirmOrderUseCase;
 import band.gosrock.api.order.service.CreateOrderUseCase;
@@ -34,6 +35,7 @@ public class OrderController {
 
     private final CreateOrderUseCase createOrderUseCase;
     private final ConfirmOrderUseCase confirmOrderUseCase;
+    private final ApproveOrderUseCase approveOrderUseCase;
     private final CancelOrderUseCase cancelOrderUseCase;
 
     private final RefundOrderUseCase refundOrderUseCase;
@@ -56,12 +58,18 @@ public class OrderController {
         return createOrderUseCase.execute(createOrderRequest);
     }
 
-    @Operation(summary = "결제 승인요청 . successUrl 로 돌아온 웹페이지에서 query 로 받은 응답값을 서버로 보냅니당.")
+    @Operation(summary = "결제 확인하기 . successUrl 로 돌아온 웹페이지에서 query 로 받은 응답값을 서버로 보냅니당.")
     @PostMapping("/{order_uuid}/confirm")
     public OrderResponse confirmOrder(
             @PathVariable("order_uuid") String orderUuid,
             @RequestBody ConfirmOrderRequest confirmOrderRequest) {
         return confirmOrderUseCase.execute(orderUuid, confirmOrderRequest);
+    }
+
+    @Operation(summary = "주문 승인하기 . 호스트 관리자가 티켓 주문을 승인합니다. ( 어드민 이벤트쪽으로 이동예정 )")
+    @PostMapping("/{order_uuid}/approve")
+    public OrderResponse confirmOrder(@PathVariable("order_uuid") String orderUuid) {
+        return approveOrderUseCase.execute(orderUuid);
     }
 
     @Operation(summary = "결제 취소요청. 호스트 관리자가 결제를 취소 시킵니다.! (호스트 관리자용(관리자쪽에서 사용))")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderPaymentResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderPaymentResponse.java
@@ -5,7 +5,6 @@ import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderStatus;
 import band.gosrock.domain.domains.order.domain.PaymentInfo;
-import band.gosrock.domain.domains.order.domain.PaymentMethod;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,10 +12,13 @@ import lombok.Getter;
 @Getter
 @Builder
 public class OrderPaymentResponse {
-    @Schema(description = "결제 수단", defaultValue = "간편결제")
-    private final PaymentMethod paymentMethod;
+    @Schema(description = "결제 수단 ( 승인 결제 , 간편 결제 , 카드 결제 등 )", defaultValue = "간편결제")
+    private final String paymentMethod;
 
-    @Schema(description = "공급자", defaultValue = "카카오페이")
+    @Schema(
+            description = "공급자 ( 카카오페이 , 현대카드 등 승인결제일경우 null 입니다. )",
+            defaultValue = "카카오페이",
+            nullable = true)
     private final String provider;
 
     @Schema(description = "공급가액 (금액)", defaultValue = "12000원")
@@ -34,15 +36,15 @@ public class OrderPaymentResponse {
     @Schema(description = "결제 상태", defaultValue = "결제 완료")
     private final OrderStatus orderStatus;
 
-    @Schema(description = "영수증 주소", defaultValue = "영수증주소")
+    @Schema(description = "영수증 주소", defaultValue = "영수증주소", nullable = true)
     private final String receiptUrl;
 
     public static OrderPaymentResponse from(Order order) {
         PaymentInfo totalPaymentInfo = order.getTotalPaymentInfo();
 
         return OrderPaymentResponse.builder()
-                .paymentMethod(order.getPaymentMethod())
-                .provider(order.getPaymentProvider())
+                .paymentMethod(order.getMethod())
+                .provider(order.getProvider())
                 .discountAmount(totalPaymentInfo.getDiscountAmount())
                 .supplyAmount(totalPaymentInfo.getSupplyAmount())
                 .totalAmount(totalPaymentInfo.getPaymentAmount())

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderResponse.java
@@ -3,6 +3,7 @@ package band.gosrock.api.order.model.dto.response;
 
 import band.gosrock.domain.common.vo.RefundInfoVo;
 import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.domain.domains.order.domain.OrderMethod;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
@@ -29,9 +30,13 @@ public class OrderResponse {
     @Schema(description = "주문 id")
     private final Long orderId;
 
+    @Schema(description = "주문 방식 ( 결제 방식 , 승인 방식 )")
+    private final OrderMethod orderMethod;
+
     public static OrderResponse of(Order order, List<OrderLineTicketResponse> tickets) {
         return OrderResponse.builder()
                 .refundInfo(order.getTotalRefundInfo())
+                .orderMethod(order.getOrderMethod())
                 .paymentInfo(OrderPaymentResponse.from(order))
                 .tickets(tickets)
                 .orderUuid(order.getUuid())

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/mapper/OrderMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/mapper/OrderMapper.java
@@ -1,4 +1,4 @@
-package band.gosrock.api.order.mapper;
+package band.gosrock.api.order.model.mapper;
 
 
 import band.gosrock.api.config.security.SecurityUtils;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ApproveOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ApproveOrderUseCase.java
@@ -1,0 +1,25 @@
+package band.gosrock.api.order.service;
+
+
+import band.gosrock.api.config.security.SecurityUtils;
+import band.gosrock.api.order.model.dto.response.OrderResponse;
+import band.gosrock.api.order.model.mapper.OrderMapper;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.order.service.OrderApproveService;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class ApproveOrderUseCase {
+
+    private final OrderApproveService orderApproveService;
+
+    private final OrderMapper orderMapper;
+
+    public OrderResponse execute(String orderUuid) {
+        // TODO : 권한 체크 ( 호스트 관리자인지 )
+        Long currentUserId = SecurityUtils.getCurrentUserId();
+        String confirmOrderUuid = orderApproveService.execute(orderUuid, currentUserId);
+        return orderMapper.toOrderResponse(confirmOrderUuid);
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CancelOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CancelOrderUseCase.java
@@ -2,8 +2,8 @@ package band.gosrock.api.order.service;
 
 
 import band.gosrock.api.config.security.SecurityUtils;
-import band.gosrock.api.order.mapper.OrderMapper;
 import band.gosrock.api.order.model.dto.response.OrderResponse;
+import band.gosrock.api.order.model.mapper.OrderMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.order.service.WithdrawOrderService;
 import lombok.RequiredArgsConstructor;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ConfirmOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ConfirmOrderUseCase.java
@@ -2,9 +2,9 @@ package band.gosrock.api.order.service;
 
 
 import band.gosrock.api.config.security.SecurityUtils;
-import band.gosrock.api.order.mapper.OrderMapper;
 import band.gosrock.api.order.model.dto.request.ConfirmOrderRequest;
 import band.gosrock.api.order.model.dto.response.OrderResponse;
+import band.gosrock.api.order.model.mapper.OrderMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.order.service.OrderConfirmService;
 import band.gosrock.infrastructure.outer.api.tossPayments.dto.request.ConfirmPaymentsRequest;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ReadOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ReadOrderUseCase.java
@@ -1,8 +1,8 @@
 package band.gosrock.api.order.service;
 
 
-import band.gosrock.api.order.mapper.OrderMapper;
 import band.gosrock.api.order.model.dto.response.OrderResponse;
+import band.gosrock.api.order.model.mapper.OrderMapper;
 import band.gosrock.common.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/RefundOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/RefundOrderUseCase.java
@@ -2,8 +2,8 @@ package band.gosrock.api.order.service;
 
 
 import band.gosrock.api.config.security.SecurityUtils;
-import band.gosrock.api.order.mapper.OrderMapper;
 import band.gosrock.api.order.model.dto.response.OrderResponse;
+import band.gosrock.api.order.model.mapper.OrderMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.order.service.WithdrawOrderService;
 import lombok.RequiredArgsConstructor;

--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
@@ -54,7 +54,8 @@ public enum ErrorCode implements BaseErrorCode {
     EVENT_NOT_FOUND(NOT_FOUND, "Event-404-1", "Event Not Found"),
     ORDER_NOT_APPROVAL(BAD_REQUEST, "Order-400-5", "승인 주문이 아닙니다."),
     ORDER_NOT_PAYMENT(BAD_REQUEST, "Order-400-6", "결제 주문이 아닙니다."),
-    HOST_NOT_AUTH_EVENT(FORBIDDEN, "Event-403-1", "Host Not Auth Event");
+    HOST_NOT_AUTH_EVENT(FORBIDDEN, "Event-403-1", "Host Not Auth Event"),
+    ORDER_NOT_REFUND_DATE(BAD_REQUEST, "Order-400-7", "환불을 할 수 있는 기한을 지났습니다.");
     private int status;
     private String code;
     private String reason;

--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
@@ -52,7 +52,6 @@ public enum ErrorCode implements BaseErrorCode {
     ORDER_CANNOT_CANCEL(BAD_REQUEST, "Order-404-3", "주문을 취소할 수 없는 상태입니다."),
     ORDER_CANNOT_REFUND(BAD_REQUEST, "Order-404-4", "주문을 환불할 수 없는 상태입니다."),
     EVENT_NOT_FOUND(NOT_FOUND, "Event-404-1", "Event Not Found"),
-    Host_NOT_AUTH_EVENT(FORBIDDEN, "Event-403-1", "Host Not Auth Event"),
     ORDER_NOT_APPROVAL(BAD_REQUEST, "Order-400-5", "승인 주문이 아닙니다."),
     ORDER_NOT_PAYMENT(BAD_REQUEST, "Order-400-6", "결제 주문이 아닙니다."),
     HOST_NOT_AUTH_EVENT(FORBIDDEN, "Event-403-1", "Host Not Auth Event");

--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
@@ -52,7 +52,8 @@ public enum ErrorCode implements BaseErrorCode {
     ORDER_CANNOT_CANCEL(BAD_REQUEST, "Order-404-3", "주문을 취소할 수 없는 상태입니다."),
     ORDER_CANNOT_REFUND(BAD_REQUEST, "Order-404-4", "주문을 환불할 수 없는 상태입니다."),
     EVENT_NOT_FOUND(NOT_FOUND, "Event-404-1", "Event Not Found"),
-    Host_NOT_AUTH_EVENT(FORBIDDEN, "Event-403-1", "Host Not Auth Event");
+    Host_NOT_AUTH_EVENT(FORBIDDEN, "Event-403-1", "Host Not Auth Event"),
+    ORDER_NOT_APPROVAL(BAD_REQUEST, "Order-400-5", "승인 주문이 아닙니다.");
     private int status;
     private String code;
     private String reason;

--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/ErrorCode.java
@@ -53,7 +53,8 @@ public enum ErrorCode implements BaseErrorCode {
     ORDER_CANNOT_REFUND(BAD_REQUEST, "Order-404-4", "주문을 환불할 수 없는 상태입니다."),
     EVENT_NOT_FOUND(NOT_FOUND, "Event-404-1", "Event Not Found"),
     Host_NOT_AUTH_EVENT(FORBIDDEN, "Event-403-1", "Host Not Auth Event"),
-    ORDER_NOT_APPROVAL(BAD_REQUEST, "Order-400-5", "승인 주문이 아닙니다.");
+    ORDER_NOT_APPROVAL(BAD_REQUEST, "Order-400-5", "승인 주문이 아닙니다."),
+    ORDER_NOT_PAYMENT(BAD_REQUEST, "Order-400-6", "결제 주문이 아닙니다.");
     private int status;
     private String code;
     private String reason;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/DoneOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/DoneOrderEvent.java
@@ -3,18 +3,17 @@ package band.gosrock.domain.common.events.order;
 
 import band.gosrock.domain.common.aop.domainEvent.DomainEvent;
 import band.gosrock.domain.domains.order.domain.Order;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class NewOrderEvent extends DomainEvent {
+public class DoneOrderEvent extends DomainEvent {
 
     private final String uuid;
     private final Order order;
 
-    public static NewOrderEvent of(String uuid, Order order){
-        return new NewOrderEvent(uuid,order);
+    public static DoneOrderEvent of(String uuid, Order order){
+        return new DoneOrderEvent(uuid,order);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/DoneOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/DoneOrderEvent.java
@@ -13,7 +13,7 @@ public class DoneOrderEvent extends DomainEvent {
     private final String uuid;
     private final Order order;
 
-    public static DoneOrderEvent of(String uuid, Order order){
-        return new DoneOrderEvent(uuid,order);
+    public static DoneOrderEvent of(String uuid, Order order) {
+        return new DoneOrderEvent(uuid, order);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/NewOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/NewOrderEvent.java
@@ -1,0 +1,20 @@
+package band.gosrock.domain.common.events.order;
+
+
+import band.gosrock.domain.common.aop.domainEvent.DomainEvent;
+import band.gosrock.domain.domains.order.domain.Order;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class NewOrderEvent extends DomainEvent {
+
+    private final String uuid;
+    private final Order order;
+
+    public static NewOrderEvent of(String uuid, Order order){
+        return new NewOrderEvent(uuid,order);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
@@ -1,0 +1,19 @@
+package band.gosrock.domain.common.events.order;
+
+
+import band.gosrock.domain.common.aop.domainEvent.DomainEvent;
+import band.gosrock.domain.domains.order.domain.Order;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class WithDrawOrderEvent extends DomainEvent {
+
+    private final String uuid;
+    private final Order order;
+
+    public static WithDrawOrderEvent of(String uuid, Order order){
+        return new WithDrawOrderEvent(uuid,order);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
@@ -13,7 +13,7 @@ public class WithDrawOrderEvent extends DomainEvent {
     private final String uuid;
     private final Order order;
 
-    public static WithDrawOrderEvent of(String uuid, Order order){
-        return new WithDrawOrderEvent(uuid,order);
+    public static WithDrawOrderEvent of(String uuid, Order order) {
+        return new WithDrawOrderEvent(uuid, order);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/Cart.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/Cart.java
@@ -37,7 +37,7 @@ public class Cart extends BaseTimeEntity {
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "cart_id")
     private List<CartLineItem> cartLineItems = new ArrayList<>();
-
+    /** ---------------------------- 생성 관련 메서드 ---------------------------------- */
     @Builder
     public Cart(Long userId, List<CartLineItem> cartLineItems) {
         CartLineItem cartLineItem = cartLineItems.stream().findFirst().orElseThrow();
@@ -46,20 +46,26 @@ public class Cart extends BaseTimeEntity {
         this.cartLineItems.addAll(cartLineItems);
     }
 
-    public Money getTotalPrice() {
-        return cartLineItems.stream()
-                .map(CartLineItem::getTotalCartLinePrice)
-                .reduce(Money.ZERO, Money::plus);
-    }
+    /** ---------------------------- 커맨드 메서드 ---------------------------------- */
 
-    public Long getTotalQuantity() {
-        return cartLineItems.stream().map(CartLineItem::getQuantity).reduce(0L, Long::sum);
-    }
+    /** ---------------------------- 검증 메서드 ---------------------------------- */
 
+    /** ---------------------------- 조회용 메서드 ---------------------------------- */
     /** 결제가 필요한 오더인지 반환합니다. */
     public Boolean isNeedPayment() {
         return this.cartLineItems.stream()
                 .map(CartLineItem::isNeedPayment)
                 .reduce(Boolean.FALSE, (Boolean::logicalOr));
+    }
+
+    /** 카트에 담긴 상품의 총 갯수를 가져옵니다. */
+    public Long getTotalQuantity() {
+        return cartLineItems.stream().map(CartLineItem::getQuantity).reduce(0L, Long::sum);
+    }
+    /** 카트에 담긴 상품의 총 가격을 가져옵니다 . (상품 + 옵션 ) * 총갯수 = 카트라인의 가격 , 카트라인의 가격의 합집합 */
+    public Money getTotalPrice() {
+        return cartLineItems.stream()
+                .map(CartLineItem::getTotalCartLinePrice)
+                .reduce(Money.ZERO, Money::plus);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/Cart.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/Cart.java
@@ -56,10 +56,10 @@ public class Cart extends BaseTimeEntity {
         return cartLineItems.stream().map(CartLineItem::getQuantity).reduce(0L, Long::sum);
     }
 
-    /**
-     * 결제가 필요한 오더인지 반환합니다.
-     */
-    public Boolean isNeedPayment(){
-        return this.cartLineItems.stream().map(CartLineItem::isNeedPayment).reduce(Boolean.FALSE,(Boolean::logicalOr));
+    /** 결제가 필요한 오더인지 반환합니다. */
+    public Boolean isNeedPayment() {
+        return this.cartLineItems.stream()
+                .map(CartLineItem::isNeedPayment)
+                .reduce(Boolean.FALSE, (Boolean::logicalOr));
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/Cart.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/Cart.java
@@ -55,4 +55,11 @@ public class Cart extends BaseTimeEntity {
     public Long getTotalQuantity() {
         return cartLineItems.stream().map(CartLineItem::getQuantity).reduce(0L, Long::sum);
     }
+
+    /**
+     * 결제가 필요한 오더인지 반환합니다.
+     */
+    public Boolean isNeedPayment(){
+        return this.cartLineItems.stream().map(CartLineItem::isNeedPayment).reduce(Boolean.FALSE,(Boolean::logicalOr));
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartLineItem.java
@@ -46,6 +46,7 @@ public class CartLineItem extends BaseTimeEntity {
     @JoinColumn(name = "cart_line_id")
     private List<CartOptionAnswer> cartOptionAnswers = new ArrayList<>();
 
+    /** ---------------------------- 생성 관련 메서드 ---------------------------------- */
     @Builder
     public CartLineItem(
             TicketItem ticketItem, Long quantity, List<CartOptionAnswer> cartOptionAnswers) {
@@ -54,37 +55,41 @@ public class CartLineItem extends BaseTimeEntity {
         this.cartOptionAnswers.addAll(cartOptionAnswers);
     }
 
+    /** ---------------------------- 커맨드 메서드 ---------------------------------- */
+
+    /** ---------------------------- 검증 메서드 ---------------------------------- */
+
+    /** ---------------------------- 조회용 메서드 ---------------------------------- */
+
+    /** 응답한 옵션들의 총 가격을 불러옵니다. */
     public Money getTotalOptionsPrice() {
         return cartOptionAnswers.stream()
                 .map(CartOptionAnswer::getOptionPrice)
                 .reduce(Money.ZERO, Money::plus);
     }
-
+    /** 상품의 이름을 가져옵니다. */
     public String getTicketName() {
         return ticketItem.getName();
     }
 
-    public Money getTicketPrice() {
-        return ticketItem.getPrice();
-    }
-
+    /** 카트라인의 총 가격을 가져옵니다. 상품 + 옵션답변의 가격 */
     public Money getTotalCartLinePrice() {
         Money totalOptionAnswerPrice = getTotalOptionsPrice();
         return ticketItem.getPrice().plus(totalOptionAnswerPrice).times(quantity);
     }
-
+    /** 상품의 타입을 가져옵니다. ( 승인 방식 , 결제 방식 ) */
     public TicketType getTicketType() {
         return ticketItem.getType();
     }
-
+    /** 옵션응답의 정보 VO를 가져옵니다. */
     public List<OptionAnswerVo> getOptionAnswerVos() {
         return cartOptionAnswers.stream().map(CartOptionAnswer::getOptionAnswerVo).toList();
     }
-
+    /** 상품의 가격을 가져옵니다. */
     public Money getItemPrice() {
         return ticketItem.getPrice();
     }
-
+    /** 장바구니의 담긴 상품이 결제가 필요한지. 가져옵니다. */
     public Boolean isNeedPayment() {
         return ticketItem.isNeedPayment();
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartLineItem.java
@@ -85,7 +85,7 @@ public class CartLineItem extends BaseTimeEntity {
         return ticketItem.getPrice();
     }
 
-    public Boolean isNeedPayment(){
+    public Boolean isNeedPayment() {
         return ticketItem.isNeedPayment();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartLineItem.java
@@ -84,4 +84,8 @@ public class CartLineItem extends BaseTimeEntity {
     public Money getItemPrice() {
         return ticketItem.getPrice();
     }
+
+    public Boolean isNeedPayment(){
+        return ticketItem.isNeedPayment();
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartOptionAnswer.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartOptionAnswer.java
@@ -34,13 +34,18 @@ public class CartOptionAnswer extends BaseTimeEntity {
     private Option option;
 
     private String answer;
-
+    /** ---------------------------- 생성 관련 메서드 ---------------------------------- */
     @Builder
     public CartOptionAnswer(Option option, String answer) {
         this.option = option;
         this.answer = answer;
     }
 
+    /** ---------------------------- 커맨드 메서드 ---------------------------------- */
+
+    /** ---------------------------- 검증 메서드 ---------------------------------- */
+
+    /** ---------------------------- 조회용 메서드 ---------------------------------- */
     protected Money getOptionPrice() {
         return option.getAdditionalPrice();
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -6,6 +6,7 @@ import band.gosrock.domain.common.model.BaseTimeEntity;
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.common.vo.RefundInfoVo;
 import band.gosrock.domain.domains.cart.domain.Cart;
+import band.gosrock.domain.domains.cart.domain.CartLineItem;
 import band.gosrock.domain.domains.coupon.domain.IssuedCoupon;
 import band.gosrock.domain.domains.order.exception.InvalidOrderException;
 import band.gosrock.domain.domains.order.exception.NotOwnerOrderException;
@@ -253,5 +254,12 @@ public class Order extends BaseTimeEntity {
     public void refund() {
         orderStatus.validCanRefund();
         this.orderStatus = OrderStatus.REFUND;
+    }
+
+    /**
+     * 결제가 필요한 오더인지 반환합니다.
+     */
+    public Boolean isNeedPayment(){
+        return this.orderLineItems.stream().map(OrderLineItem::isNeedPayment).reduce(Boolean.FALSE,(Boolean::logicalOr));
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -291,4 +291,8 @@ public class Order extends BaseTimeEntity {
         if (this.orderMethod.equals(OrderMethod.APPROVAL)) return null;
         return this.pgPaymentInfo.getReceiptUrl();
     }
+
+    public Boolean isMethodPayment(){
+        return orderMethod.isPayment();
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -108,6 +108,7 @@ public class Order extends BaseTimeEntity {
         this.orderName = OrderName;
         this.orderLineItems.addAll(orderLineItems);
         this.orderStatus = orderStatus;
+        this.orderMethod = orderMethod;
     }
 
     /** 카드, 간편결제등 토스 요청 과정이 필요한 결제를 생성합니다. */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -6,7 +6,6 @@ import band.gosrock.domain.common.model.BaseTimeEntity;
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.common.vo.RefundInfoVo;
 import band.gosrock.domain.domains.cart.domain.Cart;
-import band.gosrock.domain.domains.cart.domain.CartLineItem;
 import band.gosrock.domain.domains.coupon.domain.IssuedCoupon;
 import band.gosrock.domain.domains.order.exception.InvalidOrderException;
 import band.gosrock.domain.domains.order.exception.NotOwnerOrderException;
@@ -256,10 +255,10 @@ public class Order extends BaseTimeEntity {
         this.orderStatus = OrderStatus.REFUND;
     }
 
-    /**
-     * 결제가 필요한 오더인지 반환합니다.
-     */
-    public Boolean isNeedPayment(){
-        return this.orderLineItems.stream().map(OrderLineItem::isNeedPayment).reduce(Boolean.FALSE,(Boolean::logicalOr));
+    /** 결제가 필요한 오더인지 반환합니다. */
+    public Boolean isNeedPayment() {
+        return this.orderLineItems.stream()
+                .map(OrderLineItem::isNeedPayment)
+                .reduce(Boolean.FALSE, (Boolean::logicalOr));
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -10,12 +10,13 @@ import band.gosrock.domain.domains.coupon.domain.IssuedCoupon;
 import band.gosrock.domain.domains.order.exception.InvalidOrderException;
 import band.gosrock.domain.domains.order.exception.NotApprovalOrderException;
 import band.gosrock.domain.domains.order.exception.NotOwnerOrderException;
+import band.gosrock.domain.domains.order.exception.NotPaymentOrderException;
 import band.gosrock.domain.domains.order.exception.OrderLineNotFountException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
-import javax.persistence.AttributeOverride;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -58,24 +59,15 @@ public class Order extends BaseTimeEntity {
     @Column(nullable = false)
     private String orderName;
 
-    // 결제 방식 ( 토스 승인 이후 저장 )
-    @Enumerated(EnumType.STRING)
-    private PaymentMethod paymentMethod = PaymentMethod.DEFAULT;
-    // 토스 결제 승인후 결제 긁힌 시간 ( 토스 승인 이후 저장 )
+    // 결제 대행사 정보 ( 토스 승인 이후 저장 )
+    @Embedded private PgPaymentInfo pgPaymentInfo;
+
+    // 결제 완료 된시간 승인 결제등.
     private LocalDateTime approvedAt;
 
-    // 결제 공급자 정보 ex 카카오페이 ( 토스 승인 이후 저장 )
-    private String paymentProvider;
-
-    // 영수증 주소 ( 토스 승인 이후 저장 )
-    private String receiptUrl;
-    // 승인된 거래키 ( 취소 때 사용 )
-    private String paymentKey;
-    // 세금 ( 토스 승인 이후 저장 )
-    @Embedded
-    @AttributeOverride(name = "amount", column = @Column(name = "vat_amount"))
-    private Money vat;
-
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderMethod orderMethod;
     // 결제 정보
     @Embedded private PaymentInfo totalPaymentInfo;
 
@@ -104,38 +96,39 @@ public class Order extends BaseTimeEntity {
         this.orderNo = "R" + Long.sum(NO_START_NUMBER, this.id);
     }
 
+    /** ---------------------------- 생성 관련 메서드 ---------------------------------- */
     @Builder
     public Order(
             Long userId,
             String OrderName,
             List<OrderLineItem> orderLineItems,
-            OrderStatus orderStatus) {
+            OrderStatus orderStatus,
+            OrderMethod orderMethod) {
         this.userId = userId;
         this.orderName = OrderName;
         this.orderLineItems.addAll(orderLineItems);
         this.orderStatus = orderStatus;
     }
 
-    /**
-     * 카드, 간편결제등 토스 요청 과정이 필요한 결제를 생성합니다.
-     */
+    /** 카드, 간편결제등 토스 요청 과정이 필요한 결제를 생성합니다. */
     public static Order createPaymentOrder(Long userId, Cart cart) {
-        return orderBaseBuilder(userId, cart).orderStatus(OrderStatus.PENDING_PAYMENT).build();
+        return orderBaseBuilder(userId, cart)
+                .orderStatus(OrderStatus.PENDING_PAYMENT)
+                .orderMethod(OrderMethod.PAYMENT)
+                .build();
     }
 
-    /**
-     * 승인 결제인 주문을 생성합니다.
-     */
+    /** 승인 결제인 주문을 생성합니다. */
     public static Order createApproveOrder(Long userId, Cart cart) {
-        return orderBaseBuilder(userId, cart).orderStatus(OrderStatus.PENDING_APPROVE).build();
+        return orderBaseBuilder(userId, cart)
+                .orderStatus(OrderStatus.PENDING_APPROVE)
+                .orderMethod(OrderMethod.APPROVAL)
+                .build();
     }
 
-    /**
-     * 주문을 생성합니다.
-     */
-    public static Order createOrder(Long userId, Cart cart){
-        if(cart.isNeedPayment())
-            return createPaymentOrder(userId , cart);
+    /** 주문을 생성합니다. */
+    public static Order createOrder(Long userId, Cart cart) {
+        if (cart.isNeedPayment()) return createPaymentOrder(userId, cart);
         return createApproveOrder(userId, cart);
     }
 
@@ -148,22 +141,7 @@ public class Order extends BaseTimeEntity {
                 .orderLineItems(orderLineItems);
     }
 
-    public Money getTotalSupplyPrice() {
-        return orderLineItems.stream()
-                .map(OrderLineItem::getTotalOrderLinePrice)
-                .reduce(Money.ZERO, Money::plus);
-    }
-
-    public Money getTotalPaymentPrice() {
-        return getTotalSupplyPrice().minus(getTotalDiscountPrice());
-    }
-
-    public Money getTotalDiscountPrice() {
-        if (issuedCoupon != null) {
-            return issuedCoupon.getDiscountAmount(getTotalSupplyPrice());
-        }
-        return Money.ZERO;
-    }
+    /** ---------------------------- 커맨드 메서드 ---------------------------------- */
 
     /** totalPaymentInfo 를 업데이트 합니다. */
     public void calculatePaymentInfo() {
@@ -175,52 +153,103 @@ public class Order extends BaseTimeEntity {
                         .build();
     }
 
-    /** 오더의 결제를 승인 합니다. */
-    public void confirmPaymentOrder(Money requestAmount) {
-
-        if (!getTotalPaymentPrice().equals(requestAmount)) {
-            throw InvalidOrderException.EXCEPTION;
-        }
-        orderStatus.validCanPaymentConfirm();
+    /** 결제 방식의 주문을 승인 합니다. */
+    public void confirmPayment(
+            Money pgAmount, LocalDateTime approvedAt, PgPaymentInfo pgPaymentInfo) {
         // TODO: 재고량 비교 필요?
+        validCanConfirmPayment(pgAmount);
+        validPgAndOrderAmountIsEqual(pgAmount);
         orderStatus = OrderStatus.CONFIRM;
+        this.approvedAt = approvedAt;
+        this.pgPaymentInfo = pgPaymentInfo;
     }
 
-    public void approveOrder() {
-        if(isNeedPayment()){
+    /** 승인 방식의 주문을 승인합니다. */
+    public void approve() {
+        if (isNeedPayment()) {
             throw NotApprovalOrderException.EXCEPTION;
         }
         orderStatus.validCanApprove();
         // TODO: 재고량 비교 필요?
+        this.approvedAt = LocalDateTime.now();
         orderStatus = OrderStatus.APPROVED;
     }
 
+    /** 관리자가 주문을 취소 시킵니다 */
+    public void cancel() {
+        orderStatus.validCanCancel();
+        this.orderStatus = OrderStatus.CANCELED;
+    }
+
+    /** 사용자가 주문을 환불 시킵니다. */
+    public void refund() {
+        orderStatus.validCanRefund();
+        this.orderStatus = OrderStatus.REFUND;
+    }
+
+    /** ---------------------------- 검증 메서드 ---------------------------------- */
+
+    /** PG 사를 통한 결제 대금이 주문의 가격과 동일한지 검증합니다. */
+    public void validPgAndOrderAmountIsEqual(Money pgAmount) {
+        if (!pgAmount.equals(getTotalPaymentPrice())) {
+            throw InvalidOrderException.EXCEPTION;
+        }
+    }
+    /** 주문에대한 주인인지 검증합니다. */
     public void validOwner(Long currentUserId) {
         if (!userId.equals(currentUserId)) {
             throw NotOwnerOrderException.EXCEPTION;
         }
     }
+    /** 결제 방식의 주문을 승인할수있는지 확인합니다. */
+    public void validCanConfirmPayment(Money requestAmount) {
+        if (!getTotalPaymentPrice().equals(requestAmount)) {
+            throw InvalidOrderException.EXCEPTION;
+        }
+        if (!isNeedPayment()) {
+            throw NotPaymentOrderException.EXCEPTION;
+        }
+        orderStatus.validCanPaymentConfirm();
+    }
+
+    /** ---------------------------- 조회용 메서드 ---------------------------------- */
+    /** 결제 방식의 paymentKey를 가져옵니다. */
+    public String getPaymentKey() {
+        if (Objects.isNull(this.pgPaymentInfo)) {
+            throw NotPaymentOrderException.EXCEPTION;
+        }
+        return this.pgPaymentInfo.getPaymentKey();
+    }
 
     /**
-     * 토스 결제 승인 이후 넘어온 응답값을 바탕으로 vat 등 결제 정보를 업데이트 합니다.
+     * 쿠폰의 이름을 가져옵니다
      *
-     * @param approvedAt
-     * @param paymentMethod
-     * @param vat
+     * @default 사용하지않음
      */
-    public void afterPaymentAddInfo(
-            LocalDateTime approvedAt,
-            PaymentMethod paymentMethod,
-            Money vat,
-            String provider,
-            String receiptUrl,
-            String paymentKey) {
-        this.approvedAt = approvedAt;
-        this.paymentMethod = paymentMethod;
-        this.vat = vat;
-        this.paymentProvider = provider;
-        this.receiptUrl = receiptUrl;
-        this.paymentKey = paymentKey;
+    public String getCouponName() {
+        if (issuedCoupon != null) {
+            return issuedCoupon.getCouponName();
+        }
+        return "사용하지 않음";
+    }
+
+    /** 총 공급가액을 가져옵니다. */
+    public Money getTotalSupplyPrice() {
+        return orderLineItems.stream()
+                .map(OrderLineItem::getTotalOrderLinePrice)
+                .reduce(Money.ZERO, Money::plus);
+    }
+
+    /** 총 결제금액을 가져옵니다. 공급가액 - 할인가 */
+    public Money getTotalPaymentPrice() {
+        return getTotalSupplyPrice().minus(getTotalDiscountPrice());
+    }
+    /** 총 할인금액을 가져옵니다. */
+    public Money getTotalDiscountPrice() {
+        if (issuedCoupon != null) {
+            return issuedCoupon.getDiscountAmount(getTotalSupplyPrice());
+        }
+        return Money.ZERO;
     }
 
     /**
@@ -237,39 +266,28 @@ public class Order extends BaseTimeEntity {
         return orderLineItem.getRefundInfo();
     }
 
-    /**
-     * 쿠폰의 이름을 가져옵니다
-     *
-     * @default 사용하지않음
-     * @return
-     */
-    public String getCouponName() {
-        if (issuedCoupon != null) {
-            return issuedCoupon.getCouponName();
-        }
-        return "사용하지 않음";
-    }
-
-    public void validPgAndOrderAmountIsEqual(Money pgAmount) {
-        if (!pgAmount.equals(getTotalPaymentPrice())) {
-            throw InvalidOrderException.EXCEPTION;
-        }
-    }
-
-    public void cancel() {
-        orderStatus.validCanCancel();
-        this.orderStatus = OrderStatus.CANCELED;
-    }
-
-    public void refund() {
-        orderStatus.validCanRefund();
-        this.orderStatus = OrderStatus.REFUND;
-    }
-
     /** 결제가 필요한 오더인지 반환합니다. */
     public Boolean isNeedPayment() {
         return this.orderLineItems.stream()
                 .map(OrderLineItem::isNeedPayment)
                 .reduce(Boolean.FALSE, (Boolean::logicalOr));
+    }
+
+    /** 결제 수단 정보를 가져옵니다. */
+    public String getMethod() {
+        if (this.orderMethod.equals(OrderMethod.APPROVAL)) return OrderMethod.APPROVAL.getKr();
+        return this.pgPaymentInfo.getPaymentMethod().getKr();
+    }
+
+    /** 결제 공급자 정보를 가져옵니다. */
+    public String getProvider() {
+        if (this.orderMethod.equals(OrderMethod.APPROVAL)) return null;
+        return this.pgPaymentInfo.getPaymentProvider();
+    }
+
+    /** 결제 공급자 정보를 가져옵니다. */
+    public String getReceiptUrl() {
+        if (this.orderMethod.equals(OrderMethod.APPROVAL)) return null;
+        return this.pgPaymentInfo.getReceiptUrl();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -2,6 +2,9 @@ package band.gosrock.domain.domains.order.domain;
 
 import static band.gosrock.common.consts.DuDoongStatic.NO_START_NUMBER;
 
+import band.gosrock.domain.common.aop.domainEvent.Events;
+import band.gosrock.domain.common.events.order.DoneOrderEvent;
+import band.gosrock.domain.common.events.order.WithDrawOrderEvent;
 import band.gosrock.domain.common.model.BaseTimeEntity;
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.common.vo.RefundInfoVo;
@@ -163,6 +166,7 @@ public class Order extends BaseTimeEntity {
         orderStatus = OrderStatus.CONFIRM;
         this.approvedAt = approvedAt;
         this.pgPaymentInfo = pgPaymentInfo;
+        Events.raise(DoneOrderEvent.of(this.uuid,this));
     }
 
     /** 승인 방식의 주문을 승인합니다. */
@@ -174,18 +178,21 @@ public class Order extends BaseTimeEntity {
         // TODO: 재고량 비교 필요?
         this.approvedAt = LocalDateTime.now();
         orderStatus = OrderStatus.APPROVED;
+        Events.raise(DoneOrderEvent.of(this.uuid,this));
     }
 
     /** 관리자가 주문을 취소 시킵니다 */
     public void cancel() {
         orderStatus.validCanCancel();
         this.orderStatus = OrderStatus.CANCELED;
+        Events.raise(WithDrawOrderEvent.of(this.uuid,this));
     }
 
     /** 사용자가 주문을 환불 시킵니다. */
     public void refund() {
         orderStatus.validCanRefund();
         this.orderStatus = OrderStatus.REFUND;
+        Events.raise(WithDrawOrderEvent.of(this.uuid,this));
     }
 
     /** ---------------------------- 검증 메서드 ---------------------------------- */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -166,7 +166,7 @@ public class Order extends BaseTimeEntity {
         orderStatus = OrderStatus.CONFIRM;
         this.approvedAt = approvedAt;
         this.pgPaymentInfo = pgPaymentInfo;
-        Events.raise(DoneOrderEvent.of(this.uuid,this));
+        Events.raise(DoneOrderEvent.of(this.uuid, this));
     }
 
     /** 승인 방식의 주문을 승인합니다. */
@@ -178,21 +178,21 @@ public class Order extends BaseTimeEntity {
         // TODO: 재고량 비교 필요?
         this.approvedAt = LocalDateTime.now();
         orderStatus = OrderStatus.APPROVED;
-        Events.raise(DoneOrderEvent.of(this.uuid,this));
+        Events.raise(DoneOrderEvent.of(this.uuid, this));
     }
 
     /** 관리자가 주문을 취소 시킵니다 */
     public void cancel() {
         orderStatus.validCanCancel();
         this.orderStatus = OrderStatus.CANCELED;
-        Events.raise(WithDrawOrderEvent.of(this.uuid,this));
+        Events.raise(WithDrawOrderEvent.of(this.uuid, this));
     }
 
     /** 사용자가 주문을 환불 시킵니다. */
     public void refund() {
         orderStatus.validCanRefund();
         this.orderStatus = OrderStatus.REFUND;
-        Events.raise(WithDrawOrderEvent.of(this.uuid,this));
+        Events.raise(WithDrawOrderEvent.of(this.uuid, this));
     }
 
     /** ---------------------------- 검증 메서드 ---------------------------------- */
@@ -299,7 +299,7 @@ public class Order extends BaseTimeEntity {
         return this.pgPaymentInfo.getReceiptUrl();
     }
 
-    public Boolean isMethodPayment(){
+    public Boolean isMethodPayment() {
         return orderMethod.isPayment();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
@@ -7,7 +7,6 @@ import band.gosrock.domain.common.vo.OptionAnswerVo;
 import band.gosrock.domain.common.vo.RefundInfoVo;
 import band.gosrock.domain.domains.cart.domain.CartLineItem;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
-import band.gosrock.domain.domains.ticket_item.domain.TicketType;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
@@ -91,7 +90,7 @@ public class OrderLineItem extends BaseTimeEntity {
         return orderOptionAnswer.stream().map(OrderOptionAnswer::getOptionAnswerVo).toList();
     }
 
-    public Boolean isNeedPayment(){
+    public Boolean isNeedPayment() {
         return ticketItem.isNeedPayment();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
@@ -7,6 +7,7 @@ import band.gosrock.domain.common.vo.OptionAnswerVo;
 import band.gosrock.domain.common.vo.RefundInfoVo;
 import band.gosrock.domain.domains.cart.domain.CartLineItem;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.ticket_item.domain.TicketType;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
@@ -88,5 +89,9 @@ public class OrderLineItem extends BaseTimeEntity {
 
     public List<OptionAnswerVo> getOptionAnswerVos() {
         return orderOptionAnswer.stream().map(OrderOptionAnswer::getOptionAnswerVo).toList();
+    }
+
+    public Boolean isNeedPayment(){
+        return ticketItem.isNeedPayment();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
@@ -101,4 +101,8 @@ public class OrderLineItem extends BaseTimeEntity {
     public Boolean isNeedPayment() {
         return ticketItem.isNeedPayment();
     }
+
+    public Boolean canRefund() {
+        return this.getRefundInfo().getAvailAble();
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
@@ -47,7 +47,7 @@ public class OrderLineItem extends BaseTimeEntity {
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "order_line_item_id")
     private List<OrderOptionAnswer> orderOptionAnswer = new ArrayList<>();
-
+    /** ---------------------------- 생성 관련 메서드 ---------------------------------- */
     @Builder
     public OrderLineItem(
             TicketItem ticketItem, Long quantity, List<OrderOptionAnswer> orderOptionAnswer) {
@@ -68,28 +68,36 @@ public class OrderLineItem extends BaseTimeEntity {
                 .build();
     }
 
+    /** ---------------------------- 커맨드 메서드 ---------------------------------- */
+
+    /** ---------------------------- 검증 메서드 ---------------------------------- */
+
+    /** ---------------------------- 조회용 메서드 ---------------------------------- */
+
+    /** 응답한 옵션들의 총 가격을 불러옵니다. */
     protected Money getTotalOptionAnswersPrice() {
         return orderOptionAnswer.stream()
                 .map(OrderOptionAnswer::getOptionPrice)
                 .reduce(Money.ZERO, Money::plus);
     }
 
+    /** 카트라인의 총 가격을 가져옵니다. 상품 + 옵션답변의 가격 */
     public Money getTotalOrderLinePrice() {
         return getItemPrice().plus(getTotalOptionAnswersPrice()).times(quantity);
     }
-
+    /** 상품의 가격을 가져옵니다. */
     public Money getItemPrice() {
         return ticketItem.getPrice();
     }
-
+    /** 환불 가능 정보를 불러옵니다. */
     public RefundInfoVo getRefundInfo() {
         return ticketItem.getRefundInfoVo();
     }
-
+    /** 옵션응답의 정보 VO를 가져옵니다. */
     public List<OptionAnswerVo> getOptionAnswerVos() {
         return orderOptionAnswer.stream().map(OrderOptionAnswer::getOptionAnswerVo).toList();
     }
-
+    /** 결제가 필요한 오더라인인지 가져옵니다. */
     public Boolean isNeedPayment() {
         return ticketItem.isNeedPayment();
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderMethod.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderMethod.java
@@ -14,4 +14,8 @@ public enum OrderMethod {
     private String value;
 
     @JsonValue private String kr;
+
+    public Boolean isPayment(){
+        return this.equals(OrderMethod.PAYMENT);
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderMethod.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderMethod.java
@@ -1,0 +1,17 @@
+package band.gosrock.domain.domains.order.domain;
+
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OrderMethod {
+    APPROVAL("APPROVAL", "승인 방식"),
+    PAYMENT("PAYMENT", "결제 방식");
+
+    private String value;
+
+    @JsonValue private String kr;
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderMethod.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderMethod.java
@@ -15,7 +15,7 @@ public enum OrderMethod {
 
     @JsonValue private String kr;
 
-    public Boolean isPayment(){
+    public Boolean isPayment() {
         return this.equals(OrderMethod.PAYMENT);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderOptionAnswer.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderOptionAnswer.java
@@ -36,7 +36,7 @@ public class OrderOptionAnswer extends BaseTimeEntity {
     private Option option;
 
     private String answer;
-
+    /** ---------------------------- 생성 관련 메서드 ---------------------------------- */
     @Builder
     public OrderOptionAnswer(Option option, String answer) {
         this.option = option;
@@ -50,6 +50,11 @@ public class OrderOptionAnswer extends BaseTimeEntity {
                 .build();
     }
 
+    /** ---------------------------- 커맨드 메서드 ---------------------------------- */
+
+    /** ---------------------------- 검증 메서드 ---------------------------------- */
+
+    /** ---------------------------- 조회용 메서드 ---------------------------------- */
     protected Money getOptionPrice() {
         return option.getAdditionalPrice();
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderStatus.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderStatus.java
@@ -34,14 +34,19 @@ public enum OrderStatus {
 
     @JsonValue private String kr;
 
+
+    private boolean checkCanWithDraw() {
+        return this.equals(OrderStatus.CONFIRM) || this.equals(OrderStatus.APPROVED);
+    }
     public void validCanCancel() {
-        if (!this.equals(OrderStatus.CONFIRM)) {
+        if (!checkCanWithDraw()) {
             throw CanNotCancelOrderException.EXCEPTION;
         }
     }
 
+
     public void validCanRefund() {
-        if (!this.equals(OrderStatus.CONFIRM)) {
+        if (!checkCanWithDraw()) {
             throw CanNotRefundOrderException.EXCEPTION;
         }
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderStatus.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderStatus.java
@@ -34,16 +34,15 @@ public enum OrderStatus {
 
     @JsonValue private String kr;
 
-
     private boolean checkCanWithDraw() {
         return this.equals(OrderStatus.CONFIRM) || this.equals(OrderStatus.APPROVED);
     }
+
     public void validCanCancel() {
         if (!checkCanWithDraw()) {
             throw CanNotCancelOrderException.EXCEPTION;
         }
     }
-
 
     public void validCanRefund() {
         if (!checkCanWithDraw()) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderStatus.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderStatus.java
@@ -21,6 +21,8 @@ public enum OrderStatus {
     OUTDATED("OUTDATED", "결제 시간 만료"),
     // 결제 승인
     CONFIRM("CONFIRM", "결제 완료"),
+
+    APPROVED("APPROVED", "승인 완료"),
     // 사용자가 환불
     REFUND("REFUND", "환불 완료"),
 
@@ -44,8 +46,14 @@ public enum OrderStatus {
         }
     }
 
-    public void validCanOrder() {
+    public void validCanPaymentConfirm() {
         if (!this.equals(OrderStatus.PENDING_PAYMENT)) {
+            throw NotPendingOrderException.EXCEPTION;
+        }
+    }
+
+    public void validCanApprove() {
+        if (!this.equals(OrderStatus.PENDING_APPROVE)) {
             throw NotPendingOrderException.EXCEPTION;
         }
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/PaymentMethod.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/PaymentMethod.java
@@ -14,8 +14,6 @@ public enum PaymentMethod {
     EASYPAY("EASYPAY", "간편 결제"),
     // 카드결제
     CARD("CARD", "카드 결제"),
-    // 승인결제
-    APPROVAL("APPROVAL", "승인 결제"),
     // 결제방식 미지정상태
     DEFAULT("DEFAULT", "결제 방식 미지정");
     private String value;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/PgPaymentInfo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/PgPaymentInfo.java
@@ -1,0 +1,59 @@
+package band.gosrock.domain.domains.order.domain;
+
+
+import band.gosrock.domain.common.vo.Money;
+import band.gosrock.infrastructure.outer.api.tossPayments.dto.response.PaymentsResponse;
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor
+@Getter
+public class PgPaymentInfo {
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod paymentMethod = PaymentMethod.DEFAULT;
+
+    // 결제 공급자 정보 ex 카카오페이 ( 토스 승인 이후 저장 )
+    private String paymentProvider;
+
+    // 영수증 주소 ( 토스 승인 이후 저장 )
+    private String receiptUrl;
+    // 승인된 거래키 ( 취소 때 사용 )
+    private String paymentKey;
+    // 세금 ( 토스 승인 이후 저장 )
+    @Embedded
+    @AttributeOverride(name = "amount", column = @Column(name = "vat_amount"))
+    private Money vat;
+
+    @Builder
+    public PgPaymentInfo(
+            PaymentMethod paymentMethod,
+            String paymentProvider,
+            String receiptUrl,
+            String paymentKey,
+            Money vat) {
+        this.paymentMethod = paymentMethod;
+        this.paymentProvider = paymentProvider;
+        this.receiptUrl = receiptUrl;
+        this.paymentKey = paymentKey;
+        this.vat = vat;
+    }
+
+    // PaymentsResponse infra layer
+    public static PgPaymentInfo from(PaymentsResponse paymentsResponse) {
+        return PgPaymentInfo.builder()
+                .paymentKey(paymentsResponse.getPaymentKey())
+                .paymentMethod(PaymentMethod.from(paymentsResponse.getMethod()))
+                .paymentProvider(paymentsResponse.getProviderName())
+                .receiptUrl(paymentsResponse.getReceipt().getUrl())
+                .vat(Money.wons(paymentsResponse.getVat()))
+                .build();
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/NotApprovalOrderException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/NotApprovalOrderException.java
@@ -1,0 +1,14 @@
+package band.gosrock.domain.domains.order.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+import band.gosrock.common.exception.ErrorCode;
+
+public class NotApprovalOrderException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new NotApprovalOrderException();
+
+    private NotApprovalOrderException() {
+        super(ErrorCode.ORDER_NOT_APPROVAL);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/NotPaymentOrderException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/NotPaymentOrderException.java
@@ -1,0 +1,14 @@
+package band.gosrock.domain.domains.order.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+import band.gosrock.common.exception.ErrorCode;
+
+public class NotPaymentOrderException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new NotPaymentOrderException();
+
+    private NotPaymentOrderException() {
+        super(ErrorCode.ORDER_NOT_PAYMENT);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/NotRefundAvailableDateOrderException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/NotRefundAvailableDateOrderException.java
@@ -1,0 +1,14 @@
+package band.gosrock.domain.domains.order.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+import band.gosrock.common.exception.ErrorCode;
+
+public class NotRefundAvailableDateOrderException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new NotRefundAvailableDateOrderException();
+
+    private NotRefundAvailableDateOrderException() {
+        super(ErrorCode.ORDER_NOT_REFUND_DATE);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CartToOrderService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CartToOrderService.java
@@ -21,7 +21,7 @@ public class CartToOrderService {
     @Transactional
     public Order creatOrderWithOutCoupon(Long cartId, Long userId) {
         Cart cart = cartAdaptor.queryCart(cartId, userId);
-        Order order = Order.createPaymentOrder(userId, cart);
+        Order order = Order.createOrder(userId, cart);
         order.calculatePaymentInfo();
         return orderAdaptor.save(order);
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderApproveService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderApproveService.java
@@ -1,0 +1,25 @@
+package band.gosrock.domain.domains.order.service;
+
+
+import band.gosrock.common.annotation.DomainService;
+import band.gosrock.domain.common.aop.redissonLock.RedissonLock;
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
+import band.gosrock.domain.domains.order.domain.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@DomainService
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderApproveService {
+
+    private final OrderAdaptor orderAdaptor;
+
+    @RedissonLock(LockName = "주문승인", identifier = "orderUuid")
+    public String execute(String orderUuid, Long userId) {
+        Order order = orderAdaptor.findByOrderUuid(orderUuid);
+        order.validOwner(userId);
+        order.approve();
+        return orderUuid;
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderApproveService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderApproveService.java
@@ -18,7 +18,7 @@ public class OrderApproveService {
     @RedissonLock(LockName = "주문승인", identifier = "orderUuid")
     public String execute(String orderUuid, Long userId) {
         Order order = orderAdaptor.findByOrderUuid(orderUuid);
-        order.validOwner(userId);
+        // TODO : 승인 주문 관리자 할당.
         order.approve();
         return orderUuid;
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderConfirmService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderConfirmService.java
@@ -6,7 +6,7 @@ import band.gosrock.domain.common.aop.redissonLock.RedissonLock;
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
-import band.gosrock.domain.domains.order.domain.PaymentMethod;
+import band.gosrock.domain.domains.order.domain.PgPaymentInfo;
 import band.gosrock.infrastructure.outer.api.tossPayments.client.PaymentsConfirmClient;
 import band.gosrock.infrastructure.outer.api.tossPayments.dto.request.ConfirmPaymentsRequest;
 import band.gosrock.infrastructure.outer.api.tossPayments.dto.response.PaymentsResponse;
@@ -29,23 +29,19 @@ public class OrderConfirmService {
             paramClassType = ConfirmPaymentsRequest.class)
     public String execute(ConfirmPaymentsRequest confirmPaymentsRequest, Long currentUserId) {
         Order order = orderAdaptor.findByOrderUuid(confirmPaymentsRequest.getOrderId());
-
+        Money paymentWons = Money.wons(confirmPaymentsRequest.getAmount());
         order.validOwner(currentUserId);
-        order.confirmPaymentOrder(Money.wons(confirmPaymentsRequest.getAmount()));
+        order.validCanConfirmPayment(paymentWons);
         // 결제 승인요청
         PaymentsResponse paymentsResponse = paymentsConfirmClient.execute(confirmPaymentsRequest);
         // TODO : 요청 보내고 난뒤에 도메인 로직 내부에서 실패하면 결제 강제 취소 로직 AOP로 개발 예정
         try {
-            // 실제 거래된 금액이 다를때
-            order.validPgAndOrderAmountIsEqual(Money.wons(paymentsResponse.getTotalAmount()));
+            Money pgAmount = Money.wons(paymentsResponse.getTotalAmount());
             // 결제 후처리 정보 업데이트
-            order.afterPaymentAddInfo(
+            order.confirmPayment(
+                    pgAmount,
                     paymentsResponse.getApprovedAt().toLocalDateTime(),
-                    PaymentMethod.from(paymentsResponse.getMethod()),
-                    Money.wons(paymentsResponse.getVat()),
-                    paymentsResponse.getProviderName(),
-                    paymentsResponse.getReceipt().getUrl(),
-                    paymentsResponse.getPaymentKey());
+                    PgPaymentInfo.from(paymentsResponse));
             return order.getUuid();
         } catch (Exception exception) {
             // 내부오류시 결제 강제 취소

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/WithdrawOrderService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/WithdrawOrderService.java
@@ -25,10 +25,10 @@ public class WithdrawOrderService {
         // TODO : 관리자 권환으로 치환.
         order.validOwner(userId);
         order.cancel();
-        if(order.isMethodPayment()) {
+        if (order.isMethodPayment()) {
             PaymentsResponse paymentsResponse =
-                withdrawPaymentService.execute(
-                    order.getUuid(), order.getPaymentKey(), "이벤트 관리자에 의한 취소");
+                    withdrawPaymentService.execute(
+                            order.getUuid(), order.getPaymentKey(), "이벤트 관리자에 의한 취소");
         }
         return orderUuid;
     }
@@ -38,10 +38,10 @@ public class WithdrawOrderService {
         Order order = orderAdaptor.findByOrderUuid(orderUuid);
         order.validOwner(userId);
         order.refund();
-        if(order.isMethodPayment()){
+        if (order.isMethodPayment()) {
             PaymentsResponse paymentsResponse =
-                withdrawPaymentService.execute(
-                    order.getUuid(), order.getPaymentKey(), "구매자에의한 환불 요청");
+                    withdrawPaymentService.execute(
+                            order.getUuid(), order.getPaymentKey(), "구매자에의한 환불 요청");
         }
         return orderUuid;
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/WithdrawOrderService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/WithdrawOrderService.java
@@ -25,10 +25,11 @@ public class WithdrawOrderService {
         // TODO : 관리자 권환으로 치환.
         order.validOwner(userId);
         order.cancel();
-        PaymentsResponse paymentsResponse =
+        if(order.isMethodPayment()) {
+            PaymentsResponse paymentsResponse =
                 withdrawPaymentService.execute(
-                        order.getUuid(), order.getPaymentKey(), "이벤트 관리자에 의한 취소");
-
+                    order.getUuid(), order.getPaymentKey(), "이벤트 관리자에 의한 취소");
+        }
         return orderUuid;
     }
 
@@ -37,11 +38,11 @@ public class WithdrawOrderService {
         Order order = orderAdaptor.findByOrderUuid(orderUuid);
         order.validOwner(userId);
         order.refund();
-
-        PaymentsResponse paymentsResponse =
+        if(order.isMethodPayment()){
+            PaymentsResponse paymentsResponse =
                 withdrawPaymentService.execute(
-                        order.getUuid(), order.getPaymentKey(), "구매자에의한 환불 요청");
-
+                    order.getUuid(), order.getPaymentKey(), "구매자에의한 환불 요청");
+        }
         return orderUuid;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketItem.java
@@ -92,4 +92,8 @@ public class TicketItem extends BaseTimeEntity {
     public RefundInfoVo getRefundInfoVo() {
         return event.getRefundInfoVo();
     }
+
+    public Boolean isNeedPayment(){
+        return this.type.isNeedPayment();
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketItem.java
@@ -93,7 +93,7 @@ public class TicketItem extends BaseTimeEntity {
         return event.getRefundInfoVo();
     }
 
-    public Boolean isNeedPayment(){
+    public Boolean isNeedPayment() {
         return this.type.isNeedPayment();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketType.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketType.java
@@ -12,4 +12,11 @@ public enum TicketType {
     // 승인
     APPROVAL("APPROVAL");
     private String value;
+
+    /**
+     * 결제가 필요한지 상태를 반환하는 메서드
+     */
+    public Boolean isNeedPayment(){
+        return this.equals(TicketType.FIRST_COME_FIRST_SERVED);
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketType.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketType.java
@@ -13,10 +13,8 @@ public enum TicketType {
     APPROVAL("APPROVAL");
     private String value;
 
-    /**
-     * 결제가 필요한지 상태를 반환하는 메서드
-     */
-    public Boolean isNeedPayment(){
+    /** 결제가 필요한지 상태를 반환하는 메서드 */
+    public Boolean isNeedPayment() {
         return this.equals(TicketType.FIRST_COME_FIRST_SERVED);
     }
 }


### PR DESCRIPTION
## 개요
- close #84 

## 작업사항
- orderMethod 를 따로 두어서 승인 방식 , 결제 방식 ( 토스로 결제해야하는 방식 ) 을 두었습니다
- orderMethod 가 나오는 부분은 item의 타입이 선착순이냐 승인이냐 에 따릅니다.
- 장바구니(카트)에 담기 요청 성공시 결제 방식이냐 승인 방식이냐를 구별해줍니다.
- 주문 철회 방식에 두가지를 냅뒀습니다.

주문자가 철회 -> 환불
이벤트 관리자나 관리자가 철회 -> 취소
로 구별해두었습니다.

주문 승인 , 주문 결제 등 Redisson 락 달아뒀습니다.

## 변경로직
- 기존 PG 대행사의 응답값을 order 에 넣어놨었는데
- PgPaymentInfo 로 vo 로 빼버렸습니다.
