### PR TITLE
refactor : 선착순 결제시 0원 주문일 때 티켓 바로 발급

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
@@ -29,6 +29,9 @@ public class CartResponse {
     @Schema(description = "결제가 필요한지에 대한 여부를 결정합니다. 필요한 true면 결제창 띄우시면됩니다.", defaultValue = "true")
     private final Boolean isNeedPayment;
 
+    @Schema(description = "결제가 필요한지에 대한 여부를 결정합니다. 필요한 true면 결제창 띄우시면됩니다.", defaultValue = "true")
+    private final Boolean isNeedPayment;
+
     public static CartResponse of(List<CartItemResponse> cartItemResponses, Cart cart) {
         return CartResponse.builder()
                 .items(cartItemResponses)

--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
@@ -32,7 +32,7 @@ public class CartResponse {
             defaultValue = "true")
     private final Boolean isNeedPayment;
 
-    @Schema(description = "티켓의 타입. 승인방식 , 결제방식 두가지입니다.")
+    @Schema(description = "티켓의 타입. 승인 , 선착순 두가지입니다.")
     private final TicketType ticketType;
 
     public static CartResponse of(List<CartItemResponse> cartItemResponses, Cart cart) {

--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
@@ -30,7 +30,7 @@ public class CartResponse {
     @Schema(description = "결제가 필요한지에 대한 여부를 결정합니다. 필요한 true면 결제창 띄우시면됩니다.", defaultValue = "true")
     private final Boolean isNeedPayment;
 
-    @Schema(description = "결제가 필요한지에 대한 여부를 결정합니다. 필요한 true면 결제창 띄우시면됩니다.", defaultValue = "true")
+    @Schema(description = "티켓의 타입. 승인방식 , 결제방식 두가지입니다.")
     private final TicketType ticketType;
 
     public static CartResponse of(List<CartItemResponse> cartItemResponses, Cart cart) {
@@ -41,6 +41,7 @@ public class CartResponse {
                 .title(cart.getCartName())
                 .isNeedPayment(cart.isNeedPayment())
                 .totalQuantity(cart.getTotalQuantity())
+                .ticketType(cart.getItemType())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
@@ -41,7 +41,7 @@ public class CartResponse {
                 .totalPrice(cart.getTotalPrice())
                 .cartId(cart.getId())
                 .title(cart.getCartName())
-                .isNeedPayment(cart.isNeedPayment())
+                .isNeedPayment(cart.isNeedPaid())
                 .totalQuantity(cart.getTotalQuantity())
                 .ticketType(cart.getItemType())
                 .build();

--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
@@ -27,7 +27,9 @@ public class CartResponse {
     @Schema(description = "전체 아이템 수량을 의미합니다", defaultValue = "3")
     private final Long totalQuantity;
 
-    @Schema(description = "결제가 필요한지에 대한 여부를 결정합니다. 필요한 true면 결제창 띄우시면됩니다. 이단계에선 무시하셔도 됩니다.", defaultValue = "true")
+    @Schema(
+            description = "결제가 필요한지에 대한 여부를 결정합니다. 필요한 true면 결제창 띄우시면됩니다. 이단계에선 무시하셔도 됩니다.",
+            defaultValue = "true")
     private final Boolean isNeedPayment;
 
     @Schema(description = "티켓의 타입. 승인방식 , 결제방식 두가지입니다.")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
@@ -27,7 +27,7 @@ public class CartResponse {
     @Schema(description = "전체 아이템 수량을 의미합니다", defaultValue = "3")
     private final Long totalQuantity;
 
-    @Schema(description = "결제가 필요한지에 대한 여부를 결정합니다. 필요한 true면 결제창 띄우시면됩니다.", defaultValue = "true")
+    @Schema(description = "결제가 필요한지에 대한 여부를 결정합니다. 필요한 true면 결제창 띄우시면됩니다. 이단계에선 무시하셔도 됩니다.", defaultValue = "true")
     private final Boolean isNeedPayment;
 
     @Schema(description = "티켓의 타입. 승인방식 , 결제방식 두가지입니다.")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/cart/model/dto/response/CartResponse.java
@@ -3,6 +3,7 @@ package band.gosrock.api.cart.model.dto.response;
 
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.cart.domain.Cart;
+import band.gosrock.domain.domains.ticket_item.domain.TicketType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
@@ -30,7 +31,7 @@ public class CartResponse {
     private final Boolean isNeedPayment;
 
     @Schema(description = "결제가 필요한지에 대한 여부를 결정합니다. 필요한 true면 결제창 띄우시면됩니다.", defaultValue = "true")
-    private final Boolean isNeedPayment;
+    private final TicketType ticketType;
 
     public static CartResponse of(List<CartItemResponse> cartItemResponses, Cart cart) {
         return CartResponse.builder()

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/customizer/EnumValuePropertyCustomizer.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/customizer/EnumValuePropertyCustomizer.java
@@ -1,5 +1,6 @@
 package band.gosrock.api.common.customizer;
 
+
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.core.converter.AnnotatedType;
@@ -11,6 +12,9 @@ import java.util.stream.Collectors;
 import org.springdoc.core.customizers.PropertyCustomizer;
 import org.springframework.stereotype.Component;
 
+// https://stackoverflow.com/questions/68747036/how-can-have-springdoc-openapi-use-the-jsonvalue-enum-format-without-changing-t
+
+/** enum jsonvalue 어노테이션 사용할때 예시값을 보여주기 위함. */
 @Component
 public class EnumValuePropertyCustomizer implements PropertyCustomizer {
     @Override
@@ -18,9 +22,10 @@ public class EnumValuePropertyCustomizer implements PropertyCustomizer {
         if (property instanceof StringSchema && isEnumType(type)) {
             ObjectMapper objectMapper = Json.mapper();
 
-            property.setEnum(Arrays.stream(((JavaType) type.getType()).getRawClass().getEnumConstants())
-                .map(e -> objectMapper.convertValue(e, String.class))
-                .collect(Collectors.toList()));
+            property.setEnum(
+                    Arrays.stream(((JavaType) type.getType()).getRawClass().getEnumConstants())
+                            .map(e -> objectMapper.convertValue(e, String.class))
+                            .collect(Collectors.toList()));
         }
         return property;
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/customizer/EnumValuePropertyCustomizer.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/customizer/EnumValuePropertyCustomizer.java
@@ -1,0 +1,31 @@
+package band.gosrock.api.common.customizer;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.springdoc.core.customizers.PropertyCustomizer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EnumValuePropertyCustomizer implements PropertyCustomizer {
+    @Override
+    public Schema customize(Schema property, AnnotatedType type) {
+        if (property instanceof StringSchema && isEnumType(type)) {
+            ObjectMapper objectMapper = Json.mapper();
+
+            property.setEnum(Arrays.stream(((JavaType) type.getType()).getRawClass().getEnumConstants())
+                .map(e -> objectMapper.convertValue(e, String.class))
+                .collect(Collectors.toList()));
+        }
+        return property;
+    }
+
+    private boolean isEnumType(AnnotatedType type) {
+        return type.getType() instanceof JavaType t && t.isEnumType();
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
@@ -10,6 +10,7 @@ import band.gosrock.api.order.service.CancelOrderUseCase;
 import band.gosrock.api.order.service.ConfirmOrderUseCase;
 import band.gosrock.api.order.service.CreateOrderUseCase;
 import band.gosrock.api.order.service.CreateTossOrderUseCase;
+import band.gosrock.api.order.service.FreeOrderUseCase;
 import band.gosrock.api.order.service.ReadOrderUseCase;
 import band.gosrock.api.order.service.RefundOrderUseCase;
 import band.gosrock.common.annotation.DevelopOnlyApi;
@@ -36,6 +37,7 @@ public class OrderController {
     private final CreateOrderUseCase createOrderUseCase;
     private final ConfirmOrderUseCase confirmOrderUseCase;
     private final ApproveOrderUseCase approveOrderUseCase;
+    private final FreeOrderUseCase freeOrderUseCase;
     private final CancelOrderUseCase cancelOrderUseCase;
 
     private final RefundOrderUseCase refundOrderUseCase;
@@ -75,7 +77,7 @@ public class OrderController {
     @Operation(summary = "주문을 무료로 결제합니다. 선착순 방식 결제 0원일 때 지원")
     @PostMapping("/{order_uuid}/free")
     public OrderResponse freeOrder(@PathVariable("order_uuid") String orderUuid) {
-        return approveOrderUseCase.execute(orderUuid);
+        return freeOrderUseCase.execute(orderUuid);
     }
 
     @Operation(summary = "결제 취소요청. 호스트 관리자가 결제를 취소 시킵니다.! (호스트 관리자용(관리자쪽에서 사용))")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/controller/OrderController.java
@@ -72,6 +72,12 @@ public class OrderController {
         return approveOrderUseCase.execute(orderUuid);
     }
 
+    @Operation(summary = "주문을 무료로 결제합니다. 선착순 방식 결제 0원일 때 지원")
+    @PostMapping("/{order_uuid}/free")
+    public OrderResponse freeOrder(@PathVariable("order_uuid") String orderUuid) {
+        return approveOrderUseCase.execute(orderUuid);
+    }
+
     @Operation(summary = "결제 취소요청. 호스트 관리자가 결제를 취소 시킵니다.! (호스트 관리자용(관리자쪽에서 사용))")
     @PostMapping("/{order_uuid}/cancel")
     public OrderResponse cancelOrder(@PathVariable("order_uuid") String orderUuid) {

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
@@ -45,7 +45,7 @@ public class CreateOrderResponse {
                 .orderId(order.getUuid())
                 .amount(order.getTotalPaymentPrice())
                 .orderMethod(order.getOrderMethod())
-                .isNeedPayment(order.isNeedPayment())
+                .isNeedPayment(order.isNeedPaid())
                 .ticketType(order.getItemType())
                 .build();
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
@@ -26,6 +26,8 @@ public class CreateOrderResponse {
     @Schema(description = "결제금액")
     private final Money amount;
 
+    @Schema(description = "결제가 필요한지에 대한 여부를 결정합니다. 필요한 true면 결제창 띄우시면됩니다.", defaultValue = "true")
+    private final Boolean isNeedPayment;
     public static CreateOrderResponse from(Order order, Profile profile) {
         return CreateOrderResponse.builder()
                 .customerEmail(profile.getEmail())
@@ -33,6 +35,7 @@ public class CreateOrderResponse {
                 .orderName(order.getOrderName())
                 .orderId(order.getUuid())
                 .amount(order.getTotalPaymentPrice())
+                .isNeedPayment(order.isNeedPayment())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
@@ -3,6 +3,8 @@ package band.gosrock.api.order.model.dto.response;
 
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.domain.domains.order.domain.OrderMethod;
+import band.gosrock.domain.domains.ticket_item.domain.TicketType;
 import band.gosrock.domain.domains.user.domain.Profile;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -29,6 +31,12 @@ public class CreateOrderResponse {
     @Schema(description = "결제가 필요한지에 대한 여부를 결정합니다. 필요한 true면 결제창 띄우시면됩니다.", defaultValue = "true")
     private final Boolean isNeedPayment;
 
+    @Schema(description = "주문 방식 ( 결제 방식 , 승인 방식 )")
+    private final OrderMethod orderMethod;
+
+    @Schema(description = "티켓의 타입. 승인 , 선착순 두가지입니다.")
+    private final TicketType ticketType;
+
     public static CreateOrderResponse from(Order order, Profile profile) {
         return CreateOrderResponse.builder()
                 .customerEmail(profile.getEmail())
@@ -36,7 +44,9 @@ public class CreateOrderResponse {
                 .orderName(order.getOrderName())
                 .orderId(order.getUuid())
                 .amount(order.getTotalPaymentPrice())
+                .orderMethod(order.getOrderMethod())
                 .isNeedPayment(order.isNeedPayment())
+                .ticketType(order.getItemType())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
@@ -28,6 +28,7 @@ public class CreateOrderResponse {
 
     @Schema(description = "결제가 필요한지에 대한 여부를 결정합니다. 필요한 true면 결제창 띄우시면됩니다.", defaultValue = "true")
     private final Boolean isNeedPayment;
+
     public static CreateOrderResponse from(Order order, Profile profile) {
         return CreateOrderResponse.builder()
                 .customerEmail(profile.getEmail())

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/FreeOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/FreeOrderUseCase.java
@@ -1,0 +1,22 @@
+package band.gosrock.api.order.service;
+
+
+import band.gosrock.api.order.model.dto.response.OrderResponse;
+import band.gosrock.api.order.model.mapper.OrderMapper;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.order.service.FreeOrderService;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class FreeOrderUseCase {
+
+    private final FreeOrderService freeOrderService;
+
+    private final OrderMapper orderMapper;
+
+    public OrderResponse execute(String orderUuid) {
+        String confirmOrderUuid = freeOrderService.execute(orderUuid);
+        return orderMapper.toOrderResponse(confirmOrderUuid);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/DoneOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/DoneOrderEvent.java
@@ -23,7 +23,7 @@ public class DoneOrderEvent extends DomainEvent {
     public static DoneOrderEvent from(Order order) {
         return DoneOrderEvent.builder()
                 .orderMethod(order.getOrderMethod())
-                .paymentKey(order.isNeedPayment() ? order.getPaymentKey() : null)
+                .paymentKey(order.isNeedPaid() ? order.getPaymentKey() : null)
                 .userId(order.getUserId())
                 .orderUuid(order.getUuid())
                 .build();

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
@@ -23,7 +23,7 @@ public class WithDrawOrderEvent extends DomainEvent {
     public static WithDrawOrderEvent from(Order order) {
         return WithDrawOrderEvent.builder()
                 .orderMethod(order.getOrderMethod())
-                .paymentKey(order.isNeedPayment() ? order.getPaymentKey() : null)
+                .paymentKey(order.isNeedPaid() ? order.getPaymentKey() : null)
                 .userId(order.getUserId())
                 .orderUuid(order.getUuid())
                 .orderStatus(order.getOrderStatus())

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/Cart.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/Cart.java
@@ -93,13 +93,13 @@ public class Cart extends BaseTimeEntity {
                 .toList();
     }
 
-    public TicketType getItemType(){
+    public TicketType getItemType() {
         return getCartLineItem().getTicketItem().getType();
     }
 
     private CartLineItem getCartLineItem() {
         return cartLineItems.stream()
-            .findFirst()
-            .orElseThrow(() -> CartLineItemNotFoundException.EXCEPTION);
+                .findFirst()
+                .orElseThrow(() -> CartLineItemNotFoundException.EXCEPTION);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/Cart.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/Cart.java
@@ -3,7 +3,9 @@ package band.gosrock.domain.domains.cart.domain;
 
 import band.gosrock.domain.common.model.BaseTimeEntity;
 import band.gosrock.domain.common.vo.Money;
+import band.gosrock.domain.domains.cart.exception.CartLineItemNotFoundException;
 import band.gosrock.domain.domains.cart.policy.CartPolicy;
+import band.gosrock.domain.domains.ticket_item.domain.TicketType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -89,5 +91,15 @@ public class Cart extends BaseTimeEntity {
                 .map(cartLineItem -> cartLineItem.getTicketItem().getId())
                 .distinct()
                 .toList();
+    }
+
+    public TicketType getItemType(){
+        return getCartLineItem().getTicketItem().getType();
+    }
+
+    private CartLineItem getCartLineItem() {
+        return cartLineItems.stream()
+            .findFirst()
+            .orElseThrow(() -> CartLineItemNotFoundException.EXCEPTION);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/Cart.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/Cart.java
@@ -69,9 +69,9 @@ public class Cart extends BaseTimeEntity {
 
     /** ---------------------------- 조회용 메서드 ---------------------------------- */
     /** 결제가 필요한 오더인지 반환합니다. */
-    public Boolean isNeedPayment() {
+    public Boolean isNeedPaid() {
         return this.cartLineItems.stream()
-                .map(CartLineItem::isNeedPayment)
+                .map(CartLineItem::isNeedPaid)
                 .reduce(Boolean.FALSE, (Boolean::logicalOr));
     }
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartLineItem.java
@@ -117,7 +117,7 @@ public class CartLineItem extends BaseTimeEntity {
         return ticketItem.getPrice();
     }
     /** 장바구니의 담긴 상품이 결제가 필요한지. 가져옵니다. */
-    public Boolean isNeedPayment() {
+    public Boolean isNeedPaid() {
         Money totalCartLinePrice = getTotalCartLinePrice();
         // 0 < totalCartLinePrice
         return Money.ZERO.isLessThan(totalCartLinePrice);

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/domain/CartLineItem.java
@@ -118,7 +118,9 @@ public class CartLineItem extends BaseTimeEntity {
     }
     /** 장바구니의 담긴 상품이 결제가 필요한지. 가져옵니다. */
     public Boolean isNeedPayment() {
-        return ticketItem.isNeedPayment();
+        Money totalCartLinePrice = getTotalCartLinePrice();
+        // 0 < totalCartLinePrice
+        return Money.ZERO.isLessThan(totalCartLinePrice);
     }
 
     /** 아이템이 옵션을 가지고 있는지 판별합니다. */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/exception/CartErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/exception/CartErrorCode.java
@@ -19,7 +19,8 @@ public enum CartErrorCode implements BaseErrorCode {
 
     @ExplainError("한 장바구니엔 관련된 한 아이템만 올수 있음")
     CART_INVALID_ITEM_KIND_POLICY(BAD_REQUEST, "Cart_400_1", "장바구니에 아이템을 담는 정책을 위반하였습니다."),
-    CART_INVALID_OPTION_ANSWER(BAD_REQUEST, "Cart_400_2", "옵션을 잘못 응답 하였습니다.");
+    CART_INVALID_OPTION_ANSWER(BAD_REQUEST, "Cart_400_2", "옵션을 잘못 응답 하였습니다."),
+    CART_LINE_NOT_FOUND(BAD_REQUEST, "Cart_400_3", "장바구니 안에 상품을 찾을 수 없습니다.");
     private Integer status;
     private String code;
     private String reason;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/exception/CartLineItemNotFoundException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/cart/exception/CartLineItemNotFoundException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.cart.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class CartLineItemNotFoundException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new CartLineItemNotFoundException();
+
+    private CartLineItemNotFoundException() {
+        super(CartErrorCode.CART_LINE_NOT_FOUND);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
@@ -37,8 +37,7 @@ public class OrderEventHandler {
                 order.getOrderLineItems().stream()
                         .map(orderLineItem -> new CreateIssuedTicketDTO(order, orderLineItem, user))
                         .toList();
-        issuedTicketDomainService.createIssuedTicket(
-                order.getItem(), createIssuedTicketDTOS);
+        issuedTicketDomainService.createIssuedTicket(order.getItem(), createIssuedTicketDTOS);
         log.info(doneOrderEvent.getOrderUuid() + "주문 상태 완료, 티켓 생성작업 완료");
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
@@ -38,7 +38,7 @@ public class OrderEventHandler {
                         .map(orderLineItem -> new CreateIssuedTicketDTO(order, orderLineItem, user))
                         .toList();
         issuedTicketDomainService.createIssuedTicket(
-                order.getTicketItemOfOrder(), createIssuedTicketDTOS);
+                order.getItem(), createIssuedTicketDTOS);
         log.info(doneOrderEvent.getOrderUuid() + "주문 상태 완료, 티켓 생성작업 완료");
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithDrawOrderEventHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithDrawOrderEventHandler.java
@@ -33,7 +33,7 @@ public class WithDrawOrderEventHandler {
         Order order = orderAdaptor.findByOrderUuid(withDrawOrderEvent.getOrderUuid());
         List<IssuedTicket> issuedTickets =
                 issuedTicketAdaptor.findAllByOrderUuid(withDrawOrderEvent.getOrderUuid());
-        issuedTicketDomainService.withDrawIssuedTicket(order.getTicketItemOfOrder(), issuedTickets);
+        issuedTicketDomainService.withDrawIssuedTicket(order.getItem(), issuedTickets);
         log.info(withDrawOrderEvent.getOrderUuid() + "주문 상태 완료, 티켓 생성작업 완료");
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -150,7 +150,7 @@ public class Order extends BaseTimeEntity {
             return createPaymentOrder(userId, cart);
         }
         // 선착순이 아니라면? 승인 방식임. 승인방식의 결제가 필요한 상황은 지원하지않음.
-        if (cart.isNeedPayment()) {
+        if (cart.isNeedPaid()) {
             throw InvalidOrderException.EXCEPTION;
         }
         return createApproveOrder(userId, cart);

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -17,6 +17,7 @@ import band.gosrock.domain.domains.order.exception.NotPaymentOrderException;
 import band.gosrock.domain.domains.order.exception.NotRefundAvailableDateOrderException;
 import band.gosrock.domain.domains.order.exception.OrderLineNotFountException;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.ticket_item.domain.TicketType;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -143,13 +144,13 @@ public class Order extends BaseTimeEntity {
     }
 
     public static Order createOrder(Long userId, Cart cart) {
-        // 결제가 필요한 상황인데,
-        if (cart.isNeedPayment()) {
-            // 선착순이 아니라면? 승인 방식임. 승인방식의 결제가 필요한 상황은 지원하지않음.
-            if (!cart.getItemType().isFCFS()) {
-                throw InvalidOrderException.EXCEPTION;
-            }
+        // 선착순 결제라면
+        if (cart.getItemType().isFCFS()) {
             return createPaymentOrder(userId, cart);
+        }
+        // 선착순이 아니라면? 승인 방식임. 승인방식의 결제가 필요한 상황은 지원하지않음.
+        if (cart.isNeedPayment()) {
+            throw InvalidOrderException.EXCEPTION;
         }
         return createApproveOrder(userId, cart);
     }
@@ -316,8 +317,13 @@ public class Order extends BaseTimeEntity {
     }
 
     /** 주문에서 티켓 상품 반환합니다. - 민준 */
-    public TicketItem getTicketItemOfOrder() {
+    public TicketItem getItem() {
         return getOrderLineItem().getTicketItem();
+    }
+
+    /** 주문에서 티켓 상품의 타입을 반환합니다.*/
+    public TicketType getItemType() {
+        return getItem().getType();
     }
 
     /** 결제가 필요한 오더인지 반환합니다. */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -219,7 +219,7 @@ public class Order extends BaseTimeEntity {
     /** ---------------------------- 검증 메서드 ---------------------------------- */
     /** 승인 가능한 주문인지 검증합니다. */
     public void validApprovalOrder() {
-        if (isNeedPayment()) {
+        if (orderMethod.isPayment()) {
             throw NotApprovalOrderException.EXCEPTION;
         }
     }
@@ -245,7 +245,7 @@ public class Order extends BaseTimeEntity {
     }
 
     public void validPaymentOrder() {
-        if (!isNeedPayment()) {
+        if (!orderMethod.isPayment()) {
             throw NotPaymentOrderException.EXCEPTION;
         }
     }
@@ -357,5 +357,12 @@ public class Order extends BaseTimeEntity {
         return this.orderLineItems.stream()
                 .map(OrderLineItem::canRefund)
                 .reduce(Boolean.TRUE, (Boolean::logicalAnd));
+    }
+
+    /** PG 사를 통해 결제가 된 주문인지 반환합니다. */
+    public Boolean isPaid(){
+        if(isNeedPayment())
+            return Boolean.TRUE;
+        return Boolean.FALSE;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
@@ -100,7 +100,9 @@ public class OrderLineItem extends BaseTimeEntity {
     }
     /** 결제가 필요한 오더라인인지 가져옵니다. */
     public Boolean isNeedPayment() {
-        return ticketItem.isNeedPayment();
+        Money totalOrderLinePrice = getTotalOrderLinePrice();
+        // 0 < totalOrderLinePrice
+        return Money.ZERO.isLessThan(totalOrderLinePrice);
     }
     /** 주문 철회 가능 여부를 반환합니다. */
     public Boolean canRefund() {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderLineItem.java
@@ -99,7 +99,7 @@ public class OrderLineItem extends BaseTimeEntity {
         return orderOptionAnswer.stream().map(OrderOptionAnswer::getOptionAnswerVo).toList();
     }
     /** 결제가 필요한 오더라인인지 가져옵니다. */
-    public Boolean isNeedPayment() {
+    public Boolean isNeedPaid() {
         Money totalOrderLinePrice = getTotalOrderLinePrice();
         // 0 < totalOrderLinePrice
         return Money.ZERO.isLessThan(totalOrderLinePrice);

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/PaymentMethod.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/PaymentMethod.java
@@ -15,7 +15,7 @@ public enum PaymentMethod {
     // 카드결제
     CARD("CARD", "카드 결제"),
     // 결제방식 미지정상태
-    DEFAULT("DEFAULT", "결제 방식 미지정");
+    DEFAULT("DEFAULT", "");
     private String value;
 
     @JsonValue private String kr;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/NotFreeOrderException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/NotFreeOrderException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.order.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class NotFreeOrderException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new NotFreeOrderException();
+
+    private NotFreeOrderException() {
+        super(OrderErrorCode.ORDER_NOT_FREE);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/OrderErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/OrderErrorCode.java
@@ -28,7 +28,8 @@ public enum OrderErrorCode implements BaseErrorCode {
 
     ORDER_NOT_REFUND_DATE(BAD_REQUEST, "Order_400_9", "환불을 할 수 있는 기한을 지났습니다."),
     ORDER_NOT_FOUND(NOT_FOUND, "Order_404_1", "주문을 찾을 수 없습니다."),
-    ORDER_LINE_NOT_FOUND(NOT_FOUND, "Order_404_2", "주문 라인을 찾을 수 없습니다.");
+    ORDER_LINE_NOT_FOUND(NOT_FOUND, "Order_404_2", "주문 라인을 찾을 수 없습니다."),
+    ORDER_NOT_FREE(BAD_REQUEST, "Order_400_10", "무료 주문이 아닙니다.");
 
     private Integer status;
     private String code;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/FreeOrderService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/FreeOrderService.java
@@ -1,0 +1,24 @@
+package band.gosrock.domain.domains.order.service;
+
+
+import band.gosrock.common.annotation.DomainService;
+import band.gosrock.domain.common.aop.redissonLock.RedissonLock;
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
+import band.gosrock.domain.domains.order.domain.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@DomainService
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FreeOrderService {
+
+    private final OrderAdaptor orderAdaptor;
+
+    @RedissonLock(LockName = "주문", identifier = "orderUuid")
+    public String execute(String orderUuid) {
+        Order order = orderAdaptor.findByOrderUuid(orderUuid);
+        order.freeConfirm();
+        return orderUuid;
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/handler/WithDrawOrderHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/handler/WithDrawOrderHandler.java
@@ -28,10 +28,14 @@ public class WithDrawOrderHandler {
             classes = WithDrawOrderEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
     @Transactional
-    public void handleRegisterUserEvent(WithDrawOrderEvent withDrawOrderEvent) {
+    public void handleWithDrawOrderEvent(WithDrawOrderEvent withDrawOrderEvent) {
         log.info(withDrawOrderEvent.getOrderUuid() + "주문 철회 핸들러");
         OrderStatus orderStatus = withDrawOrderEvent.getOrderStatus();
         Order order = orderAdaptor.findByOrderUuid(withDrawOrderEvent.getOrderUuid());
+        // 결제를 하지않았던 주문이라면?
+        if(!order.isPaid())
+            return;
+
         String reason = "결제 취소";
         if (orderStatus.equals(OrderStatus.CANCELED)) {
             reason = "이벤트 관리자에 의한 취소";

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/handler/WithDrawOrderHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/handler/WithDrawOrderHandler.java
@@ -33,8 +33,7 @@ public class WithDrawOrderHandler {
         OrderStatus orderStatus = withDrawOrderEvent.getOrderStatus();
         Order order = orderAdaptor.findByOrderUuid(withDrawOrderEvent.getOrderUuid());
         // 결제를 하지않았던 주문이라면?
-        if(!order.isPaid())
-            return;
+        if (!order.isPaid()) return;
 
         String reason = "결제 취소";
         if (orderStatus.equals(OrderStatus.CANCELED)) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketItem.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketItem.java
@@ -97,8 +97,9 @@ public class TicketItem extends BaseTimeEntity {
         return event.getRefundInfoVo();
     }
 
-    public Boolean isNeedPayment() {
-        return this.type.isNeedPayment();
+    /** 선착순 결제인지 확인하는 메서드 */
+    public Boolean isFCFS() {
+        return this.type.isFCFS();
     }
 
     public Boolean hasOption() {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketType.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketType.java
@@ -1,6 +1,7 @@
 package band.gosrock.domain.domains.ticket_item.domain;
 
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,10 +9,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum TicketType {
     // 선착순
-    FIRST_COME_FIRST_SERVED("FIRST_COME_FIRST_SERVED"),
+    FIRST_COME_FIRST_SERVED("FIRST_COME_FIRST_SERVED","결제방식"),
     // 승인
-    APPROVAL("APPROVAL");
+    APPROVAL("APPROVAL","승인방식");
     private String value;
+
+    @JsonValue
+    private String kr;
 
     /** 결제가 필요한지 상태를 반환하는 메서드 */
     public Boolean isNeedPayment() {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketType.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/TicketType.java
@@ -9,16 +9,15 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum TicketType {
     // 선착순
-    FIRST_COME_FIRST_SERVED("FIRST_COME_FIRST_SERVED","결제방식"),
+    FIRST_COME_FIRST_SERVED("FIRST_COME_FIRST_SERVED", "선착순"),
     // 승인
-    APPROVAL("APPROVAL","승인방식");
+    APPROVAL("APPROVAL", "승인");
     private String value;
 
-    @JsonValue
-    private String kr;
+    @JsonValue private String kr;
 
-    /** 결제가 필요한지 상태를 반환하는 메서드 */
-    public Boolean isNeedPayment() {
+    /** 선착순 방식인지 반환하는 메서드 */
+    public Boolean isFCFS() {
         return this.equals(TicketType.FIRST_COME_FIRST_SERVED);
     }
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/OrderLineItemTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/OrderLineItemTest.java
@@ -90,7 +90,7 @@ class OrderLineItemTest {
         given(ticketItem.getPrice()).willReturn(Money.ZERO);
 
         // when
-        Boolean needPayment = orderLineItem.isNeedPayment();
+        Boolean needPayment = orderLineItem.isNeedPaid();
 
         assertTrue(needPayment);
     }
@@ -103,7 +103,7 @@ class OrderLineItemTest {
         given(ticketItem.getPrice()).willReturn(money3000);
 
         // when
-        Boolean needPayment = orderLineItem.isNeedPayment();
+        Boolean needPayment = orderLineItem.isNeedPaid();
 
         assertTrue(needPayment);
     }
@@ -116,7 +116,7 @@ class OrderLineItemTest {
         given(ticketItem.getPrice()).willReturn(Money.ZERO);
 
         // when
-        Boolean needPayment = orderLineItem.isNeedPayment();
+        Boolean needPayment = orderLineItem.isNeedPaid();
 
         assertFalse(needPayment);
     }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/OrderLineItemTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/OrderLineItemTest.java
@@ -79,4 +79,45 @@ class OrderLineItemTest {
         Money total = optionAnswerPrice1.plus(optionAnswerPrice2).plus(money3000).times(quantity);
         assertEquals(totalOrderLinePrice, total);
     }
+
+    @Test
+    void 옵션에_가격이_붙으면_결제가_필요한_오더라인이다() {
+        // given
+        Money optionAnswerPrice1 = Money.wons(1000L);
+        given(orderOptionAnswer1.getOptionPrice()).willReturn(optionAnswerPrice1);
+        Money optionAnswerPrice2 = Money.wons(2000L);
+        given(orderOptionAnswer2.getOptionPrice()).willReturn(optionAnswerPrice2);
+        given(ticketItem.getPrice()).willReturn(Money.ZERO);
+
+        // when
+        Boolean needPayment = orderLineItem.isNeedPayment();
+
+        assertTrue(needPayment);
+    }
+
+    @Test
+    void 아이템에_가격이_있으면_결제가_필요한_오더라인이다() {
+        // given
+        given(orderOptionAnswer1.getOptionPrice()).willReturn(Money.ZERO);
+        given(orderOptionAnswer2.getOptionPrice()).willReturn(Money.ZERO);
+        given(ticketItem.getPrice()).willReturn(money3000);
+
+        // when
+        Boolean needPayment = orderLineItem.isNeedPayment();
+
+        assertTrue(needPayment);
+    }
+
+    @Test
+    void 가격이없는_오더라인이면_결제가_필요하지않다() {
+        // given
+        given(orderOptionAnswer1.getOptionPrice()).willReturn(Money.ZERO);
+        given(orderOptionAnswer2.getOptionPrice()).willReturn(Money.ZERO);
+        given(ticketItem.getPrice()).willReturn(Money.ZERO);
+
+        // when
+        Boolean needPayment = orderLineItem.isNeedPayment();
+
+        assertFalse(needPayment);
+    }
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyFailTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyFailTest.java
@@ -11,6 +11,7 @@ import band.gosrock.domain.DomainIntegrateSpringBootTest;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderLineItem;
+import band.gosrock.domain.domains.order.domain.OrderMethod;
 import band.gosrock.domain.domains.order.domain.OrderStatus;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -40,6 +41,7 @@ class OrderApproveServiceConcurrencyFailTest {
         given(orderLineItem.isNeedPaid()).willReturn(Boolean.FALSE);
         order =
                 Order.builder()
+                        .orderMethod(OrderMethod.APPROVAL)
                         .orderStatus(OrderStatus.PENDING_APPROVE)
                         .orderLineItems(List.of(orderLineItem))
                         .build();

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyFailTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyFailTest.java
@@ -37,7 +37,7 @@ class OrderApproveServiceConcurrencyFailTest {
 
     @BeforeEach
     void setUp() {
-        given(orderLineItem.isNeedPayment()).willReturn(Boolean.FALSE);
+        given(orderLineItem.isNeedPaid()).willReturn(Boolean.FALSE);
         order =
                 Order.builder()
                         .orderStatus(OrderStatus.PENDING_APPROVE)

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
@@ -10,6 +10,7 @@ import band.gosrock.domain.DomainIntegrateSpringBootTest;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderLineItem;
+import band.gosrock.domain.domains.order.domain.OrderMethod;
 import band.gosrock.domain.domains.order.domain.OrderStatus;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -42,7 +43,8 @@ class OrderApproveServiceConcurrencyTest {
         given(orderLineItem.isNeedPaid()).willReturn(Boolean.FALSE);
         order =
                 Order.builder()
-                        .orderStatus(OrderStatus.PENDING_APPROVE)
+                    .orderMethod(OrderMethod.APPROVAL)
+                    .orderStatus(OrderStatus.PENDING_APPROVE)
                         .orderLineItems(List.of(orderLineItem))
                         .build();
         order.addUUID();

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
@@ -39,7 +39,7 @@ class OrderApproveServiceConcurrencyTest {
 
     @BeforeEach
     void setUp() {
-        given(orderLineItem.isNeedPayment()).willReturn(Boolean.FALSE);
+        given(orderLineItem.isNeedPaid()).willReturn(Boolean.FALSE);
         order =
                 Order.builder()
                         .orderStatus(OrderStatus.PENDING_APPROVE)

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
@@ -43,8 +43,8 @@ class OrderApproveServiceConcurrencyTest {
         given(orderLineItem.isNeedPaid()).willReturn(Boolean.FALSE);
         order =
                 Order.builder()
-                    .orderMethod(OrderMethod.APPROVAL)
-                    .orderStatus(OrderStatus.PENDING_APPROVE)
+                        .orderMethod(OrderMethod.APPROVAL)
+                        .orderStatus(OrderStatus.PENDING_APPROVE)
                         .orderLineItems(List.of(orderLineItem))
                         .build();
         order.addUUID();


### PR DESCRIPTION
## 개요
- close #168 

## 작업사항
- 0원 주문일때 승인 주문만이 아니라 그냥 바로 결제 되게기능을 고쳤습니다.
- 놓치고있었네요..!


 - [EnumValuePropertyCustomizer](https://github.com/Gosrock/DuDoong-Backend/commit/38bd0fa554dae2ec190b381c16d11db6063b7f93)
 - 해당 메서드 추가해서 enum에 json value 붙인게 바로 스웨거 예시값으로 되도록 만들었습니다.


## 변경로직
- 기존에 토스 결제창 필요여부를  결제금액으로 비교했었는데
( 0원이면 무조건 승인 결제로 보내버리는 방식 )
승인 0원 , 선착순 0원 으로 구분지어야하므로
카트,주문 응답시의 상품의 Type이 무엇인지 반환합니다. 
선착순, 승인 두가지로

아래 로직으로 변화했습니다.

선착순 상품인데 isNeedPaid() 가 true면 토스결제창띄움
선착순 상품인데 isNeedPaid() 가 false 면 무료상품 토스결제창 안띄움
승인 상품은 isNeedPaid() 가 항상 false 여야만 함.
