### PR TITLE
refactor: 발급 티켓 도메인 메서드 정리 및 API 추가

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/controller/AdminIssuedTicketController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/controller/AdminIssuedTicketController.java
@@ -2,12 +2,16 @@ package band.gosrock.api.issuedTicket.controller;
 
 
 import band.gosrock.api.issuedTicket.dto.response.RetrieveIssuedTicketListResponse;
+import band.gosrock.api.issuedTicket.service.EntranceIssuedTicketUseCase;
 import band.gosrock.api.issuedTicket.service.ReadIssuedTicketsUseCase;
+import band.gosrock.domain.common.vo.IssuedTicketInfoVo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +25,8 @@ public class AdminIssuedTicketController {
 
     private final ReadIssuedTicketsUseCase readIssuedTicketsUseCase;
 
+    private final EntranceIssuedTicketUseCase entranceIssuedTicketUseCase;
+
     @Operation(summary = "[어드민 기능] 발급 티켓 리스트 가져오기 API 입니다.")
     @GetMapping
     public RetrieveIssuedTicketListResponse getIssuedTickets(
@@ -29,5 +35,11 @@ public class AdminIssuedTicketController {
             @RequestParam(required = false) String userName,
             @RequestParam(required = false) String phoneNumber) {
         return readIssuedTicketsUseCase.execute(page, eventId, userName, phoneNumber);
+    }
+
+    @Operation(summary = "[어드민 기능] 발급 티켓 입장 처리 API 입니다.")
+    @PatchMapping(value = "/{issuedTicketId}")
+    public IssuedTicketInfoVo patchIssuedTicketStatus(@PathVariable Long issuedTicketId) {
+        return entranceIssuedTicketUseCase.execute(issuedTicketId);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/mapper/IssuedTicketMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/mapper/IssuedTicketMapper.java
@@ -26,6 +26,6 @@ public class IssuedTicketMapper {
     public RetrieveIssuedTicketDetailResponse toIssuedTicketDetailResponse(
             Long currentUserId, Long issuedTicketId) {
         return RetrieveIssuedTicketDetailResponse.of(
-                issuedTicketAdaptor.find(currentUserId, issuedTicketId));
+                issuedTicketAdaptor.findForUser(currentUserId, issuedTicketId));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/service/EntranceIssuedTicketUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/service/EntranceIssuedTicketUseCase.java
@@ -1,0 +1,26 @@
+package band.gosrock.api.issuedTicket.service;
+
+
+import band.gosrock.api.common.UserUtils;
+import band.gosrock.api.issuedTicket.mapper.IssuedTicketMapper;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.common.vo.IssuedTicketInfoVo;
+import band.gosrock.domain.domains.issuedTicket.service.IssuedTicketDomainService;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class EntranceIssuedTicketUseCase {
+
+    private final IssuedTicketDomainService issuedTicketDomainService;
+
+    private final IssuedTicketMapper issuedTicketMapper;
+
+    private final UserUtils userUtils;
+
+    public IssuedTicketInfoVo execute(Long issuedTicketId) {
+        Long currentUserId = userUtils.getCurrentUserId();
+        return issuedTicketDomainService.processingEntranceIssuedTicket(
+                currentUserId, issuedTicketId);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptor.java
@@ -32,7 +32,7 @@ public class IssuedTicketAdaptor {
         return issuedTicketRepository.findAllByOrderLineId(orderLineId);
     }
 
-    public IssuedTicket find(Long currentUserId, Long issuedTicketId) {
+    public IssuedTicket findForUser(Long currentUserId, Long issuedTicketId) {
         IssuedTicket issuedTicket =
                 issuedTicketRepository
                         .find(issuedTicketId)
@@ -41,6 +41,12 @@ public class IssuedTicketAdaptor {
             throw IssuedTicketUserNotMatchedException.EXCEPTION;
         }
         return issuedTicket;
+    }
+
+    public IssuedTicket find(Long issuedTicketId) {
+        return issuedTicketRepository
+                .find(issuedTicketId)
+                .orElseThrow(() -> IssuedTicketNotFoundException.EXCEPTION);
     }
 
     public Page<IssuedTicket> searchIssuedTicket(Long page, IssuedTicketCondition condition) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptor.java
@@ -55,7 +55,7 @@ public class IssuedTicketAdaptor {
         return issuedTicketRepository.searchToPage(condition, pageRequest);
     }
 
-    public void delete(IssuedTicket issuedTicket) {
+    public void cancel(IssuedTicket issuedTicket) {
         issuedTicket.cancel();
     }
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptor.java
@@ -50,7 +50,7 @@ public class IssuedTicketAdaptor {
     }
 
     public void delete(IssuedTicket issuedTicket) {
-        issuedTicket.cancelIssuedTicket();
+        issuedTicket.cancel();
     }
 
     public List<IssuedTicket> findAllByOrderUuid(String orderUuid) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
@@ -11,6 +11,7 @@ import band.gosrock.domain.domains.issuedTicket.dto.response.CreateIssuedTicketR
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelEntranceException;
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelException;
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotEntranceException;
+import band.gosrock.domain.domains.issuedTicket.exception.IssuedTicketAlreadyEntranceException;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
 import band.gosrock.domain.domains.user.domain.User;
 import java.util.ArrayList;
@@ -236,8 +237,11 @@ public class IssuedTicket extends BaseTimeEntity {
     티켓이 입장 미완료 상태가 아니면 입장 할 수 없음
      */
     public void entrance() {
-        if (this.issuedTicketStatus != IssuedTicketStatus.ENTRANCE_INCOMPLETE) {
+        if (this.issuedTicketStatus == IssuedTicketStatus.CANCELED) {
             throw CanNotEntranceException.EXCEPTION;
+        }
+        if (this.issuedTicketStatus == IssuedTicketStatus.ENTRANCE_COMPLETED) {
+            throw IssuedTicketAlreadyEntranceException.EXCEPTION;
         }
         this.issuedTicketStatus = IssuedTicketStatus.ENTRANCE_COMPLETED;
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/CanNotCancelEntranceException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/CanNotCancelEntranceException.java
@@ -1,5 +1,6 @@
 package band.gosrock.domain.domains.issuedTicket.exception;
 
+
 import band.gosrock.common.exception.DuDoongCodeException;
 
 public class CanNotCancelEntranceException extends DuDoongCodeException {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/CanNotCancelEntranceException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/CanNotCancelEntranceException.java
@@ -1,0 +1,12 @@
+package band.gosrock.domain.domains.issuedTicket.exception;
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class CanNotCancelEntranceException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new CanNotCancelEntranceException();
+
+    private CanNotCancelEntranceException() {
+        super(IssuedTicketErrorCode.CAN_NOT_CANCEL_ENTRANCE);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/CanNotCancelException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/CanNotCancelException.java
@@ -1,5 +1,6 @@
 package band.gosrock.domain.domains.issuedTicket.exception;
 
+
 import band.gosrock.common.exception.DuDoongCodeException;
 
 public class CanNotCancelException extends DuDoongCodeException {
@@ -9,5 +10,4 @@ public class CanNotCancelException extends DuDoongCodeException {
     private CanNotCancelException() {
         super(IssuedTicketErrorCode.CAN_NOT_CANCEL);
     }
-
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/CanNotCancelException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/CanNotCancelException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.issuedTicket.exception;
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class CanNotCancelException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new CanNotCancelException();
+
+    private CanNotCancelException() {
+        super(IssuedTicketErrorCode.CAN_NOT_CANCEL);
+    }
+
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/CanNotEntranceException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/CanNotEntranceException.java
@@ -1,5 +1,6 @@
 package band.gosrock.domain.domains.issuedTicket.exception;
 
+
 import band.gosrock.common.exception.DuDoongCodeException;
 
 public class CanNotEntranceException extends DuDoongCodeException {
@@ -9,5 +10,4 @@ public class CanNotEntranceException extends DuDoongCodeException {
     private CanNotEntranceException() {
         super(IssuedTicketErrorCode.CAN_NOT_ENTRANCE);
     }
-
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/CanNotEntranceException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/CanNotEntranceException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.issuedTicket.exception;
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class CanNotEntranceException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new CanNotEntranceException();
+
+    private CanNotEntranceException() {
+        super(IssuedTicketErrorCode.CAN_NOT_ENTRANCE);
+    }
+
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketAlreadyEntranceException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketAlreadyEntranceException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.issuedTicket.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class IssuedTicketAlreadyEntranceException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new IssuedTicketAlreadyEntranceException();
+
+    private IssuedTicketAlreadyEntranceException() {
+        super(IssuedTicketErrorCode.ISSUED_TICKET_ALREADY_ENTRANCE);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketErrorCode.java
@@ -16,7 +16,10 @@ import lombok.Getter;
 public enum IssuedTicketErrorCode implements BaseErrorCode {
     ISSUED_TICKET_NOT_FOUND(NOT_FOUND, "IssuedTicket_404_1", "IssuedTicket Not Found"),
     ISSUED_TICKET_NOT_MATCHED_USER(
-            BAD_REQUEST, "IssuedTicket_400_1", "IssuedTicket User Not Matched");
+            BAD_REQUEST, "IssuedTicket_400_1", "IssuedTicket User Not Matched"),
+    CAN_NOT_CANCEL(BAD_REQUEST, "IssuedTicket_400_2", "티켓을 취소 할 수 있는 상태가 아닙니다."),
+    CAN_NOT_CANCEL_ENTRANCE(BAD_REQUEST, "IssuedTicket_400_3", "티켓이 입장 취소 할 수 있는 상태가 아닙니다."),
+    CAN_NOT_ENTRANCE(BAD_REQUEST, "IssuedTicket_400_5", "티켓이 입장 할 수 있는 상태가 아닙니다.");
 
     private Integer status;
     private String code;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketErrorCode.java
@@ -19,7 +19,8 @@ public enum IssuedTicketErrorCode implements BaseErrorCode {
             BAD_REQUEST, "IssuedTicket_400_1", "IssuedTicket User Not Matched"),
     CAN_NOT_CANCEL(BAD_REQUEST, "IssuedTicket_400_2", "티켓을 취소 할 수 있는 상태가 아닙니다."),
     CAN_NOT_CANCEL_ENTRANCE(BAD_REQUEST, "IssuedTicket_400_3", "티켓이 입장 취소 할 수 있는 상태가 아닙니다."),
-    CAN_NOT_ENTRANCE(BAD_REQUEST, "IssuedTicket_400_5", "티켓이 입장 할 수 있는 상태가 아닙니다.");
+    CAN_NOT_ENTRANCE(BAD_REQUEST, "IssuedTicket_400_4", "티켓이 입장 할 수 있는 상태가 아닙니다."),
+    ISSUED_TICKET_ALREADY_ENTRANCE(BAD_REQUEST, "IssuedTicket_400_5", "이미 입장 처리된 티켓입니다.");
 
     private Integer status;
     private String code;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -46,7 +46,7 @@ public class IssuedTicketDomainService {
         issuedTickets.forEach(
                 issuedTicket -> {
                     issuedTicket.getTicketItem().increaseQuantity(1L);
-                    issuedTicketAdaptor.delete(issuedTicket);
+                    issuedTicketAdaptor.cancel(issuedTicket);
                 });
     }
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -3,7 +3,9 @@ package band.gosrock.domain.domains.issuedTicket.service;
 
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.common.aop.redissonLock.RedissonLock;
+import band.gosrock.domain.common.vo.IssuedTicketInfoVo;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
+import band.gosrock.domain.domains.event.exception.HostNotAuthEventException;
 import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
 import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketOptionAnswerAdaptor;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
@@ -12,6 +14,7 @@ import band.gosrock.domain.domains.issuedTicket.dto.response.CreateIssuedTicketR
 import band.gosrock.domain.domains.issuedTicket.repository.IssuedTicketRepository;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,5 +56,16 @@ public class IssuedTicketDomainService {
                     issuedTicket.getTicketItem().increaseQuantity(1L);
                     issuedTicketAdaptor.delete(issuedTicket);
                 });
+    }
+
+    @Transactional
+    public IssuedTicketInfoVo processingEntranceIssuedTicket(
+            Long currentUserId, Long issuedTicketId) {
+        IssuedTicket issuedTicket = issuedTicketAdaptor.find(issuedTicketId);
+        if (!Objects.equals(issuedTicket.getEvent().getHostId(), currentUserId)) {
+            throw HostNotAuthEventException.EXCEPTION;
+        }
+        issuedTicket.entrance();
+        return issuedTicket.toIssuedTicketInfoVo();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -28,11 +28,7 @@ public class IssuedTicketDomainService {
     private final IssuedTicketOptionAnswerAdaptor issuedTicketOptionAnswerAdaptor;
     private final EventAdaptor eventAdaptor;
 
-    @RedissonLock(
-            LockName = "티켓재고관리",
-            paramClassType = TicketItem.class,
-            identifier = "id",
-            needSameTransaction = true)
+    @RedissonLock(LockName = "티켓재고관리", paramClassType = TicketItem.class, identifier = "id")
     @Transactional
     public void createIssuedTicket(
             TicketItem ticketItem, List<CreateIssuedTicketDTO> createIssuedTicketDTOs) {
@@ -44,11 +40,7 @@ public class IssuedTicketDomainService {
                 });
     }
 
-    @RedissonLock(
-            LockName = "티켓재고관리",
-            paramClassType = TicketItem.class,
-            identifier = "id",
-            needSameTransaction = true)
+    @RedissonLock(LockName = "티켓재고관리", paramClassType = TicketItem.class, identifier = "id")
     @Transactional
     public void withDrawIssuedTicket(TicketItem ticketItem, List<IssuedTicket> issuedTickets) {
         issuedTickets.forEach(


### PR DESCRIPTION
## 개요
- close #167 

## 작업사항
- 발급 티켓 도메인 내부 메서드들을 조금 정리했습니다.
- 정리하면서 필요해보이는 상태변환 메서드들을 추가했습니다.
- 또 상태변환 메서드를 추가하니 입장 처리해주는 API가 필요해서 추가해주었습니다.
- 정상 응답
```
PATCH /v1/admin/issuedTickets/{issuedTicketId}

{
  "success": true,
  "status": 200,
  "data": {
    "issuedTicketId": 16,
    "issuedTicketNo": "T1000016",
    "uuid": "f8197615-ec94-472b-87b5-ba5b03b69db7",
    "ticketName": "test",
    "ticketPrice": "4000원",
    "createdAt": "2023-01-23 03:24:58",
    "issuedTicketStatus": "입장 완료",
    "optionPrice": "0원"
  },
  "timeStamp": "2023-01-23T17:40:11.571074"
}

```

- 티켓이 이미 입장 처리 되었을 때

```
{
  "success": false,
  "status": 400,
  "code": "IssuedTicket_400_5",
  "reason": "이미 입장 처리된 티켓입니다.",
  "timeStamp": "2023-01-23T17:40:50.49026",
  "path": "http://localhost:8080/api/v1/admin/issuedTickets/16"
}
```
- 추가로 해당 부분에도 락을 걸고 들어가야 할지 고민을 해봤습니다. 하지만 QR 찍는 행위가 동시에 일어 날 일은 없다고 생각해서 따로 처리하지 않았습니다.

## 변경로직
- 찬진님이 말한 티켓재고관련 Redisson Lock에서 새로운 트랜잭션이 필요하기 때문에 needSameTransaction 옵션을 디폴트값인 false로 변경하였습니다.
```
    @RedissonLock(LockName = "티켓재고관리", paramClassType = TicketItem.class, identifier = "id")

```