### PR TITLE
fix : 주문완료,철회 시 티켓 생성, 재고 관리 관련 세션 오류 해결

### DIFF
--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/DoneOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/DoneOrderEvent.java
@@ -20,12 +20,15 @@ public class DoneOrderEvent extends DomainEvent {
 
     @Nullable private final String paymentKey;
 
+    private final Long itemId;
+
     public static DoneOrderEvent from(Order order) {
         return DoneOrderEvent.builder()
                 .orderMethod(order.getOrderMethod())
                 .paymentKey(order.isNeedPaid() ? order.getPaymentKey() : null)
                 .userId(order.getUserId())
                 .orderUuid(order.getUuid())
+                .itemId(order.getItem().getId())
                 .build();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/DoneOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/DoneOrderEvent.java
@@ -28,7 +28,7 @@ public class DoneOrderEvent extends DomainEvent {
                 .paymentKey(order.isNeedPaid() ? order.getPaymentKey() : null)
                 .userId(order.getUserId())
                 .orderUuid(order.getUuid())
-                .itemId(order.getItem().getId())
+                .itemId(order.getItemId())
                 .build();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
@@ -28,7 +28,7 @@ public class WithDrawOrderEvent extends DomainEvent {
                 .userId(order.getUserId())
                 .orderUuid(order.getUuid())
                 .orderStatus(order.getOrderStatus())
-                .itemId(order.getItem().getId())
+                .itemId(order.getItemId())
                 .build();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
@@ -19,6 +19,7 @@ public class WithDrawOrderEvent extends DomainEvent {
     private final OrderStatus orderStatus;
 
     @Nullable private final String paymentKey;
+    private final Long itemId;
 
     public static WithDrawOrderEvent from(Order order) {
         return WithDrawOrderEvent.builder()
@@ -27,6 +28,7 @@ public class WithDrawOrderEvent extends DomainEvent {
                 .userId(order.getUserId())
                 .orderUuid(order.getUuid())
                 .orderStatus(order.getOrderStatus())
+                .itemId(order.getItem().getId())
                 .build();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -4,17 +4,13 @@ package band.gosrock.domain.domains.issuedTicket.service;
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.common.aop.redissonLock.RedissonLock;
 import band.gosrock.domain.common.vo.IssuedTicketInfoVo;
-import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.exception.HostNotAuthEventException;
 import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
-import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketOptionAnswerAdaptor;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.dto.request.CreateIssuedTicketDTO;
 import band.gosrock.domain.domains.issuedTicket.dto.response.CreateIssuedTicketResponse;
-import band.gosrock.domain.domains.issuedTicket.repository.IssuedTicketRepository;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
-import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
 import band.gosrock.domain.domains.user.domain.User;
 import java.util.List;
@@ -26,29 +22,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class IssuedTicketDomainService {
-
-    private final IssuedTicketRepository issuedTicketRepository;
     private final IssuedTicketAdaptor issuedTicketAdaptor;
-    private final IssuedTicketOptionAnswerAdaptor issuedTicketOptionAnswerAdaptor;
-    private final EventAdaptor eventAdaptor;
     private final UserAdaptor userAdaptor;
     private final OrderAdaptor orderAdaptor;
 
     @RedissonLock(LockName = "티켓재고관리", identifier = "itemId")
     @Transactional
-    public void createIssuedTicket(
-            Long itemId, List<CreateIssuedTicketDTO> createIssuedTicketDTOs) {
-        createIssuedTicketDTOs.forEach(
-                dto -> {
-                    CreateIssuedTicketResponse responseDTO =
-                            IssuedTicket.orderLineItemToIssuedTickets(dto);
-                    issuedTicketAdaptor.saveAll(responseDTO.getIssuedTickets());
-                });
-    }
-
-    @RedissonLock(LockName = "티켓재고관리", paramClassType = TicketItem.class, identifier = "id")
-    @Transactional
-    public void withDrawIssuedTicket(TicketItem ticketItem, List<IssuedTicket> issuedTickets) {
+    public void withDrawIssuedTicket(Long itemId, List<IssuedTicket> issuedTickets) {
         issuedTickets.forEach(
                 issuedTicket -> {
                     issuedTicket.getTicketItem().increaseQuantity(1L);

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -12,7 +12,11 @@ import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.dto.request.CreateIssuedTicketDTO;
 import band.gosrock.domain.domains.issuedTicket.dto.response.CreateIssuedTicketResponse;
 import band.gosrock.domain.domains.issuedTicket.repository.IssuedTicketRepository;
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
+import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
+import band.gosrock.domain.domains.user.domain.User;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -27,11 +31,13 @@ public class IssuedTicketDomainService {
     private final IssuedTicketAdaptor issuedTicketAdaptor;
     private final IssuedTicketOptionAnswerAdaptor issuedTicketOptionAnswerAdaptor;
     private final EventAdaptor eventAdaptor;
+    private final UserAdaptor userAdaptor;
+    private final OrderAdaptor orderAdaptor;
 
-    @RedissonLock(LockName = "티켓재고관리", paramClassType = TicketItem.class, identifier = "id")
+    @RedissonLock(LockName = "티켓재고관리", identifier = "itemId")
     @Transactional
     public void createIssuedTicket(
-            TicketItem ticketItem, List<CreateIssuedTicketDTO> createIssuedTicketDTOs) {
+            Long itemId, List<CreateIssuedTicketDTO> createIssuedTicketDTOs) {
         createIssuedTicketDTOs.forEach(
                 dto -> {
                     CreateIssuedTicketResponse responseDTO =
@@ -59,5 +65,23 @@ public class IssuedTicketDomainService {
         }
         issuedTicket.entrance();
         return issuedTicket.toIssuedTicketInfoVo();
+    }
+
+    @RedissonLock(LockName = "티켓재고관리", identifier = "itemId")
+    public void createIssuedTicket(Long itemId, String orderUuid, Long userId) {
+        User user = userAdaptor.queryUser(userId);
+        Order order = orderAdaptor.findByOrderUuid(orderUuid);
+
+        List<CreateIssuedTicketDTO> createIssuedTicketDTOS =
+            order.getOrderLineItems().stream()
+                .map(orderLineItem -> new CreateIssuedTicketDTO(order, orderLineItem, user))
+                .toList();
+
+        createIssuedTicketDTOS.forEach(
+            dto -> {
+                CreateIssuedTicketResponse responseDTO =
+                    IssuedTicket.orderLineItemToIssuedTickets(dto);
+                issuedTicketAdaptor.saveAll(responseDTO.getIssuedTickets());
+            });
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -73,15 +73,15 @@ public class IssuedTicketDomainService {
         Order order = orderAdaptor.findByOrderUuid(orderUuid);
 
         List<CreateIssuedTicketDTO> createIssuedTicketDTOS =
-            order.getOrderLineItems().stream()
-                .map(orderLineItem -> new CreateIssuedTicketDTO(order, orderLineItem, user))
-                .toList();
+                order.getOrderLineItems().stream()
+                        .map(orderLineItem -> new CreateIssuedTicketDTO(order, orderLineItem, user))
+                        .toList();
 
         createIssuedTicketDTOS.forEach(
-            dto -> {
-                CreateIssuedTicketResponse responseDTO =
-                    IssuedTicket.orderLineItemToIssuedTickets(dto);
-                issuedTicketAdaptor.saveAll(responseDTO.getIssuedTickets());
-            });
+                dto -> {
+                    CreateIssuedTicketResponse responseDTO =
+                            IssuedTicket.orderLineItemToIssuedTickets(dto);
+                    issuedTicketAdaptor.saveAll(responseDTO.getIssuedTickets());
+                });
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
@@ -4,7 +4,6 @@ package band.gosrock.domain.domains.issuedTicket.service.handlers;
 import band.gosrock.domain.common.events.order.DoneOrderEvent;
 import band.gosrock.domain.domains.issuedTicket.service.IssuedTicketDomainService;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
-import band.gosrock.domain.domains.order.domain.Order;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -26,7 +25,9 @@ public class OrderEventHandler {
     public void handleDoneOrderEvent(DoneOrderEvent doneOrderEvent) {
         log.info(doneOrderEvent.getOrderUuid() + "주문 상태 완료, 티켓 생성작업 진행");
         issuedTicketDomainService.createIssuedTicket(
-            doneOrderEvent.getItemId(), doneOrderEvent.getOrderUuid(), doneOrderEvent.getUserId());
+                doneOrderEvent.getItemId(),
+                doneOrderEvent.getOrderUuid(),
+                doneOrderEvent.getUserId());
         log.info(doneOrderEvent.getOrderUuid() + "주문 상태 완료, 티켓 생성작업 완료");
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
@@ -22,7 +22,6 @@ public class OrderEventHandler {
 
     private final IssuedTicketDomainService issuedTicketDomainService;
 
-    private final UserAdaptor userAdaptor;
 
     private final OrderAdaptor orderAdaptor;
 
@@ -31,13 +30,8 @@ public class OrderEventHandler {
             phase = TransactionPhase.BEFORE_COMMIT)
     public void handleDoneOrderEvent(DoneOrderEvent doneOrderEvent) {
         log.info(doneOrderEvent.getOrderUuid() + "주문 상태 완료, 티켓 생성작업 진행");
-        User user = userAdaptor.queryUser(doneOrderEvent.getUserId());
         Order order = orderAdaptor.findByOrderUuid(doneOrderEvent.getOrderUuid());
-        List<CreateIssuedTicketDTO> createIssuedTicketDTOS =
-                order.getOrderLineItems().stream()
-                        .map(orderLineItem -> new CreateIssuedTicketDTO(order, orderLineItem, user))
-                        .toList();
-        issuedTicketDomainService.createIssuedTicket(order.getItem(), createIssuedTicketDTOS);
+        issuedTicketDomainService.createIssuedTicket(order.getItem().getId(), doneOrderEvent.getOrderUuid() , doneOrderEvent.getUserId());
         log.info(doneOrderEvent.getOrderUuid() + "주문 상태 완료, 티켓 생성작업 완료");
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
@@ -2,13 +2,9 @@ package band.gosrock.domain.domains.issuedTicket.service.handlers;
 
 
 import band.gosrock.domain.common.events.order.DoneOrderEvent;
-import band.gosrock.domain.domains.issuedTicket.dto.request.CreateIssuedTicketDTO;
 import band.gosrock.domain.domains.issuedTicket.service.IssuedTicketDomainService;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
-import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
-import band.gosrock.domain.domains.user.domain.User;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -22,7 +18,6 @@ public class OrderEventHandler {
 
     private final IssuedTicketDomainService issuedTicketDomainService;
 
-
     private final OrderAdaptor orderAdaptor;
 
     @TransactionalEventListener(
@@ -30,8 +25,8 @@ public class OrderEventHandler {
             phase = TransactionPhase.BEFORE_COMMIT)
     public void handleDoneOrderEvent(DoneOrderEvent doneOrderEvent) {
         log.info(doneOrderEvent.getOrderUuid() + "주문 상태 완료, 티켓 생성작업 진행");
-        Order order = orderAdaptor.findByOrderUuid(doneOrderEvent.getOrderUuid());
-        issuedTicketDomainService.createIssuedTicket(order.getItem().getId(), doneOrderEvent.getOrderUuid() , doneOrderEvent.getUserId());
+        issuedTicketDomainService.createIssuedTicket(
+            doneOrderEvent.getItemId(), doneOrderEvent.getOrderUuid(), doneOrderEvent.getUserId());
         log.info(doneOrderEvent.getOrderUuid() + "주문 상태 완료, 티켓 생성작업 완료");
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithDrawOrderEventHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithDrawOrderEventHandler.java
@@ -5,8 +5,6 @@ import band.gosrock.domain.common.events.order.WithDrawOrderEvent;
 import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.service.IssuedTicketDomainService;
-import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
-import band.gosrock.domain.domains.order.domain.Order;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,17 +21,15 @@ public class WithDrawOrderEventHandler {
 
     private final IssuedTicketAdaptor issuedTicketAdaptor;
 
-    private final OrderAdaptor orderAdaptor;
-
     @TransactionalEventListener(
             classes = WithDrawOrderEvent.class,
             phase = TransactionPhase.BEFORE_COMMIT)
     public void handleWithDrawOrderEvent(WithDrawOrderEvent withDrawOrderEvent) {
-        log.info(withDrawOrderEvent.getOrderUuid() + "주문 상태 철회 , 티켓 제거 필요");
-        Order order = orderAdaptor.findByOrderUuid(withDrawOrderEvent.getOrderUuid());
+        log.info(withDrawOrderEvent.getOrderUuid() + "주문 상태 철회 , 티켓 철회 필요");
         List<IssuedTicket> issuedTickets =
                 issuedTicketAdaptor.findAllByOrderUuid(withDrawOrderEvent.getOrderUuid());
-        issuedTicketDomainService.withDrawIssuedTicket(order.getItem(), issuedTickets);
-        log.info(withDrawOrderEvent.getOrderUuid() + "주문 상태 완료, 티켓 생성작업 완료");
+        issuedTicketDomainService.withDrawIssuedTicket(
+                withDrawOrderEvent.getItemId(), issuedTickets);
+        log.info(withDrawOrderEvent.getOrderUuid() + "주문 상태 완료, 티켓 철회 완료");
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithDrawOrderEventHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithDrawOrderEventHandler.java
@@ -26,7 +26,7 @@ public class WithDrawOrderEventHandler {
     private final OrderAdaptor orderAdaptor;
 
     @TransactionalEventListener(
-            classes = WithDrawOrderEventHandler.class,
+            classes = WithDrawOrderEvent.class,
             phase = TransactionPhase.BEFORE_COMMIT)
     public void handleWithDrawOrderEvent(WithDrawOrderEvent withDrawOrderEvent) {
         log.info(withDrawOrderEvent.getOrderUuid() + "주문 상태 철회 , 티켓 제거 필요");

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -332,6 +332,10 @@ public class Order extends BaseTimeEntity {
         return getOrderLineItem().getTicketItem();
     }
 
+    public Long getItemId() {
+        return getOrderLineItem().getTicketItem().getId();
+    }
+
     /** 주문에서 티켓 상품의 타입을 반환합니다. */
     public TicketType getItemType() {
         return getItem().getType();

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyFailTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyFailTest.java
@@ -13,6 +13,7 @@ import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderLineItem;
 import band.gosrock.domain.domains.order.domain.OrderMethod;
 import band.gosrock.domain.domains.order.domain.OrderStatus;
+import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,7 @@ class OrderApproveServiceConcurrencyFailTest {
     @Autowired OrderApproveService orderApproveService;
 
     @Mock OrderLineItem orderLineItem;
+    @Mock TicketItem ticketItem;
 
     @MockBean OrderAdaptor orderAdaptor;
 
@@ -39,6 +41,8 @@ class OrderApproveServiceConcurrencyFailTest {
     @BeforeEach
     void setUp() {
         given(orderLineItem.isNeedPaid()).willReturn(Boolean.FALSE);
+        given(orderLineItem.getTicketItem()).willReturn(ticketItem);
+        given(ticketItem.getId()).willReturn(1L);
         order =
                 Order.builder()
                         .orderMethod(OrderMethod.APPROVAL)

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
@@ -12,6 +12,7 @@ import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderLineItem;
 import band.gosrock.domain.domains.order.domain.OrderMethod;
 import band.gosrock.domain.domains.order.domain.OrderStatus;
+import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
@@ -33,14 +34,16 @@ class OrderApproveServiceConcurrencyTest {
     @Autowired RedissonClient redissonClient;
 
     @Mock OrderLineItem orderLineItem;
-
     @MockBean private OrderAdaptor orderAdaptor;
 
+    @Mock TicketItem ticketItem;
     Order order;
 
     @BeforeEach
     void setUp() {
         given(orderLineItem.isNeedPaid()).willReturn(Boolean.FALSE);
+        given(orderLineItem.getTicketItem()).willReturn(ticketItem);
+        given(ticketItem.getId()).willReturn(1L);
         order =
                 Order.builder()
                         .orderMethod(OrderMethod.APPROVAL)

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/WithdrawOrderServiceTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/WithdrawOrderServiceTest.java
@@ -10,12 +10,15 @@ import band.gosrock.domain.DisableDomainEvent;
 import band.gosrock.domain.DomainIntegrateSpringBootTest;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.domain.domains.order.domain.OrderLineItem;
 import band.gosrock.domain.domains.order.domain.OrderStatus;
+import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
@@ -27,6 +30,8 @@ class WithdrawOrderServiceTest {
     @Autowired WithdrawOrderService withdrawOrderService;
 
     @MockBean OrderAdaptor orderAdaptor;
+    @Mock OrderLineItem orderLineItem;
+    @Mock TicketItem ticketItem;
 
     Order order;
 
@@ -38,10 +43,13 @@ class WithdrawOrderServiceTest {
                 Order.builder()
                         .userId(userId)
                         .orderStatus(OrderStatus.CONFIRM)
-                        .orderLineItems(List.of())
+                        .orderLineItems(List.of(orderLineItem))
                         .build();
         order.addUUID();
         given(orderAdaptor.findByOrderUuid(any())).willReturn(order);
+        given(orderLineItem.getTicketItem()).willReturn(ticketItem);
+        given(orderLineItem.canRefund()).willReturn(Boolean.TRUE);
+        given(ticketItem.getId()).willReturn(1L);
     }
 
     @Test


### PR DESCRIPTION
## 개요
- close #187 

## 작업사항
주문 완료시 티켓 생성 오류가 발생해서 수정했습니다.
아마 redisson lock required new transaction 으로 바꾸면서 생긴 문제 같습니다.

- 트랜잭션 이 새로시작됨에 따라 이번에도 세션 관련 문제가 있어서 조회 관련을 안쪽으로 넣었습니다.
- 철회관련 이벤트 리스닝 클래스가 이름이 잘못 적혀있어서 재고 복구가 안되던 오류를 해결했습니다.

## 변경로직
- done, withdraw order Event 에 item 아이디 추가 시켰습니다.