### PR TITLE
feat : 티켓상품에 옵션 적용하기

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CreateOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/CreateOrderUseCase.java
@@ -23,7 +23,7 @@ public class CreateOrderUseCase {
         Long cartId = createOrderRequest.getCartId();
         if (couponId == null) {
             return CreateOrderResponse.from(
-                    createOrderService.WithOutCoupon(cartId, user.getId()), user.getProfile());
+                    createOrderService.withOutCoupon(cartId, user.getId()), user.getProfile());
         }
         return CreateOrderResponse.from(
                 createOrderService.withCoupon(cartId, user.getId(), couponId), user.getProfile());

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/controller/TicketItemController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/controller/TicketItemController.java
@@ -1,8 +1,11 @@
 package band.gosrock.api.ticketItem.controller;
 
 
+import band.gosrock.api.ticketItem.dto.request.ApplyTicketOptionRequest;
 import band.gosrock.api.ticketItem.dto.request.CreateTicketItemRequest;
+import band.gosrock.api.ticketItem.dto.response.ApplyTicketOptionResponse;
 import band.gosrock.api.ticketItem.dto.response.CreateTicketItemResponse;
+import band.gosrock.api.ticketItem.service.ApplyTicketOptionUseCase;
 import band.gosrock.api.ticketItem.service.CreateTicketItemUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class TicketItemController {
 
     public final CreateTicketItemUseCase createTicketItemUseCase;
+    public final ApplyTicketOptionUseCase applyTicketOptionUseCase;
 
     @Operation(
             summary = "특정 이벤트에 속하는 티켓 상품을 생성합니다.",
@@ -27,5 +31,13 @@ public class TicketItemController {
     public CreateTicketItemResponse createTicketItem(
             @RequestBody @Valid CreateTicketItemRequest createTicketItemRequest) {
         return createTicketItemUseCase.execute(createTicketItemRequest);
+    }
+
+    @Operation(summary = "옵션을 티켓상품에 적용합니다.")
+    @PostMapping("/{eventId}/option")
+    public ApplyTicketOptionResponse createTicketOption(
+            @RequestBody @Valid ApplyTicketOptionRequest applyTicketOptionRequest,
+            @PathVariable Long eventId) {
+        return applyTicketOptionUseCase.execute(applyTicketOptionRequest, eventId);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/dto/request/ApplyTicketOptionRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/dto/request/ApplyTicketOptionRequest.java
@@ -1,0 +1,20 @@
+package band.gosrock.api.ticketItem.dto.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ApplyTicketOptionRequest {
+
+    @NotNull
+    @Schema(nullable = false, example = "1")
+    private Long ticketItemId;
+
+    @NotNull
+    @Schema(nullable = false, example = "1")
+    private Long optionGroupId;
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/dto/response/ApplyTicketOptionResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/dto/response/ApplyTicketOptionResponse.java
@@ -1,0 +1,28 @@
+package band.gosrock.api.ticketItem.dto.response;
+
+
+import band.gosrock.domain.domains.ticket_item.domain.ItemOptionGroup;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ApplyTicketOptionResponse {
+    @Schema(description = "상품-옵션그룹 id")
+    private final Long itemOptionGroupId;
+
+    @Schema(description = "티켓상품 id")
+    private final Long ticketItemId;
+
+    @Schema(description = "옵션그룹 id")
+    private final Long optionGroupId;
+
+    public static ApplyTicketOptionResponse from(ItemOptionGroup itemOptionGroup) {
+        return ApplyTicketOptionResponse.builder()
+                .itemOptionGroupId(itemOptionGroup.getId())
+                .ticketItemId(itemOptionGroup.getItem().getId())
+                .optionGroupId(itemOptionGroup.getOptionGroup().getId())
+                .build();
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/mapper/TicketOptionMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/mapper/TicketOptionMapper.java
@@ -4,7 +4,9 @@ package band.gosrock.api.ticketItem.mapper;
 import band.gosrock.api.ticketItem.dto.request.CreateTicketOptionRequest;
 import band.gosrock.common.annotation.Mapper;
 import band.gosrock.domain.domains.event.domain.Event;
+import band.gosrock.domain.domains.ticket_item.domain.ItemOptionGroup;
 import band.gosrock.domain.domains.ticket_item.domain.OptionGroup;
+import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
 import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 
@@ -22,5 +24,9 @@ public class TicketOptionMapper {
                 .isEssential(true)
                 .options(new ArrayList<>())
                 .build();
+    }
+
+    public ItemOptionGroup toItemOptionGroup(TicketItem ticketItem, OptionGroup optionGroup) {
+        return ItemOptionGroup.builder().item(ticketItem).optionGroup(optionGroup).build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/ApplyTicketOptionUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/ApplyTicketOptionUseCase.java
@@ -1,0 +1,56 @@
+package band.gosrock.api.ticketItem.service;
+
+
+import band.gosrock.api.common.UserUtils;
+import band.gosrock.api.ticketItem.dto.request.ApplyTicketOptionRequest;
+import band.gosrock.api.ticketItem.dto.response.ApplyTicketOptionResponse;
+import band.gosrock.api.ticketItem.mapper.TicketOptionMapper;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
+import band.gosrock.domain.domains.event.domain.Event;
+import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
+import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.ticket_item.adaptor.OptionAdaptor;
+import band.gosrock.domain.domains.ticket_item.adaptor.TicketItemAdaptor;
+import band.gosrock.domain.domains.ticket_item.domain.ItemOptionGroup;
+import band.gosrock.domain.domains.ticket_item.domain.OptionGroup;
+import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.ticket_item.service.ItemOptionGroupService;
+import band.gosrock.domain.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class ApplyTicketOptionUseCase {
+
+    private final UserUtils userUtils;
+    private final EventAdaptor eventAdaptor;
+    private final HostAdaptor hostAdaptor;
+    private final TicketItemAdaptor ticketItemAdaptor;
+    private final OptionAdaptor optionAdaptor;
+    private final ItemOptionGroupService itemOptionGroupService;
+    private final TicketOptionMapper ticketOptionMapper;
+
+    public ApplyTicketOptionResponse execute(
+            ApplyTicketOptionRequest applyTicketOptionRequest, Long eventId) {
+        User user = userUtils.getCurrentUser();
+        Event event = eventAdaptor.findById(eventId);
+        Host host = hostAdaptor.findById(event.getHostId());
+        // 권한 체크 ( 해당 이벤트의 호스트인지 )
+        host.hasHostUserId(user.getId());
+
+        TicketItem ticketItem =
+                ticketItemAdaptor.queryTicketItem(applyTicketOptionRequest.getTicketItemId());
+        OptionGroup optionGroup =
+                optionAdaptor.queryOptionGroup(applyTicketOptionRequest.getOptionGroupId());
+        // 티켓상품과 옵션이 해당 이벤트 소속인지 확인
+        itemOptionGroupService.checkEventId(eventId, ticketItem, optionGroup);
+        // 이미 적용된 옵션인지 확인
+        itemOptionGroupService.checkApply(ticketItem, optionGroup);
+
+        ItemOptionGroup itemOptionGroup =
+                itemOptionGroupService.createItemOptionGroup(
+                        ticketOptionMapper.toItemOptionGroup(ticketItem, optionGroup));
+        return ApplyTicketOptionResponse.from(itemOptionGroup);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/adaptor/ItemOptionGroupAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/adaptor/ItemOptionGroupAdaptor.java
@@ -1,0 +1,23 @@
+package band.gosrock.domain.domains.ticket_item.adaptor;
+
+
+import band.gosrock.common.annotation.Adaptor;
+import band.gosrock.domain.domains.ticket_item.domain.ItemOptionGroup;
+import band.gosrock.domain.domains.ticket_item.repository.ItemOptionGroupRepository;
+import lombok.RequiredArgsConstructor;
+
+@Adaptor
+@RequiredArgsConstructor
+public class ItemOptionGroupAdaptor {
+
+    private final ItemOptionGroupRepository itemOptionGroupRepository;
+
+    public Boolean existsQueryItemOptionGroup(Long ticketItemId, Long optionGroupId) {
+        return itemOptionGroupRepository.existsByItemIdAndOptionGroupId(
+                ticketItemId, optionGroupId);
+    }
+
+    public ItemOptionGroup save(ItemOptionGroup itemOptionGroup) {
+        return itemOptionGroupRepository.save(itemOptionGroup);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/adaptor/OptionAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/adaptor/OptionAdaptor.java
@@ -4,6 +4,7 @@ package band.gosrock.domain.domains.ticket_item.adaptor;
 import band.gosrock.common.annotation.Adaptor;
 import band.gosrock.domain.domains.ticket_item.domain.Option;
 import band.gosrock.domain.domains.ticket_item.domain.OptionGroup;
+import band.gosrock.domain.domains.ticket_item.exception.OptionGroupNotFoundException;
 import band.gosrock.domain.domains.ticket_item.exception.OptionNotFoundException;
 import band.gosrock.domain.domains.ticket_item.repository.OptionGroupRepository;
 import band.gosrock.domain.domains.ticket_item.repository.OptionRepository;
@@ -15,6 +16,12 @@ public class OptionAdaptor {
 
     private final OptionRepository optionRepository;
     private final OptionGroupRepository optionGroupRepository;
+
+    public OptionGroup queryOptionGroup(Long optionGroupId) {
+        return optionGroupRepository
+                .findById(optionGroupId)
+                .orElseThrow(() -> OptionGroupNotFoundException.EXCEPTION);
+    }
 
     public Option queryOption(Long optionId) {
         return optionRepository

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/DuplicatedItemOptionGroupException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/DuplicatedItemOptionGroupException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.ticket_item.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class DuplicatedItemOptionGroupException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new DuplicatedItemOptionGroupException();
+
+    private DuplicatedItemOptionGroupException() {
+        super(TicketItemErrorCode.DUPLICATED_ITEM_OPTION_GROUP);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/InvalidOptionGroupException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/InvalidOptionGroupException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.ticket_item.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class InvalidOptionGroupException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new InvalidOptionGroupException();
+
+    private InvalidOptionGroupException() {
+        super(TicketItemErrorCode.INVALID_OPTION_GROUP);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/InvalidTicketItemException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/InvalidTicketItemException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.ticket_item.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class InvalidTicketItemException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new InvalidTicketItemException();
+
+    private InvalidTicketItemException() {
+        super(TicketItemErrorCode.INVALID_TICKET_ITEM);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/OptionGroupNotFoundException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/OptionGroupNotFoundException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.ticket_item.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class OptionGroupNotFoundException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new OptionGroupNotFoundException();
+
+    private OptionGroupNotFoundException() {
+        super(TicketItemErrorCode.OPTION_GROUP_NOT_FOUND);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/TicketItemErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/TicketItemErrorCode.java
@@ -27,7 +27,15 @@ public enum TicketItemErrorCode implements BaseErrorCode {
     INVALID_TICKET_PRICE(BAD_REQUEST, "Ticket_Item_400_3", "티켓 가격을 설정할 수 없습니다."),
     @ExplainError("예매 취소 및 티켓 취소 요청 시 티켓 상품 공급량보다 많은 양이 반환될 때 발생하는 오류입니다.")
     TICKET_ITEM_QUANTITY_LARGER_THAN_SUPPLY_COUNT(
-            BAD_REQUEST, "Ticket_Item_400_4", "공급량보다 많은 티켓 아이템 재고가 설정되었습니다.");
+            BAD_REQUEST, "Ticket_Item_400_4", "공급량보다 많은 티켓 아이템 재고가 설정되었습니다."),
+    @ExplainError("요청에서 보내준 옵션그룹 id 값이 올바르지 않을 때 발생하는 오류입니다.")
+    OPTION_GROUP_NOT_FOUND(NOT_FOUND, "Option_Group_404_1", "옵션그룹을 찾을 수 없습니다."),
+    @ExplainError("적용할 옵션이 해당 이벤트 소속이 아닐 때 발생하는 오류입니다.")
+    INVALID_OPTION_GROUP(BAD_REQUEST, "Option_Group_400_1", "해당 옵션을 적용할 수 없습니다."),
+    @ExplainError("옵션을 적용할 상품이 해당 이벤트 소속이 아닐 때 발생하는 오류입니다.")
+    INVALID_TICKET_ITEM(BAD_REQUEST, "Ticket_Item_400_5", "해당 티켓상품에 적용할 수 없습니다."),
+    @ExplainError("해당 티켓상품에 이미 적용된 옵션일 경우 발생하는 오류입니다.")
+    DUPLICATED_ITEM_OPTION_GROUP(BAD_REQUEST, "Item_Option_Group_400_1", "이미 적용된 옵션입니다.");
 
     private Integer status;
     private String code;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/repository/ItemOptionGroupRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/repository/ItemOptionGroupRepository.java
@@ -1,0 +1,10 @@
+package band.gosrock.domain.domains.ticket_item.repository;
+
+
+import band.gosrock.domain.domains.ticket_item.domain.ItemOptionGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemOptionGroupRepository extends JpaRepository<ItemOptionGroup, Long> {
+
+    Boolean existsByItemIdAndOptionGroupId(Long itemId, Long optionGroupId);
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/service/ItemOptionGroupService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/service/ItemOptionGroupService.java
@@ -1,0 +1,42 @@
+package band.gosrock.domain.domains.ticket_item.service;
+
+
+import band.gosrock.common.annotation.DomainService;
+import band.gosrock.domain.domains.ticket_item.adaptor.ItemOptionGroupAdaptor;
+import band.gosrock.domain.domains.ticket_item.domain.ItemOptionGroup;
+import band.gosrock.domain.domains.ticket_item.domain.OptionGroup;
+import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.ticket_item.exception.DuplicatedItemOptionGroupException;
+import band.gosrock.domain.domains.ticket_item.exception.InvalidOptionGroupException;
+import band.gosrock.domain.domains.ticket_item.exception.InvalidTicketItemException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@DomainService
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ItemOptionGroupService {
+
+    private final ItemOptionGroupAdaptor itemOptionGroupAdaptor;
+
+    public void checkEventId(Long eventId, TicketItem ticketItem, OptionGroup optionGroup) {
+        if (!ticketItem.getEvent().getId().equals(eventId)) {
+            throw InvalidTicketItemException.EXCEPTION;
+        }
+        if (!optionGroup.getEvent().getId().equals(eventId)) {
+            throw InvalidOptionGroupException.EXCEPTION;
+        }
+    }
+
+    public void checkApply(TicketItem ticketItem, OptionGroup optionGroup) {
+        if (itemOptionGroupAdaptor.existsQueryItemOptionGroup(
+                ticketItem.getId(), optionGroup.getId())) {
+            throw DuplicatedItemOptionGroupException.EXCEPTION;
+        }
+    }
+
+    @Transactional
+    public ItemOptionGroup createItemOptionGroup(ItemOptionGroup itemOptionGroup) {
+        return itemOptionGroupAdaptor.save(itemOptionGroup);
+    }
+}


### PR DESCRIPTION
## 개요
- close #192

## 작업사항
- 옵션을 티켓상품에 적용하는 API 입니다.
- 헷갈리는 네이밍
   optionGroup == 옵션 질문 (ex. 뒷풀이 참여하십니까, 추천인 이름을 적어주세요)
   option == 옵션 응답 (ex. Y, 김원진)
   itemOptionGroup == 티켓상품-옵션그룹의 매핑엔티티 (적용)
- 티켓상품쪽 리펙토링 하면서  "/v1/{eventId}/ticketItems/option" 으로 uri 변경 예정

## 변경로직
