### PR TITLE
feat : 호스트 상세조회 및 가입 기능

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
@@ -2,8 +2,11 @@ package band.gosrock.api.host.controller;
 
 
 import band.gosrock.api.host.model.dto.request.CreateHostRequest;
+import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.api.host.model.dto.response.HostResponse;
 import band.gosrock.api.host.service.CreateHostUseCase;
+import band.gosrock.api.host.service.JoinHostUseCase;
+import band.gosrock.api.host.service.ReadHostListUseCase;
 import band.gosrock.api.host.service.ReadHostUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -20,18 +23,32 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class HostController {
 
-    private final CreateHostUseCase createHostUseCase;
     private final ReadHostUseCase readHostUseCase;
+    private final ReadHostListUseCase readHostListUseCase;
+    private final CreateHostUseCase createHostUseCase;
+    private final JoinHostUseCase joinHostUseCase;
 
-    @Operation(summary = "내가 속한 호스트 리스트를 가져옵니다")
+    @Operation(summary = "내가 속한 호스트 리스트를 가져옵니다.")
     @GetMapping
     public List<HostResponse> getAllHosts() {
-        return readHostUseCase.execute();
+        return readHostListUseCase.execute();
     }
 
-    @Operation(summary = "새로운 이벤트(공연)를 생성합니다")
+    @Operation(summary = "새로운 호스트를 생성합니다. 호스트를 생성한 유저 자신은 슈퍼호스트가 됩니다.")
     @PostMapping
-    public HostResponse createEvent(@RequestBody @Valid CreateHostRequest createEventRequest) {
+    public HostResponse createHost(@RequestBody @Valid CreateHostRequest createEventRequest) {
         return createHostUseCase.execute(createEventRequest);
+    }
+
+    @Operation(summary = "내가 속해있는, 고유 아이디에 해당하는 호스트 정보를 가져옵니다.")
+    @GetMapping("/{hostId}")
+    public HostDetailResponse getHostById(@PathVariable Long hostId) {
+        return readHostUseCase.execute(hostId);
+    }
+
+    @Operation(summary = "기존 호스트에 가입합니다.")
+    @PostMapping("/{hostId}/join")
+    public HostDetailResponse joinHost(@PathVariable Long hostId) {
+        return joinHostUseCase.execute(hostId);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/HostDetailResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/HostDetailResponse.java
@@ -1,0 +1,56 @@
+package band.gosrock.api.host.model.dto.response;
+
+
+import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.domain.HostRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class HostDetailResponse {
+    @Schema(description = "담당자 이메일")
+    private final String contactEmail;
+
+    @Schema(description = "담당자 전화번호")
+    private final String contactNumber;
+
+    //    @Schema(description = "마스터 유저의 정보")
+    //    private final UserInfoVo masterUserInfoVo;
+    //
+    //    @Schema(description = "호스트 유저 정보")
+    //    private final Set<UserInfoVo> userInfoVoList;
+    // todo:: UserRole 에서 Set<User> 추출해서 VO 리스트로 넣기
+
+    @Schema(description = "마스터 유저의 아이디")
+    private final Long masterUserId;
+
+    @Schema(description = "호스트 유저 아이디")
+    private final Set<Long> userId;
+
+    @Schema(description = "파트너쉽 여부")
+    private final boolean partner;
+
+    public static HostDetailResponse of(Host host) {
+        HostDetailResponseBuilder builder = HostDetailResponse.builder();
+        Set<Long> userIdList = new HashSet<>();
+        host.getHostUsers()
+                .forEach(
+                        hostUser -> {
+                            if (hostUser.getRole().equals(HostRole.SUPER_HOST)) {
+                                builder.masterUserId(hostUser.getUserId());
+                            } else {
+                                userIdList.add(hostUser.getUserId());
+                            }
+                        });
+
+        return builder.contactEmail(host.getContactEmail())
+                .contactNumber(host.getContactNumber())
+                .userId(userIdList)
+                .partner(host.getPartner())
+                .build();
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/CreateHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/CreateHostUseCase.java
@@ -5,8 +5,8 @@ import band.gosrock.api.config.security.SecurityUtils;
 import band.gosrock.api.host.model.dto.request.CreateHostRequest;
 import band.gosrock.api.host.model.dto.response.HostResponse;
 import band.gosrock.common.annotation.UseCase;
-import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.domain.HostRole;
 import band.gosrock.domain.domains.host.service.HostService;
 import band.gosrock.domain.domains.user.domain.User;
 import band.gosrock.domain.domains.user.service.UserDomainService;
@@ -19,7 +19,6 @@ public class CreateHostUseCase {
 
     private final UserDomainService userDomainService;
     private final HostService hostService;
-    private final HostAdaptor hostAdaptor;
 
     @Transactional
     public HostResponse execute(CreateHostRequest createHostRequest) {
@@ -36,6 +35,6 @@ public class CreateHostUseCase {
                                 .masterUserId(securityUserId)
                                 .build());
         // todo :: host 생성 레이어 찾기
-        return HostResponse.of(hostService.addHostUser(host, securityUserId));
+        return HostResponse.of(hostService.addHostUser(host, securityUserId, HostRole.SUPER_HOST));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/JoinHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/JoinHostUseCase.java
@@ -7,7 +7,6 @@ import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.host.domain.HostRole;
-import band.gosrock.domain.domains.host.domain.HostUser;
 import band.gosrock.domain.domains.host.exception.AlreadyJoinedHostException;
 import band.gosrock.domain.domains.host.service.HostService;
 import band.gosrock.domain.domains.user.domain.User;
@@ -29,11 +28,9 @@ public class JoinHostUseCase {
         final User user = userDomainService.retrieveUser(securityUserId);
         final Host host = hostAdaptor.findById(hostId);
 
-        for (HostUser hostUser : host.getHostUsers()) {
-            // 이 호스트에 이미 속함
-            if (hostUser.getUserId().equals(securityUserId)) {
-                throw AlreadyJoinedHostException.EXCEPTION;
-            }
+        // 이 호스트에 이미 속함
+        if (hostService.hasHostUser(host, securityUserId)) {
+            throw AlreadyJoinedHostException.EXCEPTION;
         }
         return HostDetailResponse.of(hostService.addHostUser(host, securityUserId, HostRole.HOST));
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/JoinHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/JoinHostUseCase.java
@@ -6,8 +6,10 @@ import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.domain.HostRole;
 import band.gosrock.domain.domains.host.domain.HostUser;
-import band.gosrock.domain.domains.host.exception.ForbiddenHostException;
+import band.gosrock.domain.domains.host.exception.AlreadyJoinedHostException;
+import band.gosrock.domain.domains.host.service.HostService;
 import band.gosrock.domain.domains.user.domain.User;
 import band.gosrock.domain.domains.user.service.UserDomainService;
 import lombok.RequiredArgsConstructor;
@@ -15,22 +17,24 @@ import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class ReadHostUseCase {
+public class JoinHostUseCase {
+
     private final UserDomainService userDomainService;
+    private final HostService hostService;
     private final HostAdaptor hostAdaptor;
 
+    @Transactional
     public HostDetailResponse execute(Long hostId) {
         final Long securityUserId = SecurityUtils.getCurrentUserId();
         final User user = userDomainService.retrieveUser(securityUserId);
         final Host host = hostAdaptor.findById(hostId);
+
         for (HostUser hostUser : host.getHostUsers()) {
-            // 이 호스트에 속한 유저에게 접근 인가
+            // 이 호스트에 이미 속함
             if (hostUser.getUserId().equals(securityUserId)) {
-                return HostDetailResponse.of(host);
+                throw AlreadyJoinedHostException.EXCEPTION;
             }
         }
-        // 이 호스트에 대한 접근 권한이 없음
-        throw ForbiddenHostException.EXCEPTION;
+        return HostDetailResponse.of(hostService.addHostUser(host, securityUserId, HostRole.HOST));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostListUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostListUseCase.java
@@ -1,0 +1,29 @@
+package band.gosrock.api.host.service;
+
+
+import band.gosrock.api.config.security.SecurityUtils;
+import band.gosrock.api.host.model.dto.response.HostResponse;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
+import band.gosrock.domain.domains.user.domain.User;
+import band.gosrock.domain.domains.user.service.UserDomainService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReadHostListUseCase {
+    private final UserDomainService userDomainService;
+    private final HostAdaptor hostAdaptor;
+
+    public List<HostResponse> execute() {
+        Long securityUserId = SecurityUtils.getCurrentUserId();
+        User user = userDomainService.retrieveUser(securityUserId);
+        // Todo:: hostId로 변경필요
+        return hostAdaptor.findAllByMasterUserId(securityUserId).stream()
+                .map(HostResponse::of)
+                .toList();
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostUseCase.java
@@ -6,8 +6,6 @@ import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
-import band.gosrock.domain.domains.host.domain.HostUser;
-import band.gosrock.domain.domains.host.exception.ForbiddenHostException;
 import band.gosrock.domain.domains.user.domain.User;
 import band.gosrock.domain.domains.user.service.UserDomainService;
 import lombok.RequiredArgsConstructor;
@@ -24,13 +22,6 @@ public class ReadHostUseCase {
         final Long securityUserId = SecurityUtils.getCurrentUserId();
         final User user = userDomainService.retrieveUser(securityUserId);
         final Host host = hostAdaptor.findById(hostId);
-        for (HostUser hostUser : host.getHostUsers()) {
-            // 이 호스트에 속한 유저에게 접근 인가
-            if (hostUser.getUserId().equals(securityUserId)) {
-                return HostDetailResponse.of(host);
-            }
-        }
-        // 이 호스트에 대한 접근 권한이 없음
-        throw ForbiddenHostException.EXCEPTION;
+        return HostDetailResponse.of(host);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/AlreadyJoinedHostException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/AlreadyJoinedHostException.java
@@ -1,0 +1,12 @@
+package band.gosrock.domain.domains.host.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class AlreadyJoinedHostException extends DuDoongCodeException {
+    public static final DuDoongCodeException EXCEPTION = new AlreadyJoinedHostException();
+
+    private AlreadyJoinedHostException() {
+        super(HostErrorCode.ALREADY_JOINED_HOST);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/ForbiddenHostException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/ForbiddenHostException.java
@@ -1,0 +1,12 @@
+package band.gosrock.domain.domains.host.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class ForbiddenHostException extends DuDoongCodeException {
+    public static final DuDoongCodeException EXCEPTION = new ForbiddenHostException();
+
+    private ForbiddenHostException() {
+        super(HostErrorCode.FORBIDDEN_HOST);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostErrorCode.java
@@ -15,7 +15,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum HostErrorCode implements BaseErrorCode {
     HOST_NOT_FOUND(NOT_FOUND, "Host_404_1", "해당 호스트를 찾을 수 없습니다."),
-    NOT_SUPER_HOST(BAD_REQUEST, "HOST_400_1", "슈퍼 호스트 권한이 없는 유저입니다");
+    NOT_SUPER_HOST(BAD_REQUEST, "HOST_400_1", "슈퍼 호스트 권한이 없는 유저입니다."),
+    FORBIDDEN_HOST(BAD_REQUEST, "HOST_400_2", "해당 호스트에 대한 접근 권한이 없습니다."),
+    ALREADY_JOINED_HOST(BAD_REQUEST, "HOST_400_3", "이미 가입되어 있는 호스트입니다.");
 
     private Integer status;
     private String code;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
@@ -34,6 +34,12 @@ public class HostService {
         return hostRepository.save(host);
     }
 
+    /** 해당 호스트 유저에 특정 userId 가 포함되어 있는지 반환하는 로직입니다 */
+    public Boolean hasHostUser(Host host, Long userId) {
+        return host.getHostUsers().stream()
+                .anyMatch(hostUser -> hostUser.getUserId().equals(userId));
+    }
+
     /** 해당 유저가 호스트의 마스터(담당자, 방장)인지 확인하는 검증 로직입니다 */
     public void checkSuperHost(Long hostId, Long userId) {
         Host host =

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
@@ -27,13 +27,9 @@ public class HostService {
         return hostRepository.save(host);
     }
 
-    public Host addHostUser(Host host, Long userId) {
+    public Host addHostUser(Host host, Long userId, HostRole role) {
         HostUser hostUser =
-                HostUser.builder()
-                        .userId(userId)
-                        .hostId(host.getId())
-                        .role(HostRole.SUPER_HOST)
-                        .build();
+                HostUser.builder().userId(userId).hostId(host.getId()).role(role).build();
         host.addHostUsers(Set.of(hostUser));
         return hostRepository.save(host);
     }


### PR DESCRIPTION
## 개요
- close #147 

## 작업사항
- 기존 호스트에 가입하는 기능
- 호스트 상세 조회
- 상세 조회 시 일단 유저 고유 아이디가 나오도록 하였으며 이후 UserInfoVo 로 교체할 예정입니다

## 변경로직
- 위와 같음