### PR TITLE
feat : 호스트 유저 관리 기능 구현

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/config/response/GlobalExceptionHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/config/response/GlobalExceptionHandler.java
@@ -129,7 +129,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                                                     .split("\\."));
                             String path =
                                     propertyPath.stream()
-                                            .skip(propertyPath.size() - 1)
+                                            .skip(propertyPath.size() - 1L)
                                             .findFirst()
                                             .orElse(null);
                             bindingErrors.put(path, constraintViolation.getMessage());

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
@@ -5,12 +5,15 @@ import band.gosrock.api.host.model.dto.request.*;
 import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.api.host.model.dto.response.HostResponse;
 import band.gosrock.api.host.service.*;
+import band.gosrock.domain.common.vo.UserProfileVo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import javax.validation.Valid;
+import javax.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @SecurityRequirement(name = "access-token")
@@ -18,10 +21,12 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/v1/hosts")
 @RequiredArgsConstructor
+@Validated
 public class HostController {
 
     private final ReadHostUseCase readHostUseCase;
     private final ReadHostListUseCase readHostListUseCase;
+    private final ReadInviteUserListUseCase readInviteUserListUseCase;
     private final CreateHostUseCase createHostUseCase;
     private final UpdateHostProfileUseCase updateHostProfileUseCase;
     private final UpdateHostSlackUrlUseCase updateHostSlackUrlUseCase;
@@ -39,6 +44,13 @@ public class HostController {
     @GetMapping("/{hostId}")
     public HostDetailResponse getHostById(@PathVariable Long hostId) {
         return readHostUseCase.execute(hostId);
+    }
+
+    @Operation(summary = "해당 호스트에 가입하지 않은 유저를 이메일로 검색합니다.")
+    @GetMapping("/{hostId}/invite/users")
+    public List<UserProfileVo> getInviteUserListByEmail(
+            @PathVariable Long hostId, @RequestParam(value = "email") @Email String email) {
+        return readInviteUserListUseCase.execute(hostId, email);
     }
 
     @Operation(summary = "호스트 간편 생성. 호스트를 생성한 유저 자신은 마스터 호스트가 됩니다.")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
@@ -48,7 +48,7 @@ public class HostController {
 
     @Operation(summary = "해당 호스트에 가입하지 않은 유저를 이메일로 검색합니다.")
     @GetMapping("/{hostId}/invite/users")
-    public List<UserProfileVo> getInviteUserListByEmail(
+    public UserProfileVo getInviteUserListByEmail(
             @PathVariable Long hostId, @RequestParam(value = "email") @Email String email) {
         return readInviteUserListUseCase.execute(hostId, email);
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
@@ -47,7 +47,7 @@ public class HostController {
         return createHostUseCase.execute(createEventRequest);
     }
 
-    @Operation(summary = "기존 호스트에 가입합니다.")
+    @Operation(summary = "초대 받은 호스트에 가입합니다.")
     @PostMapping("/{hostId}/join")
     public HostDetailResponse joinHost(@PathVariable Long hostId) {
         return joinHostUseCase.execute(hostId);

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/InviteHostRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/InviteHostRequest.java
@@ -1,13 +1,15 @@
 package band.gosrock.api.host.model.dto.request;
 
 
+import band.gosrock.common.annotation.Enum;
+import band.gosrock.domain.domains.host.domain.HostRole;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Email;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/** 호스트 슬랙 알람 URL 수정 요청 DTO */
+/** 호스트 초대 요청 DTO */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,4 +17,8 @@ public class InviteHostRequest {
     @Schema(defaultValue = "kls1998@naver.com", description = "초대할 유저 이메일 주소")
     @Email(message = "올바른 이메일을 입력해주세요")
     private String email;
+
+    @Schema(defaultValue = "HOST", description = "호스트 유저 역할")
+    @Enum(message = "HOST 또는 SUPER_HOST 만 허용됩니다")
+    private HostRole role;
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/ReadUserHostRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/ReadUserHostRequest.java
@@ -1,0 +1,24 @@
+package band.gosrock.api.host.model.dto.request;
+
+
+import band.gosrock.common.annotation.Enum;
+import band.gosrock.domain.domains.host.domain.HostRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.Email;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 호스트 초대 요청 DTO */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadUserHostRequest {
+    @Schema(defaultValue = "kls1998@naver.com", description = "초대할 유저 이메일 주소")
+    @Email(message = "올바른 이메일을 입력해주세요")
+    private String email;
+
+    @Schema(defaultValue = "HOST", description = "호스트 유저 역할")
+    @Enum(message = "HOST 또는 SUPER_HOST 만 허용됩니다")
+    private HostRole role;
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostRequest.java
@@ -4,36 +4,28 @@ package band.gosrock.api.host.model.dto.request;
 import band.gosrock.common.annotation.Phone;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Email;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.URL;
 
 /** 호스트 정보 변경 요청 DTO */
 @Getter
 @RequiredArgsConstructor
 public class UpdateHostRequest {
-    @Schema(defaultValue = "고스락", description = "호스트 이름")
-    @NotEmpty(message = "호스트 이름을 입력해주세요")
-    private String name;
+    @Schema(defaultValue = "https://s3.dudoong.com/img", description = "호스트 프로필 이미지")
+    @URL(message = "올바른 형식의 URL 을 입력해주세요")
+    private String profileImageUrl;
 
     @Schema(defaultValue = "고슬고슬고스락", description = "호스트 간단 소개")
     @NotNull(message = "간단 소개를 입력해주세요")
     private String introduce;
 
-    @Schema(defaultValue = "1990", description = "호스트 시작년도")
-    @Length(min = 4, max = 10, message = "4~10자리 문자열을 입력해주세요")
-    private String since;
-
-    @Schema(defaultValue = "https://s3.dudoong.com/img", description = "호스트 프로필 이미지")
-    private String profileImageUrl;
+    @Schema(defaultValue = "010-1111-3333", description = "마스터 전화번호")
+    @Phone(message = "올바른 형식의 번호를 입력하세요")
+    private String contactNumber;
 
     @Schema(defaultValue = "gosrock@gsrk.com", description = "마스터 이메일")
     @Email(message = "올바른 형식의 이메일을 입력하세요")
     private String contactEmail;
-
-    @Schema(defaultValue = "010-1111-3333", description = "마스터 전화번호")
-    @Phone(message = "올바른 형식의 번호를 입력하세요")
-    private String contactNumber;
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
@@ -37,9 +37,7 @@ public class HostMapper {
 
     public HostProfile toHostProfile(UpdateHostRequest updateHostRequest) {
         return HostProfile.builder()
-                .name(updateHostRequest.getName())
                 .introduce(updateHostRequest.getIntroduce())
-                .since(updateHostRequest.getSince())
                 .profileImageUrl(updateHostRequest.getProfileImageUrl())
                 .contactEmail(updateHostRequest.getContactEmail())
                 .contactNumber(updateHostRequest.getContactNumber())

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
@@ -13,11 +13,10 @@ import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.host.domain.HostProfile;
 import band.gosrock.domain.domains.host.domain.HostRole;
 import band.gosrock.domain.domains.host.domain.HostUser;
+import band.gosrock.domain.domains.host.exception.AlreadyJoinedHostException;
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
 import band.gosrock.domain.domains.user.domain.User;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -60,19 +59,14 @@ public class HostMapper {
     }
 
     @Transactional(readOnly = true)
-    public List<UserProfileVo> toHostInviteUserList(Long hostId, String email) {
+    public UserProfileVo toHostInviteUserList(Long hostId, String email) {
         final Host host = hostAdaptor.findById(hostId);
 
-        final List<UserProfileVo> userProfileVoList = new ArrayList<>();
-        userAdaptor
-                .queryUserByEmailContains(email)
-                .forEach(
-                        queryUser -> {
-                            if (!host.hasHostUserId(queryUser.getId())) {
-                                userProfileVoList.add(queryUser.toUserProfileVo());
-                            }
-                        });
-        return userProfileVoList;
+        final User inviteUser = userAdaptor.queryUserByEmail(email);
+        if (host.hasHostUserId(inviteUser.getId())) {
+            throw AlreadyJoinedHostException.EXCEPTION;
+        }
+        return inviteUser.toUserProfileVo();
     }
 
     @Transactional(readOnly = true)

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
@@ -7,6 +7,7 @@ import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.common.annotation.Mapper;
 import band.gosrock.domain.common.vo.HostUserVo;
 import band.gosrock.domain.common.vo.UserInfoVo;
+import band.gosrock.domain.common.vo.UserProfileVo;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.host.domain.HostProfile;
@@ -14,7 +15,9 @@ import band.gosrock.domain.domains.host.domain.HostRole;
 import band.gosrock.domain.domains.host.domain.HostUser;
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
 import band.gosrock.domain.domains.user.domain.User;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +57,22 @@ public class HostMapper {
     public HostUser toSuperHostUser(Long hostId, Long userId) {
         final Host host = hostAdaptor.findById(hostId);
         return HostUser.builder().userId(userId).host(host).role(HostRole.SUPER_HOST).build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserProfileVo> toHostInviteUserList(Long hostId, String email) {
+        final Host host = hostAdaptor.findById(hostId);
+
+        final List<UserProfileVo> userProfileVoList = new ArrayList<>();
+        userAdaptor
+                .queryUserByEmailContains(email)
+                .forEach(
+                        queryUser -> {
+                            if (!host.hasHostUserId(queryUser.getId())) {
+                                userProfileVoList.add(queryUser.toUserProfileVo());
+                            }
+                        });
+        return userProfileVoList;
     }
 
     @Transactional(readOnly = true)

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
@@ -44,10 +44,10 @@ public class HostMapper {
                 .build();
     }
 
-    /** 기본 역할인 HOST 로 강제 주입하는 생성자 */
-    public HostUser toHostUser(Long hostId, Long userId) {
+    /** 호스트 역할을 지정하여 주입하는 생성자 */
+    public HostUser toHostUser(Long hostId, Long userId, HostRole role) {
         final Host host = hostAdaptor.findById(hostId);
-        return HostUser.builder().userId(userId).host(host).role(HostRole.HOST).build();
+        return HostUser.builder().userId(userId).host(host).role(role).build();
     }
 
     /** 역할 지정하여 주입하는 생성자 */
@@ -83,8 +83,7 @@ public class HostMapper {
                                 userInfoVo ->
                                         HostUserVo.from(
                                                 userInfoVo,
-                                                host.getHostUserByUserId(userInfoVo.getUserId())
-                                                        .getRole()))
+                                                host.getHostUserByUserId(userInfoVo.getUserId())))
                         .collect(Collectors.toSet());
 
         return HostDetailResponse.of(host, hostUserVoSet);

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/CreateHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/CreateHostUseCase.java
@@ -7,6 +7,7 @@ import band.gosrock.api.host.model.dto.response.HostResponse;
 import band.gosrock.api.host.model.mapper.HostMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.domain.HostUser;
 import band.gosrock.domain.domains.host.service.HostService;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -25,10 +26,9 @@ public class CreateHostUseCase {
         final User user = userUtils.getCurrentUser();
         final Long userId = user.getId();
         // 호스트 생성
-        final Host host = hostMapper.toEntity(createHostRequest, userId);
-        hostService.createHost(host);
-
-        return HostResponse.of(
-                hostService.addHostUser(host, hostMapper.toSuperHostUser(host.getId(), userId)));
+        final Host host = hostService.createHost(hostMapper.toEntity(createHostRequest, userId));
+        // 생성한 유저를 마스터로 + 슈퍼 호스트 권한으로 등록
+        final HostUser masterHostUser = hostMapper.toSuperHostUser(host.getId(), userId);
+        return HostResponse.of(hostService.addHostUser(host, masterHostUser));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/CreateHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/CreateHostUseCase.java
@@ -29,6 +29,8 @@ public class CreateHostUseCase {
         final Host host = hostService.createHost(hostMapper.toEntity(createHostRequest, userId));
         // 생성한 유저를 마스터로 + 슈퍼 호스트 권한으로 등록
         final HostUser masterHostUser = hostMapper.toSuperHostUser(host.getId(), userId);
+        // 초대 보류 없이 즉시 활성화
+        masterHostUser.activate();
         return HostResponse.of(hostService.addHostUser(host, masterHostUser));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/InviteHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/InviteHostUseCase.java
@@ -33,7 +33,8 @@ public class InviteHostUseCase {
         final Long inviteUserId =
                 userAdaptor.queryUserByEmail(inviteHostRequest.getEmail()).getId();
         final Host host = hostAdaptor.findById(hostId);
-        final HostUser hostUser = hostMapper.toHostUser(hostId, inviteUserId);
+        final HostUser hostUser =
+                hostMapper.toHostUser(hostId, inviteUserId, inviteHostRequest.getRole());
         return hostMapper.toHostDetailResponse(hostService.addHostUser(host, hostUser));
 
         // todo :: 초대 성공 시 상대방에게 알림 이벤트 발송

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/JoinHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/JoinHostUseCase.java
@@ -29,11 +29,12 @@ public class JoinHostUseCase {
         final Long userId = user.getId();
         final Host host = hostAdaptor.findById(hostId);
 
-        // 이 호스트에 이미 속함
-        if (host.hasHostUserId(userId)) {
+        // 이 호스트에 초대받지 않음
+        host.validateHostUser(userId);
+        // 이미 활성 상태임
+        if (host.isActiveHostUserId(userId)) {
             throw AlreadyJoinedHostException.EXCEPTION;
         }
-        hostService.addHostUser(host, hostMapper.toHostUser(hostId, userId));
-        return hostMapper.toHostDetailResponse(host);
+        return hostMapper.toHostDetailResponse(hostService.activateHostUser(host, userId));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/JoinHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/JoinHostUseCase.java
@@ -7,7 +7,6 @@ import band.gosrock.api.host.model.mapper.HostMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
-import band.gosrock.domain.domains.host.exception.AlreadyJoinedHostException;
 import band.gosrock.domain.domains.host.service.HostService;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -31,10 +30,6 @@ public class JoinHostUseCase {
 
         // 이 호스트에 초대받지 않음
         host.validateHostUser(userId);
-        // 이미 활성 상태임
-        if (host.isActiveHostUserId(userId)) {
-            throw AlreadyJoinedHostException.EXCEPTION;
-        }
         return hostMapper.toHostDetailResponse(hostService.activateHostUser(host, userId));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadInviteUserListUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadInviteUserListUseCase.java
@@ -6,7 +6,6 @@ import band.gosrock.api.host.model.mapper.HostMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.common.vo.UserProfileVo;
 import band.gosrock.domain.domains.user.domain.User;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,7 +16,7 @@ public class ReadInviteUserListUseCase {
     private final UserUtils userUtils;
     private final HostMapper hostMapper;
 
-    public List<UserProfileVo> execute(Long hostId, String email) {
+    public UserProfileVo execute(Long hostId, String email) {
         final User user = userUtils.getCurrentUser();
         final Long userId = user.getId();
         return hostMapper.toHostInviteUserList(hostId, email);

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadInviteUserListUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadInviteUserListUseCase.java
@@ -1,0 +1,27 @@
+package band.gosrock.api.host.service;
+
+
+import band.gosrock.api.common.UserUtils;
+import band.gosrock.api.host.model.mapper.HostMapper;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.common.vo.UserProfileVo;
+import band.gosrock.domain.domains.user.domain.User;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.Email;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReadInviteUserListUseCase {
+    private final UserUtils userUtils;
+    private final HostMapper hostMapper;
+
+    public List<UserProfileVo> execute(Long hostId, @Valid @Email String email) {
+        final User user = userUtils.getCurrentUser();
+        final Long userId = user.getId();
+        return hostMapper.toHostInviteUserList(hostId, email);
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadInviteUserListUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadInviteUserListUseCase.java
@@ -7,8 +7,6 @@ import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.common.vo.UserProfileVo;
 import band.gosrock.domain.domains.user.domain.User;
 import java.util.List;
-import javax.validation.Valid;
-import javax.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +17,7 @@ public class ReadInviteUserListUseCase {
     private final UserUtils userUtils;
     private final HostMapper hostMapper;
 
-    public List<UserProfileVo> execute(Long hostId, @Valid @Email String email) {
+    public List<UserProfileVo> execute(Long hostId, String email) {
         final User user = userUtils.getCurrentUser();
         final Long userId = user.getId();
         return hostMapper.toHostInviteUserList(hostId, email);

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CreateOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CreateOrderUseCase.java
@@ -23,7 +23,7 @@ public class CreateOrderUseCase {
         Long cartId = createOrderRequest.getCartId();
         if (couponId == null) {
             return CreateOrderResponse.from(
-                    createOrderService.WithOutCoupon(cartId, user.getId()), user.getProfile());
+                    createOrderService.withOutCoupon(cartId, user.getId()), user.getProfile());
         }
         return CreateOrderResponse.from(
                 createOrderService.withCoupon(cartId, user.getId(), couponId), user.getProfile());

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostInfoVo.java
@@ -14,8 +14,6 @@ public class HostInfoVo {
 
     private final String introduce;
 
-    private final String since;
-
     private final String profileImageUrl;
 
     private final String contactEmail;
@@ -29,7 +27,6 @@ public class HostInfoVo {
                 .hostId(host.getId())
                 .name(host.getProfile().getName())
                 .introduce(host.getProfile().getIntroduce())
-                .since(host.getProfile().getSince())
                 .profileImageUrl(host.getProfile().getProfileImageUrl())
                 .contactEmail(host.getProfile().getContactEmail())
                 .contactNumber(host.getProfile().getContactNumber())

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostUserVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostUserVo.java
@@ -2,6 +2,7 @@ package band.gosrock.domain.common.vo;
 
 
 import band.gosrock.domain.domains.host.domain.HostRole;
+import band.gosrock.domain.domains.host.domain.HostUser;
 import band.gosrock.domain.domains.user.domain.User;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import lombok.Builder;
@@ -14,11 +15,21 @@ public class HostUserVo {
 
     private final HostRole role;
 
-    public static HostUserVo from(User user, HostRole role) {
-        return HostUserVo.builder().userInfoVo(user.toUserInfoVo()).role(role).build();
+    private final Boolean active;
+
+    public static HostUserVo from(User user, HostUser hostUser) {
+        return HostUserVo.builder()
+                .userInfoVo(user.toUserInfoVo())
+                .active(hostUser.getActive())
+                .role(hostUser.getRole())
+                .build();
     }
 
-    public static HostUserVo from(UserInfoVo userInfoVo, HostRole role) {
-        return HostUserVo.builder().userInfoVo(userInfoVo).role(role).build();
+    public static HostUserVo from(UserInfoVo userInfoVo, HostUser hostUser) {
+        return HostUserVo.builder()
+                .userInfoVo(userInfoVo)
+                .active(hostUser.getActive())
+                .role(hostUser.getRole())
+                .build();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserProfileVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserProfileVo.java
@@ -1,0 +1,28 @@
+package band.gosrock.domain.common.vo;
+
+
+import band.gosrock.domain.domains.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserProfileVo {
+
+    private final Long userId;
+
+    private final String userName;
+
+    private final String email;
+
+    private final String profileImage;
+
+    public static UserProfileVo from(User user) {
+        return UserProfileVo.builder()
+                .userId(user.getId())
+                .userName(user.getProfile().getName())
+                .email(user.getProfile().getEmail())
+                .profileImage(user.getProfile().getProfileImage())
+                .build();
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
@@ -53,8 +53,8 @@ public class Host extends BaseTimeEntity {
                 .orElse(null);
     }
 
-    public void setProfile(HostProfile hostProfile) {
-        this.profile = hostProfile;
+    public void updateProfile(HostProfile hostProfile) {
+        this.profile.updateProfile(hostProfile);
     }
 
     public void setSlackUrl(String slackUrl) {
@@ -99,7 +99,6 @@ public class Host extends BaseTimeEntity {
     public Host(
             String name,
             String introduce,
-            String since,
             String profileImageUrl,
             String contactEmail,
             String contactNumber,
@@ -109,7 +108,6 @@ public class Host extends BaseTimeEntity {
                 HostProfile.builder()
                         .name(name)
                         .introduce(introduce)
-                        .since(since)
                         .profileImageUrl(profileImageUrl)
                         .contactEmail(contactEmail)
                         .contactNumber(contactNumber)

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostProfile.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostProfile.java
@@ -18,10 +18,6 @@ public class HostProfile {
     // 간단 소개
     private String introduce;
 
-    // 호스트 시작 연도
-    @Column(length = 10) // xxxx.xx.xx 까지 허용
-    private String since;
-
     // 프로필 이미지 url
     private String profileImageUrl;
 
@@ -32,17 +28,22 @@ public class HostProfile {
     @Column(length = 15)
     private String contactNumber;
 
+    protected void updateProfile(HostProfile hostProfile) {
+        this.profileImageUrl = hostProfile.getProfileImageUrl();
+        this.introduce = hostProfile.getIntroduce();
+        this.contactEmail = hostProfile.getContactEmail();
+        this.contactNumber = hostProfile.getContactNumber();
+    }
+
     @Builder
     public HostProfile(
             String name,
             String introduce,
-            String since,
             String profileImageUrl,
             String contactEmail,
             String contactNumber) {
         this.name = name;
         this.introduce = introduce;
-        this.since = since;
         this.profileImageUrl = profileImageUrl;
         this.contactEmail = contactEmail;
         this.contactNumber = contactNumber;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostRole.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostRole.java
@@ -9,10 +9,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum HostRole {
     // 슈퍼 호스트 (조회, 변경 가능)
-    SUPER_HOST("SUPER_HOST"),
+    SUPER_HOST("SUPER_HOST", "매니저"),
     // 일반 호스트 (조회만 가능)
-    HOST("HOST");
+    HOST("HOST", "게스트");
 
+    private final String name;
     private final String value;
 
     // Enum Validation 을 위한 코드, enum 에 속하지 않으면 null 리턴

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostUser.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostUser.java
@@ -2,6 +2,7 @@ package band.gosrock.domain.domains.host.domain;
 
 
 import band.gosrock.domain.common.model.BaseTimeEntity;
+import band.gosrock.domain.domains.host.exception.AlreadyJoinedHostException;
 import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -40,6 +41,9 @@ public class HostUser extends BaseTimeEntity {
     }
 
     public void activate() {
+        if (this.active) {
+            throw AlreadyJoinedHostException.EXCEPTION;
+        }
         this.active = true;
     }
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostUser.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostUser.java
@@ -28,12 +28,19 @@ public class HostUser extends BaseTimeEntity {
     @Column(name = "user_id")
     private Long userId;
 
+    // 초대 승락 여부
+    private Boolean active = false;
+
     // 유저의 권한
     @Enumerated(EnumType.STRING)
     private HostRole role = HostRole.HOST;
 
     public void setHostRole(HostRole role) {
         this.role = role;
+    }
+
+    public void activate() {
+        this.active = true;
     }
 
     @Builder

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostErrorCode.java
@@ -19,7 +19,7 @@ public enum HostErrorCode implements BaseErrorCode {
     ALREADY_JOINED_HOST(BAD_REQUEST, "HOST_400_3", "이미 가입되어 있는 유저입니다."),
     NOT_MASTER_HOST(BAD_REQUEST, "HOST_400_4", "마스터 호스트 권한이 없는 유저입니다."),
     FORBIDDEN_HOST_OPERATION(BAD_REQUEST, "HOST_400_5", "마스터 호스트의 권한은 변경할 수 없습니다."),
-    NOT_ACCEPTED_HOST(BAD_REQUEST, "HOST_400_6", "아직 초대를 승낙하지 않은 유저입니다."),
+    NOT_ACCEPTED_HOST(BAD_REQUEST, "HOST_400_6", "아직 초대를 수락하지 않은 유저입니다."),
     HOST_NOT_FOUND(NOT_FOUND, "Host_404_1", "해당 호스트를 찾을 수 없습니다."),
     HOST_USER_NOT_FOUND(NOT_FOUND, "HOST_404_2", "가입된 호스트 유저가 아닙니다.");
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostErrorCode.java
@@ -19,6 +19,7 @@ public enum HostErrorCode implements BaseErrorCode {
     ALREADY_JOINED_HOST(BAD_REQUEST, "HOST_400_3", "이미 가입되어 있는 유저입니다."),
     NOT_MASTER_HOST(BAD_REQUEST, "HOST_400_4", "마스터 호스트 권한이 없는 유저입니다."),
     FORBIDDEN_HOST_OPERATION(BAD_REQUEST, "HOST_400_5", "마스터 호스트의 권한은 변경할 수 없습니다."),
+    NOT_ACCEPTED_HOST(BAD_REQUEST, "HOST_400_6", "아직 초대를 승낙하지 않은 유저입니다."),
     HOST_NOT_FOUND(NOT_FOUND, "Host_404_1", "해당 호스트를 찾을 수 없습니다."),
     HOST_USER_NOT_FOUND(NOT_FOUND, "HOST_404_2", "가입된 호스트 유저가 아닙니다.");
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/NotAcceptedHostException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/NotAcceptedHostException.java
@@ -1,0 +1,12 @@
+package band.gosrock.domain.domains.host.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class NotAcceptedHostException extends DuDoongCodeException {
+    public static final DuDoongCodeException EXCEPTION = new NotAcceptedHostException();
+
+    private NotAcceptedHostException() {
+        super(HostErrorCode.NOT_ACCEPTED_HOST);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
@@ -42,7 +42,7 @@ public class HostService {
     }
 
     public Host updateHostProfile(Host host, HostProfile profile) {
-        host.setProfile(profile);
+        host.updateProfile(profile);
         return hostRepository.save(host);
     }
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
@@ -24,10 +24,6 @@ public class HostService {
         return hostRepository.save(host);
     }
 
-    public Host updateHost(Host host) {
-        return hostRepository.save(host);
-    }
-
     public Host addHostUser(Host host, HostUser hostUser) {
         if (host.hasHostUserId(hostUser.getUserId())) {
             throw AlreadyJoinedHostException.EXCEPTION;
@@ -49,6 +45,16 @@ public class HostService {
     public Host updateHostSlackUrl(Host host, String url) {
         host.setSlackUrl(url);
         return hostRepository.save(host);
+    }
+
+    public Host activateHostUser(Host host, Long userId) {
+        host.getHostUserByUserId(userId).activate();
+        return hostRepository.save(host);
+    }
+
+    /** 해당 유저가 호스트에 속하는지 확인하는 검증 로직입니다 */
+    public void validateHostUser(Host host, Long userId) {
+        host.validateHostUser(userId);
     }
 
     /** 해당 유저가 호스트의 마스터(담당자, 방장)인지 확인하는 검증 로직입니다 */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/adaptor/UserAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/adaptor/UserAdaptor.java
@@ -6,6 +6,7 @@ import band.gosrock.domain.domains.user.domain.OauthInfo;
 import band.gosrock.domain.domains.user.domain.User;
 import band.gosrock.domain.domains.user.exception.UserNotFoundException;
 import band.gosrock.domain.domains.user.repository.UserRepository;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
@@ -39,5 +40,10 @@ public class UserAdaptor {
         return userRepository
                 .findByProfileEmail(email)
                 .orElseThrow(() -> UserNotFoundException.EXCEPTION);
+    }
+
+    /** 이메일로 유저를 가져오는 쿼리 */
+    public List<User> queryUserByEmailContains(String email) {
+        return userRepository.findByProfileEmailContains(email);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/adaptor/UserAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/adaptor/UserAdaptor.java
@@ -6,7 +6,6 @@ import band.gosrock.domain.domains.user.domain.OauthInfo;
 import band.gosrock.domain.domains.user.domain.User;
 import band.gosrock.domain.domains.user.exception.UserNotFoundException;
 import band.gosrock.domain.domains.user.repository.UserRepository;
-import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
@@ -40,10 +39,5 @@ public class UserAdaptor {
         return userRepository
                 .findByProfileEmail(email)
                 .orElseThrow(() -> UserNotFoundException.EXCEPTION);
-    }
-
-    /** 이메일로 유저를 가져오는 쿼리 */
-    public List<User> queryUserByEmailContains(String email) {
-        return userRepository.findByProfileEmailContains(email);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
@@ -5,6 +5,7 @@ import band.gosrock.domain.common.aop.domainEvent.Events;
 import band.gosrock.domain.common.events.user.UserRegisterEvent;
 import band.gosrock.domain.common.model.BaseTimeEntity;
 import band.gosrock.domain.common.vo.UserInfoVo;
+import band.gosrock.domain.common.vo.UserProfileVo;
 import band.gosrock.domain.domains.user.exception.AlreadyDeletedUserException;
 import band.gosrock.domain.domains.user.exception.ForbiddenUserException;
 import javax.persistence.Column;
@@ -76,5 +77,9 @@ public class User extends BaseTimeEntity {
 
     public UserInfoVo toUserInfoVo() {
         return UserInfoVo.from(this);
+    }
+
+    public UserProfileVo toUserProfileVo() {
+        return UserProfileVo.from(this);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/repository/UserRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/repository/UserRepository.java
@@ -3,7 +3,6 @@ package band.gosrock.domain.domains.user.repository;
 
 import band.gosrock.domain.domains.user.domain.OauthInfo;
 import band.gosrock.domain.domains.user.domain.User;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,7 +15,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     /** email 로 유저를 가져오는 쿼리 */
     Optional<User> findByProfileEmail(String email);
-
-    /** email string 이 포함된 유저를 모두 가져오는 쿼리 */
-    List<User> findByProfileEmailContains(String email);
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/repository/UserRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/repository/UserRepository.java
@@ -3,6 +3,7 @@ package band.gosrock.domain.domains.user.repository;
 
 import band.gosrock.domain.domains.user.domain.OauthInfo;
 import band.gosrock.domain.domains.user.domain.User;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,4 +16,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     /** email 로 유저를 가져오는 쿼리 */
     Optional<User> findByProfileEmail(String email);
+
+    /** email string 이 포함된 유저를 모두 가져오는 쿼리 */
+    List<User> findByProfileEmailContains(String email);
 }


### PR DESCRIPTION
## 개요
- close #198 

## 작업사항
- 호스트 유저인지 확인하는 Validate 메소드 추가
- 유저 초대 및 초대 수락 기능 분리
- HostUser 에 Active 필드 추가하여 수락시에 Active = true 가 되어 기능 사용 가능
- 이메일로 유저 검색 기능 추가
- 유저 검색용 기능 정보 처리를 위한 `UserProfileVo` 추가 -> 나중에 단순 프로필 미리보기 용으로 써도 좋을듯


<img width="566" alt="image" src="https://user-images.githubusercontent.com/72291860/214779034-a66a0476-b623-4a60-88f8-67dd715a37d0.png">

- 유저 이메일 검색을 쿼리 파라미터로 받고, 검증하기 위해 `ConstraintViolationExceptionHandler` 추가 구현
- `@Valid` 와 던지는 예외가 아예 달라서 추가했습니다

<img width="266" alt="image" src="https://user-images.githubusercontent.com/72291860/214780609-27eeb516-2354-4458-9862-1656e8502b7c.png">


- 컨트롤러 상단에 `@Validated` 추가해주면 Constraints 관련 어노테이션 RequestParam 에도 사용 가능합니다

## 변경로직
- 위와 같음