### PR TITLE
feat  : 쿠폰 적용 가능한 주문 생성

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/CreateHostRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/CreateHostRequest.java
@@ -14,13 +14,13 @@ import lombok.RequiredArgsConstructor;
 public class CreateHostRequest {
     @Schema(defaultValue = "고스락", description = "호스트 이름")
     @NotEmpty(message = "호스트 이름을 입력해주세요")
-    private final String name;
+    private String name;
 
     @Schema(defaultValue = "gosrock@gsrk.com", description = "마스터 이메일")
     @Email(message = "올바른 형식의 이메일을 입력하세요")
-    private final String contactEmail;
+    private String contactEmail;
 
     @Schema(defaultValue = "010-1111-3333", description = "마스터 전화번호")
     @Phone(message = "올바른 형식의 번호를 입력하세요")
-    private final String contactNumber;
+    private String contactNumber;
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostRequest.java
@@ -16,24 +16,24 @@ import org.hibernate.validator.constraints.Length;
 public class UpdateHostRequest {
     @Schema(defaultValue = "고스락", description = "호스트 이름")
     @NotEmpty(message = "호스트 이름을 입력해주세요")
-    private final String name;
+    private String name;
 
     @Schema(defaultValue = "고슬고슬고스락", description = "호스트 간단 소개")
     @NotNull(message = "간단 소개를 입력해주세요")
-    private final String introduce;
+    private String introduce;
 
     @Schema(defaultValue = "1990", description = "호스트 시작년도")
     @Length(min = 4, max = 10, message = "4~10자리 문자열을 입력해주세요")
-    private final String since;
+    private String since;
 
     @Schema(defaultValue = "https://s3.dudoong.com/img", description = "호스트 프로필 이미지")
-    private final String profileImageUrl;
+    private String profileImageUrl;
 
     @Schema(defaultValue = "gosrock@gsrk.com", description = "마스터 이메일")
     @Email(message = "올바른 형식의 이메일을 입력하세요")
-    private final String contactEmail;
+    private String contactEmail;
 
     @Schema(defaultValue = "010-1111-3333", description = "마스터 전화번호")
     @Phone(message = "올바른 형식의 번호를 입력하세요")
-    private final String contactNumber;
+    private String contactNumber;
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CreateOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CreateOrderUseCase.java
@@ -5,8 +5,7 @@ import band.gosrock.api.common.UserUtils;
 import band.gosrock.api.order.model.dto.request.CreateOrderRequest;
 import band.gosrock.api.order.model.dto.response.CreateOrderResponse;
 import band.gosrock.common.annotation.UseCase;
-import band.gosrock.domain.domains.order.domain.Order;
-import band.gosrock.domain.domains.order.service.CartToOrderService;
+import band.gosrock.domain.domains.order.service.CreateOrderService;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
 
@@ -14,18 +13,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CreateOrderUseCase {
 
-    private final CartToOrderService cartToOrderService;
+    private final CreateOrderService createOrderService;
 
     private final UserUtils userUtils;
 
     public CreateOrderResponse execute(CreateOrderRequest createOrderRequest) {
         User user = userUtils.getCurrentUser();
-        if (createOrderRequest.getCouponId() == null) {
-            Order order =
-                    cartToOrderService.creatOrderWithOutCoupon(
-                            createOrderRequest.getCartId(), user.getId());
-            return CreateOrderResponse.from(order, user.getProfile());
+        Long couponId = createOrderRequest.getCouponId();
+        Long cartId = createOrderRequest.getCartId();
+        if (couponId == null) {
+            return CreateOrderResponse.from(
+                    createOrderService.WithOutCoupon(cartId, user.getId()), user.getProfile());
         }
-        return null;
+        return CreateOrderResponse.from(
+                createOrderService.withCoupon(cartId, user.getId(), couponId), user.getProfile());
     }
 }

--- a/DuDoong-Common/src/main/java/band/gosrock/common/consts/DuDoongStatic.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/consts/DuDoongStatic.java
@@ -18,6 +18,8 @@ public class DuDoongStatic {
     public static final int INTERNAL_SERVER = 500;
 
     public static final Long NO_START_NUMBER = 1000000L;
+    public static final Long MINIMUM_PAYMENT_WON = 1000L;
+    public static final Long ZERO = 0L;
 
     public static final String KAKAO_OAUTH_QUERY_STRING =
             "/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code";

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/CreateOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/CreateOrderEvent.java
@@ -3,7 +3,6 @@ package band.gosrock.domain.common.events.order;
 
 import band.gosrock.domain.common.aop.domainEvent.DomainEvent;
 import band.gosrock.domain.domains.order.domain.Order;
-import band.gosrock.domain.domains.order.domain.OrderMethod;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.lang.Nullable;
@@ -18,8 +17,7 @@ public class CreateOrderEvent extends DomainEvent {
 
     private final Boolean isUsingCoupon;
 
-    @Nullable
-    private final Long issuedCouponId;
+    @Nullable private final Long issuedCouponId;
 
     public static CreateOrderEvent from(Order order) {
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/CreateOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/CreateOrderEvent.java
@@ -1,0 +1,33 @@
+package band.gosrock.domain.common.events.order;
+
+
+import band.gosrock.domain.common.aop.domainEvent.DomainEvent;
+import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.domain.domains.order.domain.OrderMethod;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.lang.Nullable;
+
+@Getter
+@Builder
+public class CreateOrderEvent extends DomainEvent {
+
+    private final String orderUuid;
+
+    private final Long userId;
+
+    private final Boolean isUsingCoupon;
+
+    @Nullable
+    private final Long issuedCouponId;
+
+    public static CreateOrderEvent from(Order order) {
+
+        return CreateOrderEvent.builder()
+                .userId(order.getUserId())
+                .orderUuid(order.getUuid())
+                .isUsingCoupon(order.hasCoupon())
+                .issuedCouponId(order.getOrderCouponVo().getCouponId())
+                .build();
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/Money.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/Money.java
@@ -69,6 +69,10 @@ public class Money {
         return amount.compareTo(other.amount) >= 0;
     }
 
+    public boolean isGreaterThan(Money other) {
+        return amount.compareTo(other.amount) > 0;
+    }
+
     public BigDecimal getAmount() {
         return amount;
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/adaptor/IssuedCouponAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/adaptor/IssuedCouponAdaptor.java
@@ -4,6 +4,7 @@ package band.gosrock.domain.domains.coupon.adaptor;
 import band.gosrock.common.annotation.Adaptor;
 import band.gosrock.domain.domains.coupon.domain.IssuedCoupon;
 import band.gosrock.domain.domains.coupon.exception.AlreadyIssuedCouponException;
+import band.gosrock.domain.domains.coupon.exception.CouponNotFoundException;
 import band.gosrock.domain.domains.coupon.repository.IssuedCouponRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,5 +29,9 @@ public class IssuedCouponAdaptor {
                         l -> {
                             throw AlreadyIssuedCouponException.EXCEPTION;
                         });
+    }
+
+    public IssuedCoupon query(Long couponCampaignId){
+        return issuedCouponRepository.findById(couponCampaignId).orElseThrow(()-> CouponNotFoundException.EXCEPTION);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/adaptor/IssuedCouponAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/adaptor/IssuedCouponAdaptor.java
@@ -31,7 +31,9 @@ public class IssuedCouponAdaptor {
                         });
     }
 
-    public IssuedCoupon query(Long couponCampaignId){
-        return issuedCouponRepository.findById(couponCampaignId).orElseThrow(()-> CouponNotFoundException.EXCEPTION);
+    public IssuedCoupon query(Long couponCampaignId) {
+        return issuedCouponRepository
+                .findById(couponCampaignId)
+                .orElseThrow(() -> CouponNotFoundException.EXCEPTION);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/IssuedCoupon.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/IssuedCoupon.java
@@ -28,7 +28,7 @@ public class IssuedCoupon extends BaseTimeEntity {
     private Long userId;
 
     @ColumnDefault("'false'")
-    private boolean usageStatus;
+    private boolean usageStatus = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "coupon_campaign_id", nullable = false)
@@ -64,14 +64,14 @@ public class IssuedCoupon extends BaseTimeEntity {
         return this.couponCampaign.getCouponCode();
     }
 
-    public void validMine(Long userId){
-        if(!Objects.equals(userId,this.userId)){
+    public void validMine(Long userId) {
+        if (!Objects.equals(userId, this.userId)) {
             throw NotMyCouponException.EXCEPTION;
         }
     }
 
     public void use() {
-        if(!usageStatus){
+        if (usageStatus) {
             throw AlreadyUsedCouponException.EXCEPTION;
         }
         usageStatus = true;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/IssuedCoupon.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/IssuedCoupon.java
@@ -71,12 +71,9 @@ public class IssuedCoupon extends BaseTimeEntity {
     }
 
     public void use() {
-        if (usageStatus) {
+        if (usageStatus) { // 동시성 이슈 가능
             throw AlreadyUsedCouponException.EXCEPTION;
         }
         usageStatus = true;
     }
-
-    // TODO : 밸리데이션 진행해주세요.
-    public void validCanDiscount(Money supplyAmount) {}
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/IssuedCoupon.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/IssuedCoupon.java
@@ -76,4 +76,7 @@ public class IssuedCoupon extends BaseTimeEntity {
         }
         usageStatus = true;
     }
+
+    // TODO : 밸리데이션 진행해주세요.
+    public void validCanDiscount(Money supplyAmount) {}
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/IssuedCoupon.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/IssuedCoupon.java
@@ -3,6 +3,9 @@ package band.gosrock.domain.domains.coupon.domain;
 
 import band.gosrock.domain.common.model.BaseTimeEntity;
 import band.gosrock.domain.common.vo.Money;
+import band.gosrock.domain.domains.coupon.exception.AlreadyUsedCouponException;
+import band.gosrock.domain.domains.coupon.exception.NotMyCouponException;
+import java.util.Objects;
 import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -30,7 +33,6 @@ public class IssuedCoupon extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "coupon_campaign_id", nullable = false)
     private CouponCampaign couponCampaign;
-
     /** 주문에서 사용하는 할인 금액 계산 함수, 할인 금액보다 결제 금액이 작을 경우 할인 불가로 Money.ZERO 리턴 */
     public Money getDiscountAmount(Money supplyAmount) {
         if (couponCampaign.getDiscountType().equals(DiscountType.AMOUNT)) { // 정액 할인
@@ -60,5 +62,18 @@ public class IssuedCoupon extends BaseTimeEntity {
 
     public String getCouponName() { // 쿠폰코드==쿠폰이름
         return this.couponCampaign.getCouponCode();
+    }
+
+    public void validMine(Long userId){
+        if(!Objects.equals(userId,this.userId)){
+            throw NotMyCouponException.EXCEPTION;
+        }
+    }
+
+    public void use() {
+        if(!usageStatus){
+            throw AlreadyUsedCouponException.EXCEPTION;
+        }
+        usageStatus = true;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/OrderCouponVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/OrderCouponVo.java
@@ -1,17 +1,22 @@
 package band.gosrock.domain.domains.coupon.domain;
 
+import static band.gosrock.common.consts.DuDoongStatic.MINIMUM_PAYMENT_WON;
+import static band.gosrock.common.consts.DuDoongStatic.ZERO;
 
 import band.gosrock.domain.common.vo.Money;
+import band.gosrock.domain.domains.order.exception.LessThanMinmumPaymentOrderException;
 import javax.persistence.Embeddable;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Embeddable
 @NoArgsConstructor
 public class OrderCouponVo {
     private String name = "사용하지 않음";
     private Money discountAmount = Money.ZERO;
-    private Long couponId = 0L;
+    private Long couponId = ZERO;
 
     @Builder
     public OrderCouponVo(String name, Money discountAmount, Long couponId) {
@@ -26,6 +31,17 @@ public class OrderCouponVo {
                 .discountAmount(coupon.getDiscountAmount(OrderSupplyAmount))
                 .name(coupon.getCouponName())
                 .build();
+    }
+
+    public void validMinimumPaymentAmount(Money supplyAmount) {
+        Money paymentAmount = supplyAmount.minus(this.discountAmount);
+        if (paymentAmount.isLessThan(Money.wons(MINIMUM_PAYMENT_WON))) {
+            throw LessThanMinmumPaymentOrderException.EXCEPTION;
+        }
+    }
+
+    public Boolean isDefault(){
+        return couponId.equals(ZERO);
     }
 
     public static OrderCouponVo empty() {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/OrderCouponVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/OrderCouponVo.java
@@ -1,0 +1,34 @@
+package band.gosrock.domain.domains.coupon.domain;
+
+
+import band.gosrock.domain.common.vo.Money;
+import javax.persistence.Embeddable;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor
+public class OrderCouponVo {
+    private String name = "사용하지 않음";
+    private Money discountAmount = Money.ZERO;
+    private Long couponId = 0L;
+
+    @Builder
+    public OrderCouponVo(String name, Money discountAmount, Long couponId) {
+        this.name = name;
+        this.discountAmount = discountAmount;
+        this.couponId = couponId;
+    }
+
+    public static OrderCouponVo of(IssuedCoupon coupon, Money OrderSupplyAmount) {
+        return OrderCouponVo.builder()
+                .couponId(coupon.getId())
+                .discountAmount(coupon.getDiscountAmount(OrderSupplyAmount))
+                .name(coupon.getCouponName())
+                .build();
+    }
+
+    public static OrderCouponVo empty() {
+        return new OrderCouponVo();
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/OrderCouponVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/OrderCouponVo.java
@@ -36,12 +36,13 @@ public class OrderCouponVo {
     public void validMinimumPaymentAmount(Money supplyAmount) {
         Money paymentAmount = supplyAmount.minus(this.discountAmount);
         // 0원 결제는 가능함!
-        if (!paymentAmount.equals(Money.ZERO) && paymentAmount.isLessThan(Money.wons(MINIMUM_PAYMENT_WON))) {
+        if (!paymentAmount.equals(Money.ZERO)
+                && paymentAmount.isLessThan(Money.wons(MINIMUM_PAYMENT_WON))) {
             throw LessThanMinmumPaymentOrderException.EXCEPTION;
         }
     }
 
-    public Boolean isDefault(){
+    public Boolean isDefault() {
         return couponId.equals(ZERO);
     }
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/OrderCouponVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/domain/OrderCouponVo.java
@@ -35,7 +35,8 @@ public class OrderCouponVo {
 
     public void validMinimumPaymentAmount(Money supplyAmount) {
         Money paymentAmount = supplyAmount.minus(this.discountAmount);
-        if (paymentAmount.isLessThan(Money.wons(MINIMUM_PAYMENT_WON))) {
+        // 0원 결제는 가능함!
+        if (!paymentAmount.equals(Money.ZERO) && paymentAmount.isLessThan(Money.wons(MINIMUM_PAYMENT_WON))) {
             throw LessThanMinmumPaymentOrderException.EXCEPTION;
         }
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/exception/AlreadyUsedCouponException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/exception/AlreadyUsedCouponException.java
@@ -1,9 +1,11 @@
 package band.gosrock.domain.domains.coupon.exception;
 
+
 import band.gosrock.common.exception.DuDoongCodeException;
 
 public class AlreadyUsedCouponException extends DuDoongCodeException {
     public static final DuDoongCodeException EXCEPTION = new AlreadyUsedCouponException();
+
     private AlreadyUsedCouponException() {
         super(CouponErrorCode.ALREADY_USED_COUPON);
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/exception/AlreadyUsedCouponException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/exception/AlreadyUsedCouponException.java
@@ -1,0 +1,10 @@
+package band.gosrock.domain.domains.coupon.exception;
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class AlreadyUsedCouponException extends DuDoongCodeException {
+    public static final DuDoongCodeException EXCEPTION = new AlreadyUsedCouponException();
+    private AlreadyUsedCouponException() {
+        super(CouponErrorCode.ALREADY_USED_COUPON);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/exception/CouponErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/exception/CouponErrorCode.java
@@ -16,10 +16,14 @@ import lombok.Getter;
 public enum CouponErrorCode implements BaseErrorCode {
     DUPLICATE_COUPON_CODE(BAD_REQUEST, "Coupon_400_1", "동일한 쿠폰 코드가 이미 존재합니다."),
     WRONG_DISCOUNT_AMOUNT(BAD_REQUEST, "Coupon_400_2", "정률 할인은 100 이하 퍼센트만 할인 가능합니다."),
-    NOT_FOUND_COUPON_CAMPAIGN(NOT_FOUND, "Coupon_400_3", "존재하지 않는 쿠폰 캠페인입니다."),
+    NOT_FOUND_COUPON_CAMPAIGN(NOT_FOUND, "Coupon_404_1", "존재하지 않는 쿠폰 캠페인입니다."),
     ALREADY_ISSUED_COUPON(BAD_REQUEST, "Coupon_400_4", "이미 발급된 쿠폰입니다."),
     NO_COUPON_STOCK_LEFT(BAD_REQUEST, "Coupon_400_5", "쿠폰이 모두 소진됐습니다."),
-    NOT_COUPON_ISSUING_PERIOD(BAD_REQUEST, "Coupon_400_6", "쿠폰 발급 가능 시각이 아닙니다.");
+    NOT_COUPON_ISSUING_PERIOD(BAD_REQUEST, "Coupon_400_6", "쿠폰 발급 가능 시각이 아닙니다."),
+    NOT_FOUND_COUPON(NOT_FOUND, "Coupon_404_2", "존재하지 않는 쿠폰 입니다."),
+
+    NOT_MY_COUPON(BAD_REQUEST, "Coupon_400_7", "내 쿠폰이 아닙니다."),
+    ALREADY_USED_COUPON(BAD_REQUEST, "Coupon_400_8", "이미 사용한 쿠폰입니다.");
     private final Integer status;
     private final String code;
     private final String reason;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/exception/CouponNotFoundException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/exception/CouponNotFoundException.java
@@ -1,0 +1,12 @@
+package band.gosrock.domain.domains.coupon.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class CouponNotFoundException extends DuDoongCodeException {
+    public static final DuDoongCodeException EXCEPTION = new CouponNotFoundException();
+
+    private CouponNotFoundException() {
+        super(CouponErrorCode.NOT_FOUND_COUPON);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/exception/NotMyCouponException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/exception/NotMyCouponException.java
@@ -1,0 +1,12 @@
+package band.gosrock.domain.domains.coupon.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class NotMyCouponException extends DuDoongCodeException {
+    public static final DuDoongCodeException EXCEPTION = new NotMyCouponException();
+
+    private NotMyCouponException() {
+        super(CouponErrorCode.NOT_MY_COUPON);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/service/UseCouponService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/service/UseCouponService.java
@@ -1,0 +1,22 @@
+package band.gosrock.domain.domains.coupon.service;
+
+import band.gosrock.common.annotation.DomainService;
+import band.gosrock.domain.common.aop.redissonLock.RedissonLock;
+import band.gosrock.domain.domains.coupon.adaptor.IssuedCouponAdaptor;
+import band.gosrock.domain.domains.coupon.domain.IssuedCoupon;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class UseCouponService {
+
+    private final IssuedCouponAdaptor issuedCouponAdaptor;
+
+    @RedissonLock(LockName = "쿠폰", identifier = "couponId")
+    public Long execute(Long userId, Long couponId){
+        IssuedCoupon coupon = issuedCouponAdaptor.query(couponId);
+        coupon.validMine(userId);
+        coupon.use();
+        return couponId;
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/service/UseCouponService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/service/UseCouponService.java
@@ -1,5 +1,6 @@
 package band.gosrock.domain.domains.coupon.service;
 
+
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.common.aop.redissonLock.RedissonLock;
 import band.gosrock.domain.domains.coupon.adaptor.IssuedCouponAdaptor;
@@ -13,7 +14,7 @@ public class UseCouponService {
     private final IssuedCouponAdaptor issuedCouponAdaptor;
 
     @RedissonLock(LockName = "쿠폰", identifier = "couponId")
-    public Long execute(Long userId, Long couponId){
+    public Long execute(Long userId, Long couponId) {
         IssuedCoupon coupon = issuedCouponAdaptor.query(couponId);
         coupon.validMine(userId);
         coupon.use();

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/service/handler/CreateOrderHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/service/handler/CreateOrderHandler.java
@@ -1,0 +1,32 @@
+package band.gosrock.domain.domains.coupon.service.handler;
+
+
+import band.gosrock.domain.common.events.order.CreateOrderEvent;
+import band.gosrock.domain.domains.coupon.service.UseCouponService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CreateOrderHandler {
+
+    private final UseCouponService useCouponService;
+
+    @TransactionalEventListener(
+            classes = CreateOrderEvent.class,
+            phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleDoneOrderFailEvent(CreateOrderEvent createOrderEvent) {
+        log.info(createOrderEvent.getOrderUuid() + "주문 생성 이벤트 쿠폰 사용 리스너");
+
+        if (createOrderEvent.getIsUsingCoupon()) {
+            log.info(createOrderEvent.getOrderUuid() + "주문 생성 이벤트 쿠폰 사용 리스너 : 쿠폰 사용 도메인 서비스 호출");
+            useCouponService.execute(
+                    createOrderEvent.getUserId(), createOrderEvent.getIssuedCouponId());
+            log.info(createOrderEvent.getOrderUuid() + "주문 생성 이벤트 쿠폰 사용 리스너 : 쿠폰 사용 도메인 서비스 호출종료");
+        }
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
@@ -3,7 +3,6 @@ package band.gosrock.domain.domains.issuedTicket.service.handlers;
 
 import band.gosrock.domain.common.events.order.DoneOrderEvent;
 import band.gosrock.domain.domains.issuedTicket.service.IssuedTicketDomainService;
-import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -16,8 +15,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class OrderEventHandler {
 
     private final IssuedTicketDomainService issuedTicketDomainService;
-
-    private final OrderAdaptor orderAdaptor;
 
     @TransactionalEventListener(
             classes = DoneOrderEvent.class,

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -363,9 +363,11 @@ public class Order extends BaseTimeEntity {
 
     /** 결제가 필요한 오더인지 반환합니다. */
     public Boolean isNeedPaid() {
-        return this.orderLineItems.stream()
-                .map(OrderLineItem::isNeedPaid)
-                .reduce(Boolean.FALSE, (Boolean::logicalOr));
+        // 결제 여부는 총 결제금액으로 정함
+        return Money.ZERO.isLessThan(getTotalPaymentPrice());
+//        return this.orderLineItems.stream()
+//                .map(OrderLineItem::isNeedPaid)
+//                .reduce(Boolean.FALSE, (Boolean::logicalOr));
     }
 
     /** 결제 수단 정보를 가져옵니다. */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -308,7 +308,7 @@ public class Order extends BaseTimeEntity {
      * @default 사용하지않음
      */
     public String getCouponName() {
-       return orderCouponVo.getName();
+        return orderCouponVo.getName();
     }
 
     /** 총 공급가액을 가져옵니다. */
@@ -365,9 +365,9 @@ public class Order extends BaseTimeEntity {
     public Boolean isNeedPaid() {
         // 결제 여부는 총 결제금액으로 정함
         return Money.ZERO.isLessThan(getTotalPaymentPrice());
-//        return this.orderLineItems.stream()
-//                .map(OrderLineItem::isNeedPaid)
-//                .reduce(Boolean.FALSE, (Boolean::logicalOr));
+        //        return this.orderLineItems.stream()
+        //                .map(OrderLineItem::isNeedPaid)
+        //                .reduce(Boolean.FALSE, (Boolean::logicalOr));
     }
 
     /** 결제 수단 정보를 가져옵니다. */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/LessThanMinmumPaymentOrderException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/LessThanMinmumPaymentOrderException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.order.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class LessThanMinmumPaymentOrderException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new LessThanMinmumPaymentOrderException();
+
+    private LessThanMinmumPaymentOrderException() {
+        super(OrderErrorCode.ORDER_LESS_THAN_MINIMUM);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/OrderErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/OrderErrorCode.java
@@ -29,7 +29,9 @@ public enum OrderErrorCode implements BaseErrorCode {
     ORDER_NOT_REFUND_DATE(BAD_REQUEST, "Order_400_9", "환불을 할 수 있는 기한을 지났습니다."),
     ORDER_NOT_FOUND(NOT_FOUND, "Order_404_1", "주문을 찾을 수 없습니다."),
     ORDER_LINE_NOT_FOUND(NOT_FOUND, "Order_404_2", "주문 라인을 찾을 수 없습니다."),
-    ORDER_NOT_FREE(BAD_REQUEST, "Order_400_10", "무료 주문이 아닙니다.");
+    ORDER_NOT_FREE(BAD_REQUEST, "Order_400_10", "무료 주문이 아닙니다."),
+
+    ORDER_LESS_THAN_MINIMUM(BAD_REQUEST, "Order_400_11", "최소 결제금액인 1000원보다 낮은 주문입니다.");
 
     private Integer status;
     private String code;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CreateOrderService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CreateOrderService.java
@@ -23,7 +23,7 @@ public class CreateOrderService {
     private final IssuedCouponAdaptor issuedCouponAdaptor;
 
     @Transactional
-    public Order WithOutCoupon(Long cartId, Long userId) {
+    public Order withOutCoupon(Long cartId, Long userId) {
         Cart cart = cartAdaptor.queryCart(cartId, userId);
         Order order = Order.create(userId, cart);
         order.calculatePaymentInfo();

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CreateOrderService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CreateOrderService.java
@@ -4,6 +4,8 @@ package band.gosrock.domain.domains.order.service;
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.domains.cart.adaptor.CartAdaptor;
 import band.gosrock.domain.domains.cart.domain.Cart;
+import band.gosrock.domain.domains.coupon.adaptor.IssuedCouponAdaptor;
+import band.gosrock.domain.domains.coupon.domain.IssuedCoupon;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
 import lombok.RequiredArgsConstructor;
@@ -12,14 +14,27 @@ import org.springframework.transaction.annotation.Transactional;
 @DomainService
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class CartToOrderService {
+public class CreateOrderService {
 
     private final CartAdaptor cartAdaptor;
 
     private final OrderAdaptor orderAdaptor;
 
+    private final IssuedCouponAdaptor issuedCouponAdaptor;
+
     @Transactional
-    public Order creatOrderWithOutCoupon(Long cartId, Long userId) {
+    public Order WithOutCoupon(Long cartId, Long userId) {
+        Cart cart = cartAdaptor.queryCart(cartId, userId);
+        Order order = Order.createOrder(userId, cart);
+        order.calculatePaymentInfo();
+        return orderAdaptor.save(order);
+    }
+
+    @Transactional
+    public Order withCoupon(Long cartId, Long userId, Long couponId) {
+        IssuedCoupon coupon = issuedCouponAdaptor.query(couponId);
+        coupon.validMine(userId);
+
         Cart cart = cartAdaptor.queryCart(cartId, userId);
         Order order = Order.createOrder(userId, cart);
         order.calculatePaymentInfo();

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CreateOrderService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CreateOrderService.java
@@ -6,7 +6,6 @@ import band.gosrock.domain.domains.cart.adaptor.CartAdaptor;
 import band.gosrock.domain.domains.cart.domain.Cart;
 import band.gosrock.domain.domains.coupon.adaptor.IssuedCouponAdaptor;
 import band.gosrock.domain.domains.coupon.domain.IssuedCoupon;
-import band.gosrock.domain.domains.coupon.service.UseCouponService;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
 import lombok.RequiredArgsConstructor;
@@ -23,8 +22,6 @@ public class CreateOrderService {
 
     private final IssuedCouponAdaptor issuedCouponAdaptor;
 
-    private final UseCouponService useCouponService;
-
     @Transactional
     public Order WithOutCoupon(Long cartId, Long userId) {
         Cart cart = cartAdaptor.queryCart(cartId, userId);
@@ -35,11 +32,7 @@ public class CreateOrderService {
 
     @Transactional
     public Order withCoupon(Long cartId, Long userId, Long couponId) {
-
         IssuedCoupon coupon = issuedCouponAdaptor.query(couponId);
-        // 쿠폰 재고 감소 체크
-        useCouponService.execute(userId, couponId);
-
         Cart cart = cartAdaptor.queryCart(cartId, userId);
         Order order = Order.createWithCoupon(userId, cart, coupon);
         order.calculatePaymentInfo();

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CreateOrderService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CreateOrderService.java
@@ -25,7 +25,7 @@ public class CreateOrderService {
     @Transactional
     public Order WithOutCoupon(Long cartId, Long userId) {
         Cart cart = cartAdaptor.queryCart(cartId, userId);
-        Order order = Order.createOrder(userId, cart);
+        Order order = Order.create(userId, cart);
         order.calculatePaymentInfo();
         return orderAdaptor.save(order);
     }
@@ -33,10 +33,8 @@ public class CreateOrderService {
     @Transactional
     public Order withCoupon(Long cartId, Long userId, Long couponId) {
         IssuedCoupon coupon = issuedCouponAdaptor.query(couponId);
-        coupon.validMine(userId);
-
         Cart cart = cartAdaptor.queryCart(cartId, userId);
-        Order order = Order.createOrder(userId, cart);
+        Order order = Order.createWithCoupon(userId, cart, coupon);
         order.calculatePaymentInfo();
         return orderAdaptor.save(order);
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CreateOrderService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/CreateOrderService.java
@@ -6,6 +6,7 @@ import band.gosrock.domain.domains.cart.adaptor.CartAdaptor;
 import band.gosrock.domain.domains.cart.domain.Cart;
 import band.gosrock.domain.domains.coupon.adaptor.IssuedCouponAdaptor;
 import band.gosrock.domain.domains.coupon.domain.IssuedCoupon;
+import band.gosrock.domain.domains.coupon.service.UseCouponService;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,8 @@ public class CreateOrderService {
 
     private final IssuedCouponAdaptor issuedCouponAdaptor;
 
+    private final UseCouponService useCouponService;
+
     @Transactional
     public Order WithOutCoupon(Long cartId, Long userId) {
         Cart cart = cartAdaptor.queryCart(cartId, userId);
@@ -32,7 +35,11 @@ public class CreateOrderService {
 
     @Transactional
     public Order withCoupon(Long cartId, Long userId, Long couponId) {
+
         IssuedCoupon coupon = issuedCouponAdaptor.query(couponId);
+        // 쿠폰 재고 감소 체크
+        useCouponService.execute(userId, couponId);
+
         Cart cart = cartAdaptor.queryCart(cartId, userId);
         Order order = Order.createWithCoupon(userId, cart, coupon);
         order.calculatePaymentInfo();

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/CunCurrencyExecutorService.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/CunCurrencyExecutorService.java
@@ -27,6 +27,7 @@ public class CunCurrencyExecutorService {
                             // 오류없이 성공을 하면 성공횟수를 증가시킵니다.
                             successCount.getAndIncrement();
                         } catch (Throwable e) {
+                            // 에러뜨면 여기서 확인해보셔요!
                             log.info(e.getClass().getName());
                         } finally {
                             latch.countDown();

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/coupon/domain/IssuedCouponTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/coupon/domain/IssuedCouponTest.java
@@ -1,0 +1,42 @@
+package band.gosrock.domain.domains.coupon.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import band.gosrock.domain.domains.coupon.exception.AlreadyUsedCouponException;
+import band.gosrock.domain.domains.coupon.exception.NotMyCouponException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IssuedCouponTest {
+
+    static Long userId = 1L;
+
+    IssuedCoupon issuedCoupon;
+
+    @BeforeEach
+    void setUp() {
+        issuedCoupon = IssuedCoupon.builder().userId(userId).build();
+    }
+
+    @Test
+    void 사용가능한_쿠폰_상태_확인() {
+        // given
+        // when
+        // 이미 사용한 상태라면?
+        issuedCoupon.use();
+        // then
+        assertThrows(AlreadyUsedCouponException.class, () -> issuedCoupon.use());
+    }
+
+    @Test
+    void 내쿠폰_확인() {
+        // given
+        // when
+        issuedCoupon.validMine(userId);
+        //
+        assertThrows(NotMyCouponException.class, () -> issuedCoupon.validMine(2L));
+    }
+}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/OrderTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/OrderTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
 import band.gosrock.domain.common.vo.Money;
-import band.gosrock.domain.domains.coupon.domain.IssuedCoupon;
 import band.gosrock.domain.domains.coupon.domain.OrderCouponVo;
 import band.gosrock.domain.domains.order.exception.NotOwnerOrderException;
 import band.gosrock.domain.domains.order.exception.NotRefundAvailableDateOrderException;
@@ -27,7 +26,7 @@ class OrderTest {
     // 조회용테스트 order
     Order notHaveCouponOrder;
 
-    Order couponOrder ;
+    Order couponOrder;
 
     @BeforeEach
     void setUp() {
@@ -38,15 +37,17 @@ class OrderTest {
                         .orderLineItems(List.of(orderLineItem1, orderLineItem2))
                         .orderStatus(OrderStatus.PENDING_APPROVE)
                         .orderMethod(OrderMethod.APPROVAL)
+                        .orderCouponVo(OrderCouponVo.empty())
                         .build();
-        couponOrder = Order.builder()
-            .userId(1L)
-            .orderName("주문이름")
-            .orderLineItems(List.of(orderLineItem1, orderLineItem2))
-            .orderStatus(OrderStatus.PENDING_APPROVE)
-            .orderMethod(OrderMethod.APPROVAL)
-            .orderCouponVo(orderCouponVo)
-            .build();
+        couponOrder =
+                Order.builder()
+                        .userId(1L)
+                        .orderName("주문이름")
+                        .orderLineItems(List.of(orderLineItem1, orderLineItem2))
+                        .orderStatus(OrderStatus.PENDING_APPROVE)
+                        .orderMethod(OrderMethod.APPROVAL)
+                        .orderCouponVo(orderCouponVo)
+                        .build();
     }
 
     @Test

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyFailTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyFailTest.java
@@ -8,6 +8,8 @@ import band.gosrock.domain.CunCurrencyExecutorService;
 import band.gosrock.domain.DisableDomainEvent;
 import band.gosrock.domain.DisableRedissonLock;
 import band.gosrock.domain.DomainIntegrateSpringBootTest;
+import band.gosrock.domain.common.vo.Money;
+import band.gosrock.domain.domains.coupon.domain.OrderCouponVo;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderLineItem;
@@ -40,7 +42,7 @@ class OrderApproveServiceConcurrencyFailTest {
 
     @BeforeEach
     void setUp() {
-        given(orderLineItem.isNeedPaid()).willReturn(Boolean.FALSE);
+        given(orderLineItem.getTotalOrderLinePrice()).willReturn(Money.ZERO);
         given(orderLineItem.getTicketItem()).willReturn(ticketItem);
         given(ticketItem.getId()).willReturn(1L);
         order =
@@ -48,6 +50,7 @@ class OrderApproveServiceConcurrencyFailTest {
                         .orderMethod(OrderMethod.APPROVAL)
                         .orderStatus(OrderStatus.PENDING_APPROVE)
                         .orderLineItems(List.of(orderLineItem))
+                        .orderCouponVo(OrderCouponVo.empty())
                         .build();
         order.addUUID();
         given(orderAdaptor.findByOrderUuid(any())).willReturn(order);

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
@@ -7,6 +7,8 @@ import static org.mockito.BDDMockito.given;
 import band.gosrock.domain.CunCurrencyExecutorService;
 import band.gosrock.domain.DisableDomainEvent;
 import band.gosrock.domain.DomainIntegrateSpringBootTest;
+import band.gosrock.domain.common.vo.Money;
+import band.gosrock.domain.domains.coupon.domain.OrderCouponVo;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderLineItem;
@@ -41,7 +43,7 @@ class OrderApproveServiceConcurrencyTest {
 
     @BeforeEach
     void setUp() {
-        given(orderLineItem.isNeedPaid()).willReturn(Boolean.FALSE);
+        given(orderLineItem.getTotalOrderLinePrice()).willReturn(Money.ZERO);
         given(orderLineItem.getTicketItem()).willReturn(ticketItem);
         given(ticketItem.getId()).willReturn(1L);
         order =
@@ -49,6 +51,7 @@ class OrderApproveServiceConcurrencyTest {
                         .orderMethod(OrderMethod.APPROVAL)
                         .orderStatus(OrderStatus.PENDING_APPROVE)
                         .orderLineItems(List.of(orderLineItem))
+                        .orderCouponVo(OrderCouponVo.empty())
                         .build();
         order.addUUID();
         // https://stackoverflow.com/questions/11785498/simulate-first-call-fails-second-call-succeeds

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/WithdrawOrderServiceTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/WithdrawOrderServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.BDDMockito.given;
 import band.gosrock.domain.CunCurrencyExecutorService;
 import band.gosrock.domain.DisableDomainEvent;
 import band.gosrock.domain.DomainIntegrateSpringBootTest;
+import band.gosrock.domain.common.vo.Money;
+import band.gosrock.domain.domains.coupon.domain.OrderCouponVo;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderLineItem;
@@ -44,11 +46,14 @@ class WithdrawOrderServiceTest {
                         .userId(userId)
                         .orderStatus(OrderStatus.CONFIRM)
                         .orderLineItems(List.of(orderLineItem))
+                        .orderCouponVo(OrderCouponVo.empty())
                         .build();
         order.addUUID();
         given(orderAdaptor.findByOrderUuid(any())).willReturn(order);
         given(orderLineItem.getTicketItem()).willReturn(ticketItem);
         given(orderLineItem.canRefund()).willReturn(Boolean.TRUE);
+        given(orderLineItem.getTotalOrderLinePrice()).willReturn(Money.ZERO);
+
         given(ticketItem.getId()).willReturn(1L);
     }
 


### PR DESCRIPTION
## 개요
- close #115 

## 작업사항
- 주문 도메인에 쿠폰 엔티티를 빼고 orderCouponVo 로 변경했습니다.
- 쿠폰 적용해서 계산이 가능합니다.
- 쿠폰 적용시에 분산락 적용했습니다
- 민준이쪽 티켓 로직과 같이 
주문 생성 이벤트 소싱후
비동기가아닌 동기적 이벤트 수신으로 쿠폰 적용상태를 변경시킵니다.
before_commit role 이므로 실패한다면
주문 생성까지도 롤백됩니다.
또한 쿠폰 적용도 실패된다면 주문 생성 또한 롤백됩니다.


추후 채린이가 withdraworderevent 주문 철회 이벤트에 쿠폰 복구 작업예정입니다ㅏ
@cofls6581  혹시 지금 createOrderEvent 처럼 필요한 필드
가령 couponId , isUseCoupon 등 필드 필요하면 withdraworderevent에 추가하셔유!


## 변경로직
- 내용을 적어주세요.