### PR TITLE
refactor : 에러코드 도메인 별로 분할 (#117)

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/example/controller/ExampleController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/example/controller/ExampleController.java
@@ -9,6 +9,8 @@ import band.gosrock.common.annotation.ApiErrorCodeExample;
 import band.gosrock.common.annotation.ApiErrorExceptionsExample;
 import band.gosrock.common.annotation.DevelopOnlyApi;
 import band.gosrock.common.exception.GlobalErrorCode;
+import band.gosrock.domain.domains.cart.exception.CartErrorCode;
+import band.gosrock.domain.domains.issuedTicket.exception.IssuedTicketErrorCode;
 import band.gosrock.domain.domains.order.exception.OrderErrorCode;
 import band.gosrock.domain.domains.user.exception.UserErrorCode;
 import band.gosrock.infrastructure.outer.api.tossPayments.exception.PaymentsCancelErrorCode;
@@ -63,6 +65,18 @@ public class ExampleController {
     @Operation(summary = "주문 도메인 관련 에러 코드 나열")
     @ApiErrorCodeExample(OrderErrorCode.class)
     public void getOrderErrorCode() {}
+
+    @GetMapping("/cart")
+    @DevelopOnlyApi
+    @Operation(summary = "주문 도메인 관련 에러 코드 나열")
+    @ApiErrorCodeExample(CartErrorCode.class)
+    public void getCartErrorCode() {}
+
+    @GetMapping("/issuedTicket")
+    @DevelopOnlyApi
+    @Operation(summary = "주문 도메인 관련 에러 코드 나열")
+    @ApiErrorCodeExample(IssuedTicketErrorCode.class)
+    public void getIssuedTicketErrorCode() {}
 
     @GetMapping("/toss/create")
     @DevelopOnlyApi

--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/GlobalErrorCode.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/GlobalErrorCode.java
@@ -48,8 +48,6 @@ public enum GlobalErrorCode implements BaseErrorCode {
     TOSS_PAYMENTS_UNHANDLED(INTERNAL_SERVER, "PAYMENTS_INTERNAL_SERVER", "관리자에게 연락부탁드려요."),
     BAD_LOCK_IDENTIFIER(500, "AOP_500_1", "락의 키값이 잘못 세팅 되었습니다"),
     BAD_FILE_EXTENSION(BAD_REQUEST, "FILE_400_1", "파일 확장자가 잘못 되었습니다."),
-    CART_NOT_FOUND(NOT_FOUND, "Cart_404_1", "Cart Not Found."),
-
     ISSUED_TICKET_NOT_FOUND(NOT_FOUND, "IssuedTicket_404_1", "IssuedTicket Not Found"),
     ISSUED_TICKET_NOT_MATCHED_USER(
             FORBIDDEN, "IssuedTicket_403_1", "IssuedTicket User Not Matched"),

--- a/DuDoong-Common/src/main/java/band/gosrock/common/exception/GlobalErrorCode.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/exception/GlobalErrorCode.java
@@ -48,13 +48,7 @@ public enum GlobalErrorCode implements BaseErrorCode {
     TOSS_PAYMENTS_UNHANDLED(INTERNAL_SERVER, "PAYMENTS_INTERNAL_SERVER", "관리자에게 연락부탁드려요."),
     BAD_LOCK_IDENTIFIER(500, "AOP_500_1", "락의 키값이 잘못 세팅 되었습니다"),
     BAD_FILE_EXTENSION(BAD_REQUEST, "FILE_400_1", "파일 확장자가 잘못 되었습니다."),
-    ISSUED_TICKET_NOT_FOUND(NOT_FOUND, "IssuedTicket_404_1", "IssuedTicket Not Found"),
-    ISSUED_TICKET_NOT_MATCHED_USER(
-            FORBIDDEN, "IssuedTicket_403_1", "IssuedTicket User Not Matched"),
-    TOSS_PAYMENTS_ENUM_NOT_MATCH(INTERNAL_SERVER, "INFRA_500_1", "토스페이먼츠 이넘값 관련 매칭 안된 문제입니다."),
-
-    EVENT_NOT_FOUND(NOT_FOUND, "Event_404_1", "Event Not Found"),
-    HOST_NOT_AUTH_EVENT(FORBIDDEN, "Event_403_1", "Host Not Auth Event");
+    TOSS_PAYMENTS_ENUM_NOT_MATCH(INTERNAL_SERVER, "INFRA_500_1", "토스페이먼츠 이넘값 관련 매칭 안된 문제입니다.");
     private Integer status;
     private String code;
     private String reason;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/exception/CartErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/exception/CartErrorCode.java
@@ -1,6 +1,5 @@
 package band.gosrock.domain.domains.cart.exception;
 
-import static band.gosrock.common.consts.DuDoongStatic.BAD_REQUEST;
 import static band.gosrock.common.consts.DuDoongStatic.NOT_FOUND;
 
 import band.gosrock.common.annotation.ExplainError;
@@ -17,18 +16,13 @@ public enum CartErrorCode implements BaseErrorCode {
     @ExplainError("id로 카트를 찾을 때 못 찾으면 발생하는 오류")
     CART_NOT_FOUND(NOT_FOUND, "Cart_404_1", "장바구니를 찾을 수 없습니다.");
 
-
     private Integer status;
     private String code;
     private String reason;
 
     @Override
     public ErrorReason getErrorReason() {
-        return ErrorReason.builder()
-                .reason(reason)
-                .code(code)
-                .status(status)
-                .build();
+        return ErrorReason.builder().reason(reason).code(code).status(status).build();
     }
 
     @Override

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/exception/CartErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/exception/CartErrorCode.java
@@ -1,0 +1,40 @@
+package band.gosrock.domain.domains.cart.exception;
+
+import static band.gosrock.common.consts.DuDoongStatic.BAD_REQUEST;
+import static band.gosrock.common.consts.DuDoongStatic.NOT_FOUND;
+
+import band.gosrock.common.annotation.ExplainError;
+import band.gosrock.common.dto.ErrorReason;
+import band.gosrock.common.exception.BaseErrorCode;
+import java.lang.reflect.Field;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CartErrorCode implements BaseErrorCode {
+    @ExplainError("id로 카트를 찾을 때 못 찾으면 발생하는 오류")
+    CART_NOT_FOUND(NOT_FOUND, "Cart_404_1", "장바구니를 찾을 수 없습니다.");
+
+
+    private Integer status;
+    private String code;
+    private String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.builder()
+                .reason(reason)
+                .code(code)
+                .status(status)
+                .build();
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getReason();
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/exception/CartNotFoundException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/exception/CartNotFoundException.java
@@ -9,6 +9,6 @@ public class CartNotFoundException extends DuDoongCodeException {
     public static final DuDoongCodeException EXCEPTION = new CartNotFoundException();
 
     private CartNotFoundException() {
-        super(GlobalErrorCode.CART_NOT_FOUND);
+        super(CartErrorCode.CART_NOT_FOUND);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/exception/CartNotFoundException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/exception/CartNotFoundException.java
@@ -2,7 +2,6 @@ package band.gosrock.domain.domains.cart.exception;
 
 
 import band.gosrock.common.exception.DuDoongCodeException;
-import band.gosrock.common.exception.GlobalErrorCode;
 
 public class CartNotFoundException extends DuDoongCodeException {
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/EventErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/EventErrorCode.java
@@ -1,7 +1,6 @@
 package band.gosrock.domain.domains.event.exception;
 
 import static band.gosrock.common.consts.DuDoongStatic.BAD_REQUEST;
-import static band.gosrock.common.consts.DuDoongStatic.FORBIDDEN;
 import static band.gosrock.common.consts.DuDoongStatic.NOT_FOUND;
 
 import band.gosrock.common.annotation.ExplainError;
@@ -15,7 +14,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum EventErrorCode implements BaseErrorCode {
-
     EVENT_NOT_FOUND(NOT_FOUND, "Event_404_1", "이벤트를 찾을 수 없습니다."),
     HOST_NOT_AUTH_EVENT(BAD_REQUEST, "Event_400_1", "Host Not Auth Event");
     private Integer status;
@@ -24,11 +22,7 @@ public enum EventErrorCode implements BaseErrorCode {
 
     @Override
     public ErrorReason getErrorReason() {
-        return ErrorReason.builder()
-                .reason(reason)
-                .code(code)
-                .status(status)
-                .build();
+        return ErrorReason.builder().reason(reason).code(code).status(status).build();
     }
 
     @Override

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/EventErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/EventErrorCode.java
@@ -1,0 +1,40 @@
+package band.gosrock.domain.domains.event.exception;
+
+import static band.gosrock.common.consts.DuDoongStatic.BAD_REQUEST;
+import static band.gosrock.common.consts.DuDoongStatic.FORBIDDEN;
+import static band.gosrock.common.consts.DuDoongStatic.NOT_FOUND;
+
+import band.gosrock.common.annotation.ExplainError;
+import band.gosrock.common.dto.ErrorReason;
+import band.gosrock.common.exception.BaseErrorCode;
+import java.lang.reflect.Field;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EventErrorCode implements BaseErrorCode {
+
+    EVENT_NOT_FOUND(NOT_FOUND, "Event_404_1", "이벤트를 찾을 수 없습니다."),
+    HOST_NOT_AUTH_EVENT(BAD_REQUEST, "Event_400_1", "Host Not Auth Event");
+    private Integer status;
+    private String code;
+    private String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.builder()
+                .reason(reason)
+                .code(code)
+                .status(status)
+                .build();
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getReason();
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/EventNotFoundException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/EventNotFoundException.java
@@ -9,6 +9,6 @@ public class EventNotFoundException extends DuDoongCodeException {
     public static final DuDoongCodeException EXCEPTION = new EventNotFoundException();
 
     private EventNotFoundException() {
-        super(GlobalErrorCode.EVENT_NOT_FOUND);
+        super(EventErrorCode.EVENT_NOT_FOUND);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/EventNotFoundException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/EventNotFoundException.java
@@ -2,7 +2,6 @@ package band.gosrock.domain.domains.event.exception;
 
 
 import band.gosrock.common.exception.DuDoongCodeException;
-import band.gosrock.common.exception.GlobalErrorCode;
 
 public class EventNotFoundException extends DuDoongCodeException {
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/HostNotAuthEventException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/HostNotAuthEventException.java
@@ -9,6 +9,6 @@ public class HostNotAuthEventException extends DuDoongCodeException {
     public static final DuDoongCodeException EXCEPTION = new HostNotAuthEventException();
 
     private HostNotAuthEventException() {
-        super(GlobalErrorCode.HOST_NOT_AUTH_EVENT);
+        super(EventErrorCode.HOST_NOT_AUTH_EVENT);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/HostNotAuthEventException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/HostNotAuthEventException.java
@@ -2,7 +2,6 @@ package band.gosrock.domain.domains.event.exception;
 
 
 import band.gosrock.common.exception.DuDoongCodeException;
-import band.gosrock.common.exception.GlobalErrorCode;
 
 public class HostNotAuthEventException extends DuDoongCodeException {
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketErrorCode.java
@@ -1,0 +1,41 @@
+package band.gosrock.domain.domains.issuedTicket.exception;
+
+import static band.gosrock.common.consts.DuDoongStatic.BAD_REQUEST;
+import static band.gosrock.common.consts.DuDoongStatic.FORBIDDEN;
+import static band.gosrock.common.consts.DuDoongStatic.NOT_FOUND;
+
+import band.gosrock.common.annotation.ExplainError;
+import band.gosrock.common.dto.ErrorReason;
+import band.gosrock.common.exception.BaseErrorCode;
+import java.lang.reflect.Field;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum IssuedTicketErrorCode implements BaseErrorCode {
+    ISSUED_TICKET_NOT_FOUND(NOT_FOUND, "IssuedTicket_404_1", "IssuedTicket Not Found"),
+    ISSUED_TICKET_NOT_MATCHED_USER(
+        BAD_REQUEST, "IssuedTicket_400_1", "IssuedTicket User Not Matched");
+
+    private Integer status;
+    private String code;
+    private String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.builder()
+                .reason(reason)
+                .code(code)
+                .status(status)
+                .build();
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getReason();
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketErrorCode.java
@@ -1,7 +1,6 @@
 package band.gosrock.domain.domains.issuedTicket.exception;
 
 import static band.gosrock.common.consts.DuDoongStatic.BAD_REQUEST;
-import static band.gosrock.common.consts.DuDoongStatic.FORBIDDEN;
 import static band.gosrock.common.consts.DuDoongStatic.NOT_FOUND;
 
 import band.gosrock.common.annotation.ExplainError;
@@ -17,7 +16,7 @@ import lombok.Getter;
 public enum IssuedTicketErrorCode implements BaseErrorCode {
     ISSUED_TICKET_NOT_FOUND(NOT_FOUND, "IssuedTicket_404_1", "IssuedTicket Not Found"),
     ISSUED_TICKET_NOT_MATCHED_USER(
-        BAD_REQUEST, "IssuedTicket_400_1", "IssuedTicket User Not Matched");
+            BAD_REQUEST, "IssuedTicket_400_1", "IssuedTicket User Not Matched");
 
     private Integer status;
     private String code;
@@ -25,11 +24,7 @@ public enum IssuedTicketErrorCode implements BaseErrorCode {
 
     @Override
     public ErrorReason getErrorReason() {
-        return ErrorReason.builder()
-                .reason(reason)
-                .code(code)
-                .status(status)
-                .build();
+        return ErrorReason.builder().reason(reason).code(code).status(status).build();
     }
 
     @Override

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketNotFoundException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketNotFoundException.java
@@ -2,7 +2,6 @@ package band.gosrock.domain.domains.issuedTicket.exception;
 
 
 import band.gosrock.common.exception.DuDoongCodeException;
-import band.gosrock.common.exception.GlobalErrorCode;
 
 public class IssuedTicketNotFoundException extends DuDoongCodeException {
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketNotFoundException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketNotFoundException.java
@@ -9,6 +9,6 @@ public class IssuedTicketNotFoundException extends DuDoongCodeException {
     public static final DuDoongCodeException EXCEPTION = new IssuedTicketNotFoundException();
 
     private IssuedTicketNotFoundException() {
-        super(GlobalErrorCode.ISSUED_TICKET_NOT_FOUND);
+        super(IssuedTicketErrorCode.ISSUED_TICKET_NOT_FOUND);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketUserNotMatchedException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketUserNotMatchedException.java
@@ -2,7 +2,6 @@ package band.gosrock.domain.domains.issuedTicket.exception;
 
 
 import band.gosrock.common.exception.DuDoongCodeException;
-import band.gosrock.common.exception.GlobalErrorCode;
 
 public class IssuedTicketUserNotMatchedException extends DuDoongCodeException {
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketUserNotMatchedException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketUserNotMatchedException.java
@@ -9,6 +9,6 @@ public class IssuedTicketUserNotMatchedException extends DuDoongCodeException {
     public static final DuDoongCodeException EXCEPTION = new IssuedTicketUserNotMatchedException();
 
     private IssuedTicketUserNotMatchedException() {
-        super(GlobalErrorCode.ISSUED_TICKET_NOT_MATCHED_USER);
+        super(IssuedTicketErrorCode.ISSUED_TICKET_NOT_MATCHED_USER);
     }
 }


### PR DESCRIPTION
## 개요
- close #117  

## 작업사항
- 에러코드를 도메인별루 분할시켰습니다.
- 컨플릭트 날 위험이 줄었습니다.
- 앞으로 작업하실때 도메인 내부에 에러코드 위치시켜주세요
- 글로벌 성격띄는건 글로벌에 놔주시고!!



## 변경로직
- 민준이 에러코드에서 403 반환하는건 400으로 변환했습니다!
- 왜냐면 클라쪽에 403잡으면 바로 로그아웃 시키는 로직으로 하기로해서
- 401, 403 상태코드는 왠만하면 안쓰시면 되겠습니다!!
- 400, 404 위주로 활용해주세염