### PR TITLE
feat : 호스트 관리 기능 구현

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/coupon/service/CreateCouponUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/coupon/service/CreateCouponUseCase.java
@@ -26,7 +26,7 @@ public class CreateCouponUseCase {
         // 존재하는 유저인지 검증
         User user = userUtils.getCurrentUser();
         // 슈퍼 호스트인지 검증
-        hostService.validateSuperHost(createCouponCampaignRequest.getHostId(), user.getId());
+        hostService.validateSuperHostUser(createCouponCampaignRequest.getHostId(), user.getId());
         // 이미 생성된 쿠폰 코드인지 검증
         createCouponCampaignDomainService.checkCouponCodeExists(
                 createCouponCampaignRequest.getCouponCode());

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
@@ -60,7 +60,7 @@ public class HostController {
         return inviteHostUseCase.execute(hostId, inviteHostRequest);
     }
 
-    @Operation(summary = "호스트 유저의 권한을 변경합니다.")
+    @Operation(summary = "호스트 유저의 권한을 변경합니다.  슈퍼 호스트 이상만 가능합니다.")
     @PatchMapping("/{hostId}/role")
     public HostDetailResponse patchHostUserRole(
             @PathVariable Long hostId,
@@ -69,14 +69,14 @@ public class HostController {
     }
 
     // todo :: 슈퍼 호스트 이상으로?
-    @Operation(summary = "호스트 정보를 변경합니다. 마스터 호스트만 가능합니다.")
+    @Operation(summary = "호스트 정보를 변경합니다. 슈퍼 호스트 이상만 가능합니다.")
     @PatchMapping("/{hostId}/profile")
     public HostDetailResponse patchHostById(
             @PathVariable Long hostId, @RequestBody @Valid UpdateHostRequest updateHostRequest) {
         return updateHostProfileUseCase.execute(hostId, updateHostRequest);
     }
 
-    @Operation(summary = "호스트 슬랙 알람 URL 을 변경합니다. 마스터 호스트만 가능합니다.")
+    @Operation(summary = "호스트 슬랙 알람 URL 을 변경합니다. 슈퍼 호스트 이상만 가능합니다.")
     @PatchMapping("/{hostId}/slack")
     public HostDetailResponse patchHostSlackUrlById(
             @PathVariable Long hostId,

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
@@ -2,12 +2,11 @@ package band.gosrock.api.host.controller;
 
 
 import band.gosrock.api.host.model.dto.request.CreateHostRequest;
+import band.gosrock.api.host.model.dto.request.UpdateHostRequest;
+import band.gosrock.api.host.model.dto.request.UpdateHostSlackRequest;
 import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.api.host.model.dto.response.HostResponse;
-import band.gosrock.api.host.service.CreateHostUseCase;
-import band.gosrock.api.host.service.JoinHostUseCase;
-import band.gosrock.api.host.service.ReadHostListUseCase;
-import band.gosrock.api.host.service.ReadHostUseCase;
+import band.gosrock.api.host.service.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,6 +25,8 @@ public class HostController {
     private final ReadHostUseCase readHostUseCase;
     private final ReadHostListUseCase readHostListUseCase;
     private final CreateHostUseCase createHostUseCase;
+    private final UpdateHostProfileUseCase updateHostProfileUseCase;
+    private final UpdateHostSlackUrlUseCase updateHostSlackUrlUseCase;
     private final JoinHostUseCase joinHostUseCase;
 
     @Operation(summary = "내가 속한 호스트 리스트를 가져옵니다.")
@@ -34,10 +35,27 @@ public class HostController {
         return readHostListUseCase.execute();
     }
 
-    @Operation(summary = "새로운 호스트를 생성합니다. 호스트를 생성한 유저 자신은 슈퍼호스트가 됩니다.")
+    @Operation(summary = "호스트 간편 생성. 호스트를 생성한 유저 자신은 마스터 호스트가 됩니다.")
     @PostMapping
     public HostResponse createHost(@RequestBody @Valid CreateHostRequest createEventRequest) {
         return createHostUseCase.execute(createEventRequest);
+    }
+
+
+    // todo :: 슈퍼 호스트 이상으로?
+    @Operation(summary = "호스트 정보를 변경합니다. 마스터 호스트만 가능합니다.")
+    @PatchMapping("/{hostId}/profile")
+    public HostDetailResponse patchHostById(
+            @PathVariable Long hostId, @RequestBody @Valid UpdateHostRequest updateHostRequest) {
+        return updateHostProfileUseCase.execute(hostId, updateHostRequest);
+    }
+
+    @Operation(summary = "호스트 슬랙 알람 URL 을 변경합니다. 마스터 호스트만 가능합니다.")
+    @PatchMapping("/{hostId}/slack")
+    public HostDetailResponse patchHostSlackUrlById(
+            @PathVariable Long hostId,
+            @RequestBody @Valid UpdateHostSlackRequest updateHostSlackRequest) {
+        return updateHostSlackUrlUseCase.execute(hostId, updateHostSlackRequest);
     }
 
     @Operation(summary = "내가 속해있는, 고유 아이디에 해당하는 호스트 정보를 가져옵니다.")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
@@ -1,10 +1,7 @@
 package band.gosrock.api.host.controller;
 
 
-import band.gosrock.api.host.model.dto.request.CreateHostRequest;
-import band.gosrock.api.host.model.dto.request.InviteHostRequest;
-import band.gosrock.api.host.model.dto.request.UpdateHostRequest;
-import band.gosrock.api.host.model.dto.request.UpdateHostSlackRequest;
+import band.gosrock.api.host.model.dto.request.*;
 import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.api.host.model.dto.response.HostResponse;
 import band.gosrock.api.host.service.*;
@@ -28,6 +25,7 @@ public class HostController {
     private final CreateHostUseCase createHostUseCase;
     private final UpdateHostProfileUseCase updateHostProfileUseCase;
     private final UpdateHostSlackUrlUseCase updateHostSlackUrlUseCase;
+    private final UpdateHostUserRoleUseCase updateHostUserRoleUseCase;
     private final InviteHostUseCase inviteHostUseCase;
     private final JoinHostUseCase joinHostUseCase;
 
@@ -60,6 +58,14 @@ public class HostController {
     public HostDetailResponse inviteHost(
             @PathVariable Long hostId, @RequestBody @Valid InviteHostRequest inviteHostRequest) {
         return inviteHostUseCase.execute(hostId, inviteHostRequest);
+    }
+
+    @Operation(summary = "호스트 유저의 권한을 변경합니다.")
+    @PatchMapping("/{hostId}/role")
+    public HostDetailResponse patchHostUserRole(
+            @PathVariable Long hostId,
+            @RequestBody @Valid UpdateHostUserRoleRequest updateHostUserRoleRequest) {
+        return updateHostUserRoleUseCase.execute(hostId, updateHostUserRoleRequest);
     }
 
     // todo :: 슈퍼 호스트 이상으로?

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
@@ -2,6 +2,7 @@ package band.gosrock.api.host.controller;
 
 
 import band.gosrock.api.host.model.dto.request.CreateHostRequest;
+import band.gosrock.api.host.model.dto.request.InviteHostRequest;
 import band.gosrock.api.host.model.dto.request.UpdateHostRequest;
 import band.gosrock.api.host.model.dto.request.UpdateHostSlackRequest;
 import band.gosrock.api.host.model.dto.response.HostDetailResponse;
@@ -27,6 +28,7 @@ public class HostController {
     private final CreateHostUseCase createHostUseCase;
     private final UpdateHostProfileUseCase updateHostProfileUseCase;
     private final UpdateHostSlackUrlUseCase updateHostSlackUrlUseCase;
+    private final InviteHostUseCase inviteHostUseCase;
     private final JoinHostUseCase joinHostUseCase;
 
     @Operation(summary = "내가 속한 호스트 리스트를 가져옵니다.")
@@ -35,12 +37,30 @@ public class HostController {
         return readHostListUseCase.execute();
     }
 
+    @Operation(summary = "내가 속해있는, 고유 아이디에 해당하는 호스트 정보를 가져옵니다.")
+    @GetMapping("/{hostId}")
+    public HostDetailResponse getHostById(@PathVariable Long hostId) {
+        return readHostUseCase.execute(hostId);
+    }
+
     @Operation(summary = "호스트 간편 생성. 호스트를 생성한 유저 자신은 마스터 호스트가 됩니다.")
     @PostMapping
     public HostResponse createHost(@RequestBody @Valid CreateHostRequest createEventRequest) {
         return createHostUseCase.execute(createEventRequest);
     }
 
+    @Operation(summary = "기존 호스트에 가입합니다.")
+    @PostMapping("/{hostId}/join")
+    public HostDetailResponse joinHost(@PathVariable Long hostId) {
+        return joinHostUseCase.execute(hostId);
+    }
+
+    @Operation(summary = "다른 유저를 호스트 유저로 초대합니다.")
+    @PostMapping("/{hostId}/invite")
+    public HostDetailResponse inviteHost(
+            @PathVariable Long hostId, @RequestBody @Valid InviteHostRequest inviteHostRequest) {
+        return inviteHostUseCase.execute(hostId, inviteHostRequest);
+    }
 
     // todo :: 슈퍼 호스트 이상으로?
     @Operation(summary = "호스트 정보를 변경합니다. 마스터 호스트만 가능합니다.")
@@ -56,17 +76,5 @@ public class HostController {
             @PathVariable Long hostId,
             @RequestBody @Valid UpdateHostSlackRequest updateHostSlackRequest) {
         return updateHostSlackUrlUseCase.execute(hostId, updateHostSlackRequest);
-    }
-
-    @Operation(summary = "내가 속해있는, 고유 아이디에 해당하는 호스트 정보를 가져옵니다.")
-    @GetMapping("/{hostId}")
-    public HostDetailResponse getHostById(@PathVariable Long hostId) {
-        return readHostUseCase.execute(hostId);
-    }
-
-    @Operation(summary = "기존 호스트에 가입합니다.")
-    @PostMapping("/{hostId}/join")
-    public HostDetailResponse joinHost(@PathVariable Long hostId) {
-        return joinHostUseCase.execute(hostId);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/InviteHostRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/InviteHostRequest.java
@@ -2,17 +2,17 @@ package band.gosrock.api.host.model.dto.request;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.Email;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.validator.constraints.URL;
 
 /** 호스트 슬랙 알람 URL 수정 요청 DTO */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class UpdateHostSlackRequest {
-    @Schema(defaultValue = "https://slack.dd.com", description = "슬랙 웹훅 URL")
-    @URL(message = "올바른 슬랙 URL 을 입력해주세요")
-    private String slackUrl;
+public class InviteHostRequest {
+    @Schema(defaultValue = "kls1998@naver.com", description = "초대할 유저 이메일 주소")
+    @Email(message = "올바른 이메일을 입력해주세요")
+    private String email;
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostRequest.java
@@ -5,16 +5,29 @@ import band.gosrock.common.annotation.Phone;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
-/** 호스트 간편 생성 요청 DTO */
+/** 호스트 정보 변경 요청 DTO */
 @Getter
 @RequiredArgsConstructor
-public class CreateHostRequest {
+public class UpdateHostRequest {
     @Schema(defaultValue = "고스락", description = "호스트 이름")
     @NotEmpty(message = "호스트 이름을 입력해주세요")
     private final String name;
+
+    @Schema(defaultValue = "고슬고슬고스락", description = "호스트 간단 소개")
+    @NotNull(message = "간단 소개를 입력해주세요")
+    private final String introduce;
+
+    @Schema(defaultValue = "1990", description = "호스트 시작년도")
+    @Length(min = 4, max = 10, message = "4~10자리 문자열을 입력해주세요")
+    private final String since;
+
+    @Schema(defaultValue = "https://s3.dudoong.com/img", description = "호스트 프로필 이미지")
+    private final String profileImageUrl;
 
     @Schema(defaultValue = "gosrock@gsrk.com", description = "마스터 이메일")
     @Email(message = "올바른 형식의 이메일을 입력하세요")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostSlackRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostSlackRequest.java
@@ -1,0 +1,19 @@
+package band.gosrock.api.host.model.dto.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.URL;
+
+/** 호스트 슬랙 알람 URL 수정 요청 DTO */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateHostSlackRequest {
+    @Schema(defaultValue = "https://slack.dd.com", description = "슬랙 웹훅 URL")
+    @URL(message = "올바른 슬랙 URL 을 입력해주세요")
+    private String slackUrl;
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostUserRoleRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostUserRoleRequest.java
@@ -1,0 +1,24 @@
+package band.gosrock.api.host.model.dto.request;
+
+
+import band.gosrock.common.annotation.Enum;
+import band.gosrock.domain.domains.host.domain.HostRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 호스트 슬랙 알람 URL 수정 요청 DTO */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateHostUserRoleRequest {
+    @Schema(defaultValue = "1", description = "호스트 유저 아이디")
+    @Positive(message = "올바른 유저 고유 아이디를 입력해주세요")
+    private Long userId;
+
+    @Schema(defaultValue = "HOST", description = "호스트 유저 역할")
+    @Enum(enumClass = HostRole.class, message = "HOST 또는 SUPER_HOST 만 허용됩니다")
+    private HostRole role;
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostUserRoleRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostUserRoleRequest.java
@@ -19,6 +19,6 @@ public class UpdateHostUserRoleRequest {
     private Long userId;
 
     @Schema(defaultValue = "HOST", description = "호스트 유저 역할")
-    @Enum(enumClass = HostRole.class, message = "HOST 또는 SUPER_HOST 만 허용됩니다")
+    @Enum(message = "HOST 또는 SUPER_HOST 만 허용됩니다")
     private HostRole role;
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/CreateHostResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/CreateHostResponse.java
@@ -1,13 +1,13 @@
 package band.gosrock.api.host.model.dto.response;
 
 
-import band.gosrock.domain.domains.host.domain.Host;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Deprecated
 public class CreateHostResponse {
     @Schema(description = "담당자 이메일")
     private final String contactEmail;
@@ -22,12 +22,12 @@ public class CreateHostResponse {
     @Schema(description = "파트너쉽 여부")
     private final boolean partner;
 
-    public static CreateHostResponse of(Host host) {
-        return CreateHostResponse.builder()
-                .contactEmail(host.getContactEmail())
-                .contactNumber(host.getContactNumber())
-                .masterUserId(host.getMasterUserId()) // todo:: 마스터 정보 나오도록
-                .partner(host.getPartner())
-                .build();
-    }
+    //    public static CreateHostResponse of(Host host) {
+    //        return CreateHostResponse.builder()
+    //                .contactEmail(host.getContactEmail())
+    //                .contactNumber(host.getContactNumber())
+    //                .masterUserId(host.getMasterUserId()) // todo:: 마스터 정보 나오도록
+    //                .partner(host.getPartner())
+    //                .build();
+    //    }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/HostDetailResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/HostDetailResponse.java
@@ -1,8 +1,10 @@
 package band.gosrock.api.host.model.dto.response;
 
 
+import band.gosrock.domain.common.vo.HostInfoVo;
 import band.gosrock.domain.common.vo.UserInfoVo;
 import band.gosrock.domain.domains.host.domain.Host;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.HashSet;
 import java.util.Set;
@@ -12,20 +14,23 @@ import lombok.Getter;
 @Getter
 @Builder
 public class HostDetailResponse {
-    @Schema(description = "담당자 이메일")
-    private final String contactEmail;
-
-    @Schema(description = "담당자 전화번호")
-    private final String contactNumber;
+    @Schema(description = "호스트 정보")
+    @JsonUnwrapped
+    private final HostInfoVo hostInfo;
 
     @Schema(description = "마스터 유저의 정보")
-    private final UserInfoVo masterHostUserInfo;
+    private final UserInfoVo masterUser;
 
     @Schema(description = "호스트 유저 정보")
-    private final Set<UserInfoVo> hostUserInfoList;
+    private final Set<UserInfoVo> hostUsers;
+
+    @Schema(description = "슬랙 알람 url")
+    private final String slackUrl;
 
     @Schema(description = "파트너쉽 여부")
     private final boolean partner;
+
+    // todo:: 이벤트 정보도 묶어서 내보내기
 
     public static HostDetailResponse of(Host host, Set<UserInfoVo> userInfoVoSet) {
         HostDetailResponseBuilder builder = HostDetailResponse.builder();
@@ -33,16 +38,16 @@ public class HostDetailResponse {
         userInfoVoSet.forEach(
                 userInfoVo -> {
                     if (userInfoVo.getUserId().equals(host.getMasterUserId())) {
-                        builder.masterHostUserInfo(userInfoVo);
+                        builder.masterUser(userInfoVo);
                     } else {
                         userInfoVoList.add(userInfoVo);
                     }
                 });
 
-        return builder.contactEmail(host.getContactEmail())
-                .contactNumber(host.getContactNumber())
-                .hostUserInfoList(userInfoVoList)
+        return builder.hostInfo(HostInfoVo.from(host))
+                .hostUsers(userInfoVoList)
                 .partner(host.getPartner())
+                .slackUrl(host.getSlackUrl())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/HostDetailResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/HostDetailResponse.java
@@ -2,7 +2,7 @@ package band.gosrock.api.host.model.dto.response;
 
 
 import band.gosrock.domain.common.vo.HostInfoVo;
-import band.gosrock.domain.common.vo.UserInfoVo;
+import band.gosrock.domain.common.vo.HostUserVo;
 import band.gosrock.domain.domains.host.domain.Host;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,10 +19,10 @@ public class HostDetailResponse {
     private final HostInfoVo hostInfo;
 
     @Schema(description = "마스터 유저의 정보")
-    private final UserInfoVo masterUser;
+    private final HostUserVo masterUser;
 
     @Schema(description = "호스트 유저 정보")
-    private final Set<UserInfoVo> hostUsers;
+    private final Set<HostUserVo> hostUsers;
 
     @Schema(description = "슬랙 알람 url")
     private final String slackUrl;
@@ -32,15 +32,15 @@ public class HostDetailResponse {
 
     // todo:: 이벤트 정보도 묶어서 내보내기
 
-    public static HostDetailResponse of(Host host, Set<UserInfoVo> userInfoVoSet) {
+    public static HostDetailResponse of(Host host, Set<HostUserVo> hostUserVoSet) {
         HostDetailResponseBuilder builder = HostDetailResponse.builder();
-        Set<UserInfoVo> userInfoVoList = new HashSet<>();
-        userInfoVoSet.forEach(
-                userInfoVo -> {
-                    if (userInfoVo.getUserId().equals(host.getMasterUserId())) {
-                        builder.masterUser(userInfoVo);
+        Set<HostUserVo> userInfoVoList = new HashSet<>();
+        hostUserVoSet.forEach(
+                hostUserVo -> {
+                    if (hostUserVo.getUserInfoVo().getUserId().equals(host.getMasterUserId())) {
+                        builder.masterUser(hostUserVo);
                     } else {
-                        userInfoVoList.add(userInfoVo);
+                        userInfoVoList.add(hostUserVo);
                     }
                 });
 

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/HostResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/HostResponse.java
@@ -1,7 +1,9 @@
 package band.gosrock.api.host.model.dto.response;
 
 
+import band.gosrock.domain.common.vo.HostInfoVo;
 import band.gosrock.domain.domains.host.domain.Host;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,11 +11,9 @@ import lombok.Getter;
 @Getter
 @Builder
 public class HostResponse {
-    @Schema(description = "담당자 이메일")
-    private final String contactEmail;
-
-    @Schema(description = "담당자 전화번호")
-    private final String contactNumber;
+    @Schema(description = "호스트 프로필")
+    @JsonUnwrapped
+    private final HostInfoVo profile;
 
     @Schema(description = "마스터 유저의 고유 아이디")
     private final Long masterUserId;
@@ -23,8 +23,7 @@ public class HostResponse {
 
     public static HostResponse of(Host host) {
         return HostResponse.builder()
-                .contactEmail(host.getContactEmail())
-                .contactNumber(host.getContactNumber())
+                .profile(HostInfoVo.from(host))
                 .masterUserId(host.getMasterUserId())
                 .partner(host.getPartner())
                 .build();

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
@@ -5,6 +5,7 @@ import band.gosrock.api.host.model.dto.request.CreateHostRequest;
 import band.gosrock.api.host.model.dto.request.UpdateHostRequest;
 import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.common.annotation.Mapper;
+import band.gosrock.domain.common.vo.HostUserVo;
 import band.gosrock.domain.common.vo.UserInfoVo;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
@@ -70,13 +71,24 @@ public class HostMapper {
 
     private HostDetailResponse toHostDetailResponseExecute(Host host) {
         Set<Long> userIdList = new HashSet<>();
-
         host.getHostUsers().forEach(hostUser -> userIdList.add(hostUser.getUserId()));
         final Set<UserInfoVo> userInfoVoSet =
                 userAdaptor.queryUserListByIdIn(userIdList).stream()
                         .map(User::toUserInfoVo)
                         .collect(Collectors.toSet());
 
-        return HostDetailResponse.of(host, userInfoVoSet);
+        // todo :: 유저 리스트에 역할까지 추가하기
+
+        final Set<HostUserVo> hostUserVoSet =
+                userInfoVoSet.stream()
+                        .map(
+                                userInfoVo ->
+                                        HostUserVo.from(
+                                                userInfoVo,
+                                                host.getHostUserByUserId(userInfoVo.getUserId())
+                                                        .getRole()))
+                        .collect(Collectors.toSet());
+
+        return HostDetailResponse.of(host, hostUserVoSet);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
@@ -2,11 +2,13 @@ package band.gosrock.api.host.model.mapper;
 
 
 import band.gosrock.api.host.model.dto.request.CreateHostRequest;
+import band.gosrock.api.host.model.dto.request.UpdateHostRequest;
 import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.common.annotation.Mapper;
 import band.gosrock.domain.common.vo.UserInfoVo;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.domain.HostProfile;
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
 import band.gosrock.domain.domains.user.domain.User;
 import java.util.HashSet;
@@ -24,9 +26,22 @@ public class HostMapper {
     @Transactional(readOnly = true)
     public Host toEntity(CreateHostRequest createHostRequest, Long masterUserId) {
         return Host.builder()
+                .name(createHostRequest.getName())
                 .contactEmail(createHostRequest.getContactEmail())
                 .contactNumber(createHostRequest.getContactNumber())
                 .masterUserId(masterUserId)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public HostProfile toHostProfile(UpdateHostRequest updateHostRequest) {
+        return HostProfile.builder()
+                .name(updateHostRequest.getName())
+                .introduce(updateHostRequest.getIntroduce())
+                .since(updateHostRequest.getSince())
+                .profileImageUrl(updateHostRequest.getProfileImageUrl())
+                .contactEmail(updateHostRequest.getContactEmail())
+                .contactNumber(updateHostRequest.getContactNumber())
                 .build();
     }
 

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
@@ -45,9 +45,16 @@ public class HostMapper {
                 .build();
     }
 
-    public HostUser toHostUser(Long hostId, Long userId, HostRole role) {
+    /** 기본 역할인 HOST 로 강제 주입하는 생성자 */
+    public HostUser toHostUser(Long hostId, Long userId) {
         final Host host = hostAdaptor.findById(hostId);
-        return HostUser.builder().userId(userId).host(host).role(role).build();
+        return HostUser.builder().userId(userId).host(host).role(HostRole.HOST).build();
+    }
+
+    /** 역할 지정하여 주입하는 생성자 */
+    public HostUser toHostUser(Long hostId, Long userId, HostRole hostRole) {
+        final Host host = hostAdaptor.findById(hostId);
+        return HostUser.builder().userId(userId).host(host).role(hostRole).build();
     }
 
     @Transactional(readOnly = true)

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
@@ -53,9 +53,9 @@ public class HostMapper {
     }
 
     /** 역할 지정하여 주입하는 생성자 */
-    public HostUser toHostUser(Long hostId, Long userId, HostRole hostRole) {
+    public HostUser toSuperHostUser(Long hostId, Long userId) {
         final Host host = hostAdaptor.findById(hostId);
-        return HostUser.builder().userId(userId).host(host).role(hostRole).build();
+        return HostUser.builder().userId(userId).host(host).role(HostRole.SUPER_HOST).build();
     }
 
     @Transactional(readOnly = true)

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
@@ -9,6 +9,8 @@ import band.gosrock.domain.common.vo.UserInfoVo;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.host.domain.HostProfile;
+import band.gosrock.domain.domains.host.domain.HostRole;
+import band.gosrock.domain.domains.host.domain.HostUser;
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
 import band.gosrock.domain.domains.user.domain.User;
 import java.util.HashSet;
@@ -23,7 +25,6 @@ public class HostMapper {
     private final HostAdaptor hostAdaptor;
     private final UserAdaptor userAdaptor;
 
-    @Transactional(readOnly = true)
     public Host toEntity(CreateHostRequest createHostRequest, Long masterUserId) {
         return Host.builder()
                 .name(createHostRequest.getName())
@@ -33,7 +34,6 @@ public class HostMapper {
                 .build();
     }
 
-    @Transactional(readOnly = true)
     public HostProfile toHostProfile(UpdateHostRequest updateHostRequest) {
         return HostProfile.builder()
                 .name(updateHostRequest.getName())
@@ -43,6 +43,11 @@ public class HostMapper {
                 .contactEmail(updateHostRequest.getContactEmail())
                 .contactNumber(updateHostRequest.getContactNumber())
                 .build();
+    }
+
+    public HostUser toHostUser(Long hostId, Long userId, HostRole role) {
+        final Host host = hostAdaptor.findById(hostId);
+        return HostUser.builder().userId(userId).host(host).role(role).build();
     }
 
     @Transactional(readOnly = true)
@@ -59,7 +64,7 @@ public class HostMapper {
     private HostDetailResponse toHostDetailResponseExecute(Host host) {
         Set<Long> userIdList = new HashSet<>();
 
-        host.getHostUsers().forEach(hostUser -> userIdList.add(hostUser.getHostId()));
+        host.getHostUsers().forEach(hostUser -> userIdList.add(hostUser.getUserId()));
         final Set<UserInfoVo> userInfoVoSet =
                 userAdaptor.queryUserListByIdIn(userIdList).stream()
                         .map(User::toUserInfoVo)

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/CreateHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/CreateHostUseCase.java
@@ -7,7 +7,6 @@ import band.gosrock.api.host.model.dto.response.HostResponse;
 import band.gosrock.api.host.model.mapper.HostMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.domain.Host;
-import band.gosrock.domain.domains.host.domain.HostRole;
 import band.gosrock.domain.domains.host.service.HostService;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +29,6 @@ public class CreateHostUseCase {
         hostService.createHost(host);
 
         return HostResponse.of(
-                hostService.addHostUser(
-                        host, hostMapper.toHostUser(host.getId(), userId, HostRole.SUPER_HOST)));
+                hostService.addHostUser(host, hostMapper.toSuperHostUser(host.getId(), userId)));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/CreateHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/CreateHostUseCase.java
@@ -28,6 +28,6 @@ public class CreateHostUseCase {
         // 호스트 생성
         final Host host = hostMapper.toEntity(createHostRequest, userId);
         hostService.createHost(host);
-        return HostResponse.of(hostService.addHostUser(host, userId, HostRole.SUPER_HOST));
+        return HostResponse.of(hostService.addHostUser(host.getId(), userId, HostRole.SUPER_HOST));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/CreateHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/CreateHostUseCase.java
@@ -28,6 +28,9 @@ public class CreateHostUseCase {
         // 호스트 생성
         final Host host = hostMapper.toEntity(createHostRequest, userId);
         hostService.createHost(host);
-        return HostResponse.of(hostService.addHostUser(host.getId(), userId, HostRole.SUPER_HOST));
+
+        return HostResponse.of(
+                hostService.addHostUser(
+                        host, hostMapper.toHostUser(host.getId(), userId, HostRole.SUPER_HOST)));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/InviteHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/InviteHostUseCase.java
@@ -35,5 +35,7 @@ public class InviteHostUseCase {
         final Host host = hostAdaptor.findById(hostId);
         final HostUser hostUser = hostMapper.toHostUser(hostId, inviteUserId);
         return hostMapper.toHostDetailResponse(hostService.addHostUser(host, hostUser));
+
+        // todo :: 초대 성공 시 상대방에게 알림 이벤트 발송
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/InviteHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/InviteHostUseCase.java
@@ -2,39 +2,36 @@ package band.gosrock.api.host.service;
 
 
 import band.gosrock.api.common.UserUtils;
+import band.gosrock.api.host.model.dto.request.InviteHostRequest;
 import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.api.host.model.mapper.HostMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
-import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.host.domain.HostRole;
-import band.gosrock.domain.domains.host.exception.AlreadyJoinedHostException;
 import band.gosrock.domain.domains.host.service.HostService;
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
-public class JoinHostUseCase {
+public class InviteHostUseCase {
 
     private final UserUtils userUtils;
+    private final UserAdaptor userAdaptor;
     private final HostService hostService;
     private final HostAdaptor hostAdaptor;
     private final HostMapper hostMapper;
 
     @Transactional
-    public HostDetailResponse execute(Long hostId) {
+    public HostDetailResponse execute(Long hostId, InviteHostRequest inviteHostRequest) {
         // 존재하는 유저인지 검증
         final User user = userUtils.getCurrentUser();
-        final Long userId = user.getId();
-        final Host host = hostAdaptor.findById(hostId);
-
-        // 이 호스트에 이미 속함
-        if (host.hasHostUserId(userId)) {
-            throw AlreadyJoinedHostException.EXCEPTION;
-        }
-        hostService.addHostUser(host.getId(), userId, HostRole.HOST);
-        return hostMapper.toHostDetailResponse(host);
+        // 초대할 유저
+        final Long inviteUserId =
+                userAdaptor.queryUserByEmail(inviteHostRequest.getEmail()).getId();
+        return hostMapper.toHostDetailResponse(
+                hostService.addHostUser(hostId, inviteUserId, HostRole.HOST));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/InviteHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/InviteHostUseCase.java
@@ -7,7 +7,8 @@ import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.api.host.model.mapper.HostMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
-import band.gosrock.domain.domains.host.domain.HostRole;
+import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.domain.HostUser;
 import band.gosrock.domain.domains.host.service.HostService;
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
 import band.gosrock.domain.domains.user.domain.User;
@@ -31,7 +32,8 @@ public class InviteHostUseCase {
         // 초대할 유저
         final Long inviteUserId =
                 userAdaptor.queryUserByEmail(inviteHostRequest.getEmail()).getId();
-        return hostMapper.toHostDetailResponse(
-                hostService.addHostUser(hostId, inviteUserId, HostRole.HOST));
+        final Host host = hostAdaptor.findById(hostId);
+        final HostUser hostUser = hostMapper.toHostUser(hostId, inviteUserId);
+        return hostMapper.toHostDetailResponse(hostService.addHostUser(host, hostUser));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/JoinHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/JoinHostUseCase.java
@@ -7,7 +7,6 @@ import band.gosrock.api.host.model.mapper.HostMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
-import band.gosrock.domain.domains.host.domain.HostRole;
 import band.gosrock.domain.domains.host.exception.AlreadyJoinedHostException;
 import band.gosrock.domain.domains.host.service.HostService;
 import band.gosrock.domain.domains.user.domain.User;
@@ -34,7 +33,7 @@ public class JoinHostUseCase {
         if (host.hasHostUserId(userId)) {
             throw AlreadyJoinedHostException.EXCEPTION;
         }
-        hostService.addHostUser(host.getId(), userId, HostRole.HOST);
+        hostService.addHostUser(host, hostMapper.toHostUser(hostId, userId));
         return hostMapper.toHostDetailResponse(host);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostProfileUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostProfileUseCase.java
@@ -32,6 +32,6 @@ public class UpdateHostProfileUseCase {
         // 마스터 호스트 검증
         hostService.validateMasterUser(host, userId);
         host.setProfile(hostMapper.toHostProfile(updateHostRequest));
-        return hostMapper.toHostDetailResponse(hostService.save(host));
+        return hostMapper.toHostDetailResponse(hostService.updateHost(host));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostProfileUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostProfileUseCase.java
@@ -1,0 +1,37 @@
+package band.gosrock.api.host.service;
+
+
+import band.gosrock.api.common.UserUtils;
+import band.gosrock.api.host.model.dto.request.UpdateHostRequest;
+import band.gosrock.api.host.model.dto.response.HostDetailResponse;
+import band.gosrock.api.host.model.mapper.HostMapper;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
+import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.service.HostService;
+import band.gosrock.domain.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class UpdateHostProfileUseCase {
+    private final UserUtils userUtils;
+    private final HostService hostService;
+    private final HostAdaptor hostAdaptor;
+    private final HostMapper hostMapper;
+
+    @Transactional
+    public HostDetailResponse execute(Long hostId, UpdateHostRequest updateHostRequest) {
+        // 존재하는 유저인지 검증
+        final User user = userUtils.getCurrentUser();
+        final Long userId = user.getId();
+
+        final Host host = hostAdaptor.findById(hostId);
+
+        // 마스터 호스트 검증
+        hostService.validateMasterUser(host, userId);
+        host.setProfile(hostMapper.toHostProfile(updateHostRequest));
+        return hostMapper.toHostDetailResponse(hostService.save(host));
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostProfileUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostProfileUseCase.java
@@ -31,7 +31,7 @@ public class UpdateHostProfileUseCase {
         // 슈퍼 호스트 검증
         host.validateSuperHostUser(userId);
 
-
-        return hostMapper.toHostDetailResponse(hostService.updateHostProfile(host, hostMapper.toHostProfile(updateHostRequest)));
+        return hostMapper.toHostDetailResponse(
+                hostService.updateHostProfile(host, hostMapper.toHostProfile(updateHostRequest)));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostProfileUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostProfileUseCase.java
@@ -28,10 +28,10 @@ public class UpdateHostProfileUseCase {
         final Long userId = user.getId();
 
         final Host host = hostAdaptor.findById(hostId);
-
         // 슈퍼 호스트 검증
-        hostService.validateSuperHost(host, userId);
-        host.setProfile(hostMapper.toHostProfile(updateHostRequest));
-        return hostMapper.toHostDetailResponse(hostService.updateHost(host));
+        host.validateSuperHostUser(userId);
+
+
+        return hostMapper.toHostDetailResponse(hostService.updateHostProfile(host, hostMapper.toHostProfile(updateHostRequest)));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
@@ -30,7 +30,7 @@ public class UpdateHostSlackUrlUseCase {
         final Host host = hostAdaptor.findById(hostId);
 
         // 마스터 호스트 검증
-        hostService.validateMasterUser(host, userId);
+        hostService.validateSuperHost(host, userId);
         host.setSlackUrl(updateHostSlackRequest.getSlackUrl());
         return hostMapper.toHostDetailResponse(hostService.updateHost(host));
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
@@ -28,10 +28,9 @@ public class UpdateHostSlackUrlUseCase {
         final Long userId = user.getId();
 
         final Host host = hostAdaptor.findById(hostId);
+        final String slackUrl = updateHostSlackRequest.getSlackUrl();
         // 슈퍼 호스트 검증
         host.validateSuperHostUser(userId);
-
-        host.setSlackUrl(updateHostSlackRequest.getSlackUrl());
-        return hostMapper.toHostDetailResponse(hostService.updateHost(host));
+        return hostMapper.toHostDetailResponse(hostService.updateHostSlackUrl(host, slackUrl));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
@@ -32,6 +32,6 @@ public class UpdateHostSlackUrlUseCase {
         // 마스터 호스트 검증
         hostService.validateMasterUser(host, userId);
         host.setSlackUrl(updateHostSlackRequest.getSlackUrl());
-        return hostMapper.toHostDetailResponse(hostService.save(host));
+        return hostMapper.toHostDetailResponse(hostService.updateHost(host));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
@@ -1,0 +1,37 @@
+package band.gosrock.api.host.service;
+
+
+import band.gosrock.api.common.UserUtils;
+import band.gosrock.api.host.model.dto.request.UpdateHostSlackRequest;
+import band.gosrock.api.host.model.dto.response.HostDetailResponse;
+import band.gosrock.api.host.model.mapper.HostMapper;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
+import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.service.HostService;
+import band.gosrock.domain.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class UpdateHostSlackUrlUseCase {
+    private final UserUtils userUtils;
+    private final HostService hostService;
+    private final HostAdaptor hostAdaptor;
+    private final HostMapper hostMapper;
+
+    @Transactional
+    public HostDetailResponse execute(Long hostId, UpdateHostSlackRequest updateHostSlackRequest) {
+        // 존재하는 유저인지 검증
+        final User user = userUtils.getCurrentUser();
+        final Long userId = user.getId();
+
+        final Host host = hostAdaptor.findById(hostId);
+
+        // 마스터 호스트 검증
+        hostService.validateMasterUser(host, userId);
+        host.setSlackUrl(updateHostSlackRequest.getSlackUrl());
+        return hostMapper.toHostDetailResponse(hostService.save(host));
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
@@ -28,9 +28,9 @@ public class UpdateHostSlackUrlUseCase {
         final Long userId = user.getId();
 
         final Host host = hostAdaptor.findById(hostId);
+        // 슈퍼 호스트 검증
+        host.validateSuperHostUser(userId);
 
-        // 마스터 호스트 검증
-        hostService.validateSuperHost(host, userId);
         host.setSlackUrl(updateHostSlackRequest.getSlackUrl());
         return hostMapper.toHostDetailResponse(hostService.updateHost(host));
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostUserRoleUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostUserRoleUseCase.java
@@ -9,7 +9,6 @@ import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.host.domain.HostRole;
-import band.gosrock.domain.domains.host.exception.ForbiddenHostOperationException;
 import band.gosrock.domain.domains.host.service.HostService;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostUserRoleUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostUserRoleUseCase.java
@@ -28,19 +28,13 @@ public class UpdateHostUserRoleUseCase {
             Long hostId, UpdateHostUserRoleRequest updateHostUserRoleRequest) {
         // 존재하는 유저인지 검증
         final User user = userUtils.getCurrentUser();
-        final Host host = hostAdaptor.findById(hostId);
         final Long userId = user.getId();
+        final Host host = hostAdaptor.findById(hostId);
+        // 슈퍼 호스트 검증
+        host.validateSuperHostUser(userId);
 
         final Long updateUserId = updateHostUserRoleRequest.getUserId();
         final HostRole updateUserRole = updateHostUserRoleRequest.getRole();
-
-        // 마스터 호스트 검증
-        hostService.validateSuperHost(host, userId);
-
-        // 마스터 호스트의 권한은 변경할 수 없음
-        if (host.getMasterUserId().equals(updateUserId)) {
-            throw ForbiddenHostOperationException.EXCEPTION;
-        }
 
         return hostMapper.toHostDetailResponse(
                 hostService.updateHostUserRole(host, updateUserId, updateUserRole));

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostUserRoleUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostUserRoleUseCase.java
@@ -2,12 +2,14 @@ package band.gosrock.api.host.service;
 
 
 import band.gosrock.api.common.UserUtils;
-import band.gosrock.api.host.model.dto.request.UpdateHostRequest;
+import band.gosrock.api.host.model.dto.request.UpdateHostUserRoleRequest;
 import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.api.host.model.mapper.HostMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.domain.HostRole;
+import band.gosrock.domain.domains.host.exception.ForbiddenHostOperationException;
 import band.gosrock.domain.domains.host.service.HostService;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -15,23 +17,32 @@ import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
-public class UpdateHostProfileUseCase {
+public class UpdateHostUserRoleUseCase {
     private final UserUtils userUtils;
     private final HostService hostService;
     private final HostAdaptor hostAdaptor;
     private final HostMapper hostMapper;
 
     @Transactional
-    public HostDetailResponse execute(Long hostId, UpdateHostRequest updateHostRequest) {
+    public HostDetailResponse execute(
+            Long hostId, UpdateHostUserRoleRequest updateHostUserRoleRequest) {
         // 존재하는 유저인지 검증
         final User user = userUtils.getCurrentUser();
+        final Host host = hostAdaptor.findById(hostId);
         final Long userId = user.getId();
 
-        final Host host = hostAdaptor.findById(hostId);
+        final Long updateUserId = updateHostUserRoleRequest.getUserId();
+        final HostRole updateUserRole = updateHostUserRoleRequest.getRole();
 
-        // 슈퍼 호스트 검증
+        // 마스터 호스트 검증
         hostService.validateSuperHost(host, userId);
-        host.setProfile(hostMapper.toHostProfile(updateHostRequest));
-        return hostMapper.toHostDetailResponse(hostService.updateHost(host));
+
+        // 마스터 호스트의 권한은 변경할 수 없음
+        if (host.getMasterUserId().equals(updateUserId)) {
+            throw ForbiddenHostOperationException.EXCEPTION;
+        }
+
+        return hostMapper.toHostDetailResponse(
+                hostService.updateHostUserRole(host, updateUserId, updateUserRole));
     }
 }

--- a/DuDoong-Common/src/main/java/band/gosrock/common/annotation/Enum.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/annotation/Enum.java
@@ -19,6 +19,4 @@ public @interface Enum {
     Class<?>[] groups() default {};
 
     Class<? extends Payload>[] payload() default {};
-
-    Class<? extends java.lang.Enum<?>> enumClass();
 }

--- a/DuDoong-Common/src/main/java/band/gosrock/common/annotation/Enum.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/annotation/Enum.java
@@ -1,0 +1,24 @@
+package band.gosrock.common.annotation;
+
+
+import band.gosrock.common.annotation.validator.EnumValidator;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/** RequestBody 의 Enum 검증을 위한 어노테이션 입니다 - 노경민 */
+@Constraint(validatedBy = {EnumValidator.class})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Enum {
+    String message() default "Invalid Enum Value.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends java.lang.Enum<?>> enumClass();
+}

--- a/DuDoong-Common/src/main/java/band/gosrock/common/annotation/validator/EnumValidator.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/annotation/validator/EnumValidator.java
@@ -4,28 +4,27 @@ package band.gosrock.common.annotation.validator;
 import band.gosrock.common.annotation.Enum;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import org.springframework.beans.BeanWrapperImpl;
 
 public class EnumValidator implements ConstraintValidator<Enum, java.lang.Enum> {
-
-    private Enum annotation;
-
-    @Override
-    public void initialize(Enum constraintAnnotation) {
-        this.annotation = constraintAnnotation;
-    }
-
     @Override
     public boolean isValid(java.lang.Enum value, ConstraintValidatorContext context) {
         boolean result = false;
-        Object[] enumValues = this.annotation.enumClass().getEnumConstants();
-        if (enumValues != null) {
-            for (Object enumValue : enumValues) {
-                if (value == enumValue) {
-                    result = true;
-                    break;
+        try {
+            // 리플렉션을 이용한 Enum 클래스 가져오기
+            Class<?> reflectionEnumClass = new BeanWrapperImpl(value).getWrappedClass();
+            Object[] enumValues = reflectionEnumClass.getEnumConstants();
+            if (enumValues != null) {
+                for (Object enumValue : enumValues) {
+                    if (value == enumValue) {
+                        result = true;
+                        break;
+                    }
                 }
             }
+            return result;
+        } catch (Exception e) {
+            return false;
         }
-        return result;
     }
 }

--- a/DuDoong-Common/src/main/java/band/gosrock/common/annotation/validator/EnumValidator.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/annotation/validator/EnumValidator.java
@@ -1,0 +1,31 @@
+package band.gosrock.common.annotation.validator;
+
+
+import band.gosrock.common.annotation.Enum;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<Enum, java.lang.Enum> {
+
+    private Enum annotation;
+
+    @Override
+    public void initialize(Enum constraintAnnotation) {
+        this.annotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(java.lang.Enum value, ConstraintValidatorContext context) {
+        boolean result = false;
+        Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+        if (enumValues != null) {
+            for (Object enumValue : enumValues) {
+                if (value == enumValue) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostInfoVo.java
@@ -1,0 +1,38 @@
+package band.gosrock.domain.common.vo;
+
+
+import band.gosrock.domain.domains.host.domain.Host;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class HostInfoVo {
+    private final Long hostId;
+
+    private final String name;
+
+    private final String introduce;
+
+    private final String since;
+
+    private final String profileImageUrl;
+
+    private final String contactEmail;
+
+    private final String contactNumber;
+
+    private final boolean partner;
+
+    public static HostInfoVo from(Host host) {
+        return HostInfoVo.builder()
+                .hostId(host.getId())
+                .name(host.getProfile().getName())
+                .introduce(host.getProfile().getIntroduce())
+                .since(host.getProfile().getSince())
+                .profileImageUrl(host.getProfile().getProfileImageUrl())
+                .contactEmail(host.getProfile().getContactEmail())
+                .contactNumber(host.getProfile().getContactNumber())
+                .build();
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostUserVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostUserVo.java
@@ -1,0 +1,24 @@
+package band.gosrock.domain.common.vo;
+
+
+import band.gosrock.domain.domains.host.domain.HostRole;
+import band.gosrock.domain.domains.user.domain.User;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class HostUserVo {
+    @JsonUnwrapped private final UserInfoVo userInfoVo;
+
+    private final HostRole role;
+
+    public static HostUserVo from(User user, HostRole role) {
+        return HostUserVo.builder().userInfoVo(user.toUserInfoVo()).role(role).build();
+    }
+
+    public static HostUserVo from(UserInfoVo userInfoVo, HostRole role) {
+        return HostUserVo.builder().userInfoVo(userInfoVo).role(role).build();
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
@@ -31,9 +31,8 @@ public class Host extends BaseTimeEntity {
     private String slackUrl;
 
     // 단방향 oneToMany 매핑
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @JoinColumn(name = "host_user_id")
-    private Set<HostUser> hostUsers = new HashSet<>();
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    private final Set<HostUser> hostUsers = new HashSet<>();
 
     public void addHostUsers(Set<HostUser> hostUserList) {
         this.hostUsers.addAll(hostUserList);

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
@@ -19,12 +19,7 @@ public class Host extends BaseTimeEntity {
     @Column(name = "host_id")
     private Long id;
 
-    // 대표자 이메일
-    private String contactEmail;
-
-    // 대표자 연락처
-    @Column(length = 15)
-    private String contactNumber;
+    @Embedded private HostProfile profile;
 
     // 마스터 유저 id
     private Long masterUserId;
@@ -32,7 +27,10 @@ public class Host extends BaseTimeEntity {
     // 파트너 여부
     private Boolean partner;
 
-    //         단방향 oneToMany 매핑
+    // 슬랙 웹훅 url
+    private String slackUrl;
+
+    // 단방향 oneToMany 매핑
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "host_user_id")
     private Set<HostUser> hostUsers = new HashSet<>();
@@ -45,6 +43,14 @@ public class Host extends BaseTimeEntity {
         return this.hostUsers.stream().anyMatch(hostUser -> hostUser.getUserId().equals(userId));
     }
 
+    public void setProfile(HostProfile hostProfile) {
+        this.profile = hostProfile;
+    }
+
+    public void setSlackUrl(String slackUrl) {
+        this.slackUrl = slackUrl;
+    }
+
     public Boolean isSuperHostUserId(Long userId) {
         return this.hostUsers.stream()
                 .anyMatch(
@@ -54,10 +60,26 @@ public class Host extends BaseTimeEntity {
     }
 
     @Builder
-    public Host(String contactEmail, String contactNumber, Long masterUserId) {
-        this.contactEmail = contactEmail;
-        this.contactNumber = contactNumber;
+    public Host(
+            String name,
+            String introduce,
+            String since,
+            String profileImageUrl,
+            String contactEmail,
+            String contactNumber,
+            String slackUrl,
+            Long masterUserId) {
+        this.profile =
+                HostProfile.builder()
+                        .name(name)
+                        .introduce(introduce)
+                        .since(since)
+                        .profileImageUrl(profileImageUrl)
+                        .contactEmail(contactEmail)
+                        .contactNumber(contactNumber)
+                        .build();
         this.masterUserId = masterUserId;
+        this.slackUrl = slackUrl;
         this.partner = false; // 정책상 초기값 false 로 고정입니다
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
@@ -2,6 +2,7 @@ package band.gosrock.domain.domains.host.domain;
 
 
 import band.gosrock.domain.common.model.BaseTimeEntity;
+import band.gosrock.domain.domains.host.exception.HostUserNotFoundException;
 import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.*;
@@ -42,6 +43,13 @@ public class Host extends BaseTimeEntity {
         return this.hostUsers.stream().anyMatch(hostUser -> hostUser.getUserId().equals(userId));
     }
 
+    public HostUser getHostUserByUserId(Long userId) {
+        return this.hostUsers.stream()
+                .filter(hostUser -> hostUser.getUserId().equals(userId))
+                .findFirst()
+                .orElse(null);
+    }
+
     public void setProfile(HostProfile hostProfile) {
         this.profile = hostProfile;
     }
@@ -56,6 +64,14 @@ public class Host extends BaseTimeEntity {
                         hostUser ->
                                 hostUser.getUserId().equals(userId)
                                         && hostUser.getRole().equals(HostRole.SUPER_HOST));
+    }
+
+    public void setHostUserRole(Long userId, HostRole role) {
+        this.hostUsers.stream()
+                .filter(hostUser -> hostUser.getUserId().equals(userId))
+                .findFirst()
+                .orElseThrow(() -> HostUserNotFoundException.EXCEPTION)
+                .setHostRole(role);
     }
 
     @Builder

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
@@ -4,12 +4,11 @@ package band.gosrock.domain.domains.host.domain;
 import band.gosrock.domain.common.model.BaseTimeEntity;
 import band.gosrock.domain.domains.host.exception.ForbiddenHostOperationException;
 import band.gosrock.domain.domains.host.exception.HostUserNotFoundException;
+import band.gosrock.domain.domains.host.exception.NotMasterHostException;
+import band.gosrock.domain.domains.host.exception.NotSuperHostException;
 import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.*;
-
-import band.gosrock.domain.domains.host.exception.NotMasterHostException;
-import band.gosrock.domain.domains.host.exception.NotSuperHostException;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostProfile.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostProfile.java
@@ -1,0 +1,50 @@
+package band.gosrock.domain.domains.host.domain;
+
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HostProfile {
+    // 호스트 이름
+    private String name;
+
+    // 간단 소개
+    private String introduce;
+
+    // 호스트 시작 연도
+    @Column(length = 10) // xxxx.xx.xx 까지 허용
+    private String since;
+
+    // 프로필 이미지 url
+    private String profileImageUrl;
+
+    // 대표자 이메일
+    private String contactEmail;
+
+    // 대표자 연락처
+    @Column(length = 15)
+    private String contactNumber;
+
+    @Builder
+    public HostProfile(
+            String name,
+            String introduce,
+            String since,
+            String profileImageUrl,
+            String contactEmail,
+            String contactNumber) {
+        this.name = name;
+        this.introduce = introduce;
+        this.since = since;
+        this.profileImageUrl = profileImageUrl;
+        this.contactEmail = contactEmail;
+        this.contactNumber = contactNumber;
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostRole.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostRole.java
@@ -1,16 +1,28 @@
 package band.gosrock.domain.domains.host.domain;
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum HostRole {
-    // 슈퍼 호스트
+    // 슈퍼 호스트 (조회, 변경 가능)
     SUPER_HOST("SUPER_HOST"),
-    // 일반 호스트
+    // 일반 호스트 (조회만 가능)
     HOST("HOST");
 
-    private String value;
+    private final String value;
+
+    // Enum Validation 을 위한 코드, enum 에 속하지 않으면 null 리턴
+    @JsonCreator
+    public static HostRole fromHostRole(String val) {
+        for (HostRole hostRole : HostRole.values()) {
+            if (hostRole.name().equals(val)) {
+                return hostRole;
+            }
+        }
+        return null;
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostUser.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostUser.java
@@ -30,7 +30,11 @@ public class HostUser extends BaseTimeEntity {
 
     // 유저의 권한
     @Enumerated(EnumType.STRING)
-    private HostRole role;
+    private HostRole role = HostRole.HOST;
+
+    public void setHostRole(HostRole role) {
+        this.role = role;
+    }
 
     @Builder
     public HostUser(Host host, Long userId, HostRole role) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostUser.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostUser.java
@@ -11,12 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "tbl_host_user")
-@Table(
-        uniqueConstraints = {
-            @UniqueConstraint(
-                    name = "constraintName",
-                    columnNames = {"host_id", "user_id"})
-        })
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"host_id", "user_id"})})
 public class HostUser extends BaseTimeEntity {
 
     @Id
@@ -25,8 +20,9 @@ public class HostUser extends BaseTimeEntity {
     private Long id;
 
     // 소속 호스트 아이디
-    @Column(name = "host_id")
-    private Long hostId;
+    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_id")
+    private Host host;
 
     // 소속 호스트를 관리중인 유저 아이디
     @Column(name = "user_id")
@@ -37,8 +33,8 @@ public class HostUser extends BaseTimeEntity {
     private HostRole role;
 
     @Builder
-    public HostUser(Long hostId, Long userId, HostRole role) {
-        this.hostId = hostId;
+    public HostUser(Host host, Long userId, HostRole role) {
+        this.host = host;
         this.userId = userId;
         this.role = role;
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/ForbiddenHostOperationException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/ForbiddenHostOperationException.java
@@ -1,0 +1,12 @@
+package band.gosrock.domain.domains.host.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class ForbiddenHostOperationException extends DuDoongCodeException {
+    public static final DuDoongCodeException EXCEPTION = new ForbiddenHostOperationException();
+
+    private ForbiddenHostOperationException() {
+        super(HostErrorCode.FORBIDDEN_HOST_OPERATION);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostErrorCode.java
@@ -14,11 +14,13 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum HostErrorCode implements BaseErrorCode {
-    HOST_NOT_FOUND(NOT_FOUND, "Host_404_1", "해당 호스트를 찾을 수 없습니다."),
     NOT_SUPER_HOST(BAD_REQUEST, "HOST_400_1", "슈퍼 호스트 권한이 없는 유저입니다."),
     FORBIDDEN_HOST(BAD_REQUEST, "HOST_400_2", "해당 호스트에 대한 접근 권한이 없습니다."),
     ALREADY_JOINED_HOST(BAD_REQUEST, "HOST_400_3", "이미 가입되어 있는 유저입니다."),
-    NOT_MASTER_HOST(BAD_REQUEST, "NOT_MASTER_HOST", "마스터 호스트 권한이 없는 유저입니다.");
+    NOT_MASTER_HOST(BAD_REQUEST, "HOST_400_4", "마스터 호스트 권한이 없는 유저입니다."),
+    FORBIDDEN_HOST_OPERATION(BAD_REQUEST, "HOST_400_5", "마스터 호스트의 권한은 변경할 수 없습니다."),
+    HOST_NOT_FOUND(NOT_FOUND, "Host_404_1", "해당 호스트를 찾을 수 없습니다."),
+    HOST_USER_NOT_FOUND(NOT_FOUND, "HOST_404_2", "가입된 호스트 유저가 아닙니다.");
 
     private Integer status;
     private String code;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostErrorCode.java
@@ -17,7 +17,7 @@ public enum HostErrorCode implements BaseErrorCode {
     HOST_NOT_FOUND(NOT_FOUND, "Host_404_1", "해당 호스트를 찾을 수 없습니다."),
     NOT_SUPER_HOST(BAD_REQUEST, "HOST_400_1", "슈퍼 호스트 권한이 없는 유저입니다."),
     FORBIDDEN_HOST(BAD_REQUEST, "HOST_400_2", "해당 호스트에 대한 접근 권한이 없습니다."),
-    ALREADY_JOINED_HOST(BAD_REQUEST, "HOST_400_3", "이미 가입되어 있는 호스트입니다."),
+    ALREADY_JOINED_HOST(BAD_REQUEST, "HOST_400_3", "이미 가입되어 있는 유저입니다."),
     NOT_MASTER_HOST(BAD_REQUEST, "NOT_MASTER_HOST", "마스터 호스트 권한이 없는 유저입니다.");
 
     private Integer status;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostUserNotFoundException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostUserNotFoundException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.host.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class HostUserNotFoundException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new HostUserNotFoundException();
+
+    private HostUserNotFoundException() {
+        super(HostErrorCode.HOST_USER_NOT_FOUND);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostUserRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostUserRepository.java
@@ -1,0 +1,7 @@
+package band.gosrock.domain.domains.host.repository;
+
+
+import band.gosrock.domain.domains.host.domain.HostUser;
+import org.springframework.data.repository.CrudRepository;
+
+public interface HostUserRepository extends CrudRepository<HostUser, Long> {}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostUserRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostUserRepository.java
@@ -1,7 +1,0 @@
-package band.gosrock.domain.domains.host.repository;
-
-
-import band.gosrock.domain.domains.host.domain.HostUser;
-import org.springframework.data.repository.CrudRepository;
-
-public interface HostUserRepository extends CrudRepository<HostUser, Long> {}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
@@ -8,8 +8,6 @@ import band.gosrock.domain.domains.host.domain.HostProfile;
 import band.gosrock.domain.domains.host.domain.HostRole;
 import band.gosrock.domain.domains.host.domain.HostUser;
 import band.gosrock.domain.domains.host.exception.AlreadyJoinedHostException;
-import band.gosrock.domain.domains.host.exception.NotMasterHostException;
-import band.gosrock.domain.domains.host.exception.NotSuperHostException;
 import band.gosrock.domain.domains.host.repository.HostRepository;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +43,11 @@ public class HostService {
 
     public Host updateHostProfile(Host host, HostProfile profile) {
         host.setProfile(profile);
+        return hostRepository.save(host);
+    }
+
+    public Host updateHostSlackUrl(Host host, String url) {
+        host.setSlackUrl(url);
         return hostRepository.save(host);
     }
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
@@ -4,7 +4,6 @@ package band.gosrock.domain.domains.host.service;
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
-import band.gosrock.domain.domains.host.domain.HostRole;
 import band.gosrock.domain.domains.host.domain.HostUser;
 import band.gosrock.domain.domains.host.exception.AlreadyJoinedHostException;
 import band.gosrock.domain.domains.host.exception.NotMasterHostException;
@@ -27,22 +26,14 @@ public class HostService {
         return hostRepository.save(host);
     }
 
-    public Host save(Host host) {
+    public Host updateHost(Host host) {
         return hostRepository.save(host);
     }
 
     public Host addHostUser(Host host, HostUser hostUser) {
-        host.addHostUsers(Set.of(hostUser));
-        return hostRepository.save(host);
-    }
-
-    public Host addHostUser(Long hostId, Long userId, HostRole role) {
-        Host host = hostAdaptor.findById(hostId);
-        // 이 호스트에 이미 속함
-        if (host.hasHostUserId(userId)) {
+        if (host.hasHostUserId(hostUser.getUserId())) {
             throw AlreadyJoinedHostException.EXCEPTION;
         }
-        HostUser hostUser = HostUser.builder().userId(userId).host(host).role(role).build();
         host.addHostUsers(Set.of(hostUser));
         return hostRepository.save(host);
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
@@ -4,12 +4,12 @@ package band.gosrock.domain.domains.host.service;
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.domain.HostRole;
 import band.gosrock.domain.domains.host.domain.HostUser;
 import band.gosrock.domain.domains.host.exception.AlreadyJoinedHostException;
 import band.gosrock.domain.domains.host.exception.NotMasterHostException;
 import band.gosrock.domain.domains.host.exception.NotSuperHostException;
 import band.gosrock.domain.domains.host.repository.HostRepository;
-import band.gosrock.domain.domains.host.repository.HostUserRepository;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class HostService {
     private final HostRepository hostRepository;
-    private final HostUserRepository hostUserRepository;
     private final HostAdaptor hostAdaptor;
 
     public Host createHost(Host host) {
@@ -38,8 +37,9 @@ public class HostService {
         return hostRepository.save(host);
     }
 
-    public HostUser createHostUser(HostUser hostUser) {
-        return hostUserRepository.save(hostUser);
+    public Host updateHostUserRole(Host host, Long userId, HostRole role) {
+        host.setHostUserRole(userId, role);
+        return hostRepository.save(host);
     }
 
     /** 해당 유저가 호스트의 마스터(담당자, 방장)인지 확인하는 검증 로직입니다 */
@@ -61,6 +61,13 @@ public class HostService {
     /** 해당 유저가 슈퍼 호스트인지 확인하는 검증 로직입니다 */
     public void validateSuperHost(Long hostId, Long userId) {
         Host host = hostAdaptor.findById(hostId);
+        if (host.isSuperHostUserId(userId)) {
+            return;
+        }
+        throw NotSuperHostException.EXCEPTION;
+    }
+
+    public void validateSuperHost(Host host, Long userId) {
         if (host.isSuperHostUserId(userId)) {
             return;
         }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
@@ -24,6 +24,10 @@ public class HostService {
         return hostRepository.save(host);
     }
 
+    public Host save(Host host) {
+        return hostRepository.save(host);
+    }
+
     public Host addHostUser(Host host, HostUser hostUser) {
         host.addHostUsers(Set.of(hostUser));
         return hostRepository.save(host);
@@ -39,6 +43,13 @@ public class HostService {
     /** 해당 유저가 호스트의 마스터(담당자, 방장)인지 확인하는 검증 로직입니다 */
     public void validateMasterUser(Long hostId, Long userId) {
         Host host = hostAdaptor.findById(hostId);
+        if (host.getMasterUserId().equals(userId)) {
+            return;
+        }
+        throw NotMasterHostException.EXCEPTION;
+    }
+
+    public void validateMasterUser(Host host, Long userId) {
         if (host.getMasterUserId().equals(userId)) {
             return;
         }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
@@ -4,6 +4,7 @@ package band.gosrock.domain.domains.host.service;
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.domain.HostProfile;
 import band.gosrock.domain.domains.host.domain.HostRole;
 import band.gosrock.domain.domains.host.domain.HostUser;
 import band.gosrock.domain.domains.host.exception.AlreadyJoinedHostException;
@@ -42,35 +43,19 @@ public class HostService {
         return hostRepository.save(host);
     }
 
-    /** 해당 유저가 호스트의 마스터(담당자, 방장)인지 확인하는 검증 로직입니다 */
-    public void validateMasterUser(Long hostId, Long userId) {
-        Host host = hostAdaptor.findById(hostId);
-        if (host.getMasterUserId().equals(userId)) {
-            return;
-        }
-        throw NotMasterHostException.EXCEPTION;
+    public Host updateHostProfile(Host host, HostProfile profile) {
+        host.setProfile(profile);
+        return hostRepository.save(host);
     }
 
-    public void validateMasterUser(Host host, Long userId) {
-        if (host.getMasterUserId().equals(userId)) {
-            return;
-        }
-        throw NotMasterHostException.EXCEPTION;
+    /** 해당 유저가 호스트의 마스터(담당자, 방장)인지 확인하는 검증 로직입니다 */
+    public void validateMasterHostUser(Host host, Long userId) {
+        host.validateMasterHostUser(userId);
     }
 
     /** 해당 유저가 슈퍼 호스트인지 확인하는 검증 로직입니다 */
-    public void validateSuperHost(Long hostId, Long userId) {
+    public void validateSuperHostUser(Long hostId, Long userId) {
         Host host = hostAdaptor.findById(hostId);
-        if (host.isSuperHostUserId(userId)) {
-            return;
-        }
-        throw NotSuperHostException.EXCEPTION;
-    }
-
-    public void validateSuperHost(Host host, Long userId) {
-        if (host.isSuperHostUserId(userId)) {
-            return;
-        }
-        throw NotSuperHostException.EXCEPTION;
+        host.validateSuperHostUser(userId);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/adaptor/UserAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/adaptor/UserAdaptor.java
@@ -33,4 +33,11 @@ public class UserAdaptor {
     public Set<User> queryUserListByIdIn(Set<Long> userIdList) {
         return userRepository.findAllByIdIn(userIdList);
     }
+
+    /** 이메일로 유저를 가져오는 쿼리 */
+    public User queryUserByEmail(String email) {
+        return userRepository
+                .findByProfileEmail(email)
+                .orElseThrow(() -> UserNotFoundException.EXCEPTION);
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/repository/UserRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/repository/UserRepository.java
@@ -12,4 +12,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     /** user id 리스트에 포함되어 있는 유저를 모두 가져오는 쿼리 */
     Set<User> findAllByIdIn(Set<Long> id);
+
+    /** email 로 유저를 가져오는 쿼리 */
+    Optional<User> findByProfileEmail(String email);
 }


### PR DESCRIPTION
## 개요
- close #176 

## 작업사항
- 호스트 생성 기능을 호스트 간편 생성, 수정, 관리로 쪼개었습니다
- 호스트 상세 응답값에 유저 정보와 권한이 같이 나오도록 변경하였습니다

```
{
  "success": true,
  "status": 200,
  "data": {
    "hostId": 4,
    "name": "고스락",
    "introduce": null,
    "since": null,
    "profileImageUrl": null,
    "contactEmail": "gosrock@gsrk.com",
    "contactNumber": "010-1111-3333",
    "partner": false,
    "masterUser": {
      "userId": 1,
      "userName": "노경민",
      "email": "{ 메일 }",
      "phoneNumber": "{ 전화번호 }",
      "profileImage": "{ url 정보 }",
      "role": "SUPER_HOST"
    },
    "hostUsers": [
      {
        "userId": 2,
        "userName": "노경민",
        "email": "{ 메일 }",
        "phoneNumber": "{ 전화번호 }",
        "profileImage": "{ url 정보 }",
        "role": "SUPER_HOST"
      }
    ],
    "slackUrl": null
  },
  "timeStamp": "2023-01-23T19:19:33.8529434"
}
```

- 내 호스트에 초대 기능을 구현하였습니다
- 초대 대상도 가입 상태여야 하며, 이메일로 상대방을 찾아서 초대합니다 (나중에 수락 및 알림 기능도 만들어야함)
- host <-> hostUser 단방향 매핑 시 자꾸 fk 제약조건이 걸리며 삽입이 안되는 이유로, 양방향으로 연결하였습니다

![image](https://user-images.githubusercontent.com/72291860/214048273-287590e7-1569-4fbe-a353-88016aeba2ec.png)

- 커스텀 어노테이션 Enum 구현하였습니다
- Request 필드에 붙이면 Valid 처리해줍니다
- 리플렉션 적용하여서 편하게 Enum 만 붙이면 자동으로 타입 알아내서 검증해줍니다 굿굿

![image](https://user-images.githubusercontent.com/72291860/214049048-f85f24d3-a0db-4dba-aa85-51312eb28de6.png)

- Enum Validation 사용할 때 해당 Enum 에 JsonCreator 붙여줘야 JsonParseError 발생 안합니다

## 변경로직
- 위와 같음