### PR TITLE
refactor : 쿠폰 캠페인 생성 리팩토링 (#137)

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/coupon/dto/reqeust/CreateCouponCampaignRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/coupon/dto/reqeust/CreateCouponCampaignRequest.java
@@ -1,10 +1,7 @@
 package band.gosrock.api.coupon.dto.reqeust;
 
 
-import band.gosrock.domain.domains.coupon.domain.ApplyTarget;
-import band.gosrock.domain.domains.coupon.domain.CouponCampaign;
-import band.gosrock.domain.domains.coupon.domain.CouponStockInfo;
-import band.gosrock.domain.domains.coupon.domain.DiscountType;
+import band.gosrock.domain.domains.coupon.domain.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import javax.validation.constraints.Future;
@@ -59,14 +56,15 @@ public class CreateCouponCampaignRequest {
                         .issuedAmount(issuedAmount)
                         .remainingAmount(issuedAmount)
                         .build();
+        DateTimePeriod dateTimePeriod =
+                DateTimePeriod.builder().startAt(startAt).endAt(endAt).build();
 
         return CouponCampaign.builder()
                 .hostId(hostId)
                 .discountType(discountType)
                 .applyTarget(applyTarget)
                 .validTerm(validTerm)
-                .startAt(startAt)
-                .endAt(endAt)
+                .dateTimePeriod(dateTimePeriod)
                 .couponStockInfo(couponStockInfo)
                 .discountAmount(discountAmount)
                 .couponCode(couponCode)

--- a/DuDoong-Api/src/main/java/band/gosrock/api/coupon/dto/reqeust/CreateCouponCampaignRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/coupon/dto/reqeust/CreateCouponCampaignRequest.java
@@ -1,6 +1,7 @@
 package band.gosrock.api.coupon.dto.reqeust;
 
 
+import band.gosrock.domain.common.vo.DateTimePeriod;
 import band.gosrock.domain.domains.coupon.domain.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/coupon/service/CreateCouponUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/coupon/service/CreateCouponUseCase.java
@@ -6,7 +6,6 @@ import band.gosrock.api.coupon.dto.reqeust.CreateCouponCampaignRequest;
 import band.gosrock.api.coupon.dto.response.CreateCouponCampaignResponse;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.coupon.domain.CouponCampaign;
-import band.gosrock.domain.domains.coupon.repository.CouponCampaignRepository;
 import band.gosrock.domain.domains.coupon.service.CreateCouponCampaignDomainService;
 import band.gosrock.domain.domains.user.service.UserDomainService;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +17,6 @@ public class CreateCouponUseCase {
 
     private final UserDomainService userDomainService;
     private final CreateCouponCampaignDomainService createCouponCampaignDomainService;
-    private final CouponCampaignRepository couponCampaignRepository;
 
     @Transactional
     public CreateCouponCampaignResponse execute(
@@ -32,7 +30,8 @@ public class CreateCouponUseCase {
                 createCouponCampaignRequest.getCouponCode());
         // 쿠폰 생성
         CouponCampaign couponCampaign =
-                couponCampaignRepository.save(createCouponCampaignRequest.toOnceEntity());
+                createCouponCampaignDomainService.createCouponCampaign(
+                        createCouponCampaignRequest.toOnceEntity());
         return CreateCouponCampaignResponse.of(couponCampaign, couponCampaign.getHostId());
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/DateTimePeriod.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/DateTimePeriod.java
@@ -1,4 +1,4 @@
-package band.gosrock.domain.domains.coupon.domain;
+package band.gosrock.domain.common.vo;
 
 
 import java.time.LocalDateTime;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/adaptor/CouponCampaignAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/adaptor/CouponCampaignAdaptor.java
@@ -1,0 +1,23 @@
+package band.gosrock.domain.domains.coupon.adaptor;
+
+
+import band.gosrock.common.annotation.Adaptor;
+import band.gosrock.domain.domains.coupon.domain.CouponCampaign;
+import band.gosrock.domain.domains.coupon.exception.AlreadyExistCouponCampaignException;
+import band.gosrock.domain.domains.coupon.repository.CouponCampaignRepository;
+import lombok.RequiredArgsConstructor;
+
+@Adaptor
+@RequiredArgsConstructor
+public class CouponCampaignAdaptor {
+    private final CouponCampaignRepository couponCampaignRepository;
+
+    public CouponCampaign save(CouponCampaign couponCampaign) {
+        return couponCampaignRepository.save(couponCampaign);
+    }
+
+    public void existsByCouponCode(String couponCode) {
+        if (couponCampaignRepository.existsByCouponCode(couponCode))
+            throw AlreadyExistCouponCampaignException.EXCEPTION;
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/CouponCampaign.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/CouponCampaign.java
@@ -2,7 +2,6 @@ package band.gosrock.domain.domains.coupon.domain;
 
 
 import band.gosrock.domain.common.model.BaseTimeEntity;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.*;
@@ -36,11 +35,10 @@ public class CouponCampaign extends BaseTimeEntity {
     // 사용기한(일자) ex.10 -> 발급 이후 10일 동안 쿠폰 사용 가능
     private Long validTerm;
 
-    // 쿠폰 발행 시작 시각
-    private LocalDateTime startAt;
-    // 쿠폰 발행 마감 시각
-    private LocalDateTime endAt;
+    // 쿠폰 발행 가능 기간
+    @Embedded private DateTimePeriod dateTimePeriod;
 
+    // 쿠폰 총 발행량 및 잔량
     @Embedded private CouponStockInfo couponStockInfo;
 
     private Long discountAmount;
@@ -56,8 +54,7 @@ public class CouponCampaign extends BaseTimeEntity {
             DiscountType discountType,
             ApplyTarget applyTarget,
             Long validTerm,
-            LocalDateTime startAt,
-            LocalDateTime endAt,
+            DateTimePeriod dateTimePeriod,
             CouponStockInfo couponStockInfo,
             Long discountAmount,
             String couponCode) {
@@ -65,8 +62,7 @@ public class CouponCampaign extends BaseTimeEntity {
         this.discountType = discountType;
         this.applyTarget = applyTarget;
         this.validTerm = validTerm;
-        this.startAt = startAt;
-        this.endAt = endAt;
+        this.dateTimePeriod = dateTimePeriod;
         this.couponStockInfo = couponStockInfo;
         this.discountAmount = discountAmount;
         this.couponCode = couponCode;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/CouponCampaign.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/CouponCampaign.java
@@ -2,6 +2,7 @@ package band.gosrock.domain.domains.coupon.domain;
 
 
 import band.gosrock.domain.common.model.BaseTimeEntity;
+import band.gosrock.domain.common.vo.DateTimePeriod;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.*;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/DateTimePeriod.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/DateTimePeriod.java
@@ -1,0 +1,34 @@
+package band.gosrock.domain.domains.coupon.domain;
+
+
+import java.time.LocalDateTime;
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DateTimePeriod {
+    // 쿠폰 발행 시작 시각
+    private LocalDateTime startAt;
+    // 쿠폰 발행 마감 시각
+    private LocalDateTime endAt;
+
+    @Builder
+    public DateTimePeriod(LocalDateTime startAt, LocalDateTime endAt) {
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
+
+    public static DateTimePeriod between(LocalDateTime startAt, LocalDateTime endAt) {
+        return new DateTimePeriod(startAt, endAt);
+    }
+
+    public boolean contains(LocalDateTime datetime) {
+        return (datetime.isAfter(startAt) || datetime.equals(startAt))
+                && (datetime.isBefore(endAt) || datetime.equals(endAt));
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/service/CreateCouponCampaignDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/service/CreateCouponCampaignDomainService.java
@@ -2,8 +2,8 @@ package band.gosrock.domain.domains.coupon.service;
 
 
 import band.gosrock.common.annotation.DomainService;
-import band.gosrock.domain.domains.coupon.exception.AlreadyExistCouponCampaignException;
-import band.gosrock.domain.domains.coupon.repository.CouponCampaignRepository;
+import band.gosrock.domain.domains.coupon.adaptor.CouponCampaignAdaptor;
+import band.gosrock.domain.domains.coupon.domain.CouponCampaign;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,12 +11,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CreateCouponCampaignDomainService {
 
-    private final CouponCampaignRepository couponCampaignRepository;
+    private final CouponCampaignAdaptor couponCampaignAdaptor;
 
     @Transactional(readOnly = true)
     public void checkCouponCodeExists(String couponCode) {
-        if (couponCampaignRepository.existsByCouponCode(couponCode)) {
-            throw AlreadyExistCouponCampaignException.EXCEPTION;
-        }
+        couponCampaignAdaptor.existsByCouponCode(couponCode);
+    }
+
+    @Transactional
+    public CouponCampaign createCouponCampaign(CouponCampaign couponCampaign) {
+        return couponCampaignAdaptor.save(couponCampaign);
     }
 }


### PR DESCRIPTION
## 개요
- close #137 

## 작업사항
- adaptor 생성 후 일부 로직 변경했습니다.
- 서비스단에서 바로 레포지토리 노출하지 않고 도메인 서비스로 넘긴 후 adaptor로 감싸 처리했습니다.
- 쿠폰 발행 가능 기간 vo로 만들어서 관리하는 방식으로 변경했습니다.
[참고한 링크](https://github.com/eternity-oop/Woowahan-OO-01-object-reference/blob/master/src/main/java/org/eternity/food/domain/generic/time/DateTimePeriod.java)

## 변경로직
- 위와 동일 