### PR TITLE
feat: 응원톡 삭제, 갯수 카운팅 및 랜덤으로 뽑아오기 API 작성

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,5 +44,11 @@ public class CommentController {
     public RetrieveCommentListResponse getComments(
             @PathVariable Long eventId, @RequestParam(required = false) Long lastId) {
         return retrieveCommentUseCase.execute(eventId, lastId);
+    }
+
+    @Operation(summary = "[어드민 기능] 응원글을 삭제합니다.")
+    @DeleteMapping(value = "/{commentId}")
+    public Void deleteComment(@PathVariable Long eventId, @PathVariable Long commentId) {
+
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
@@ -3,9 +3,11 @@ package band.gosrock.api.comment.controller;
 
 import band.gosrock.api.comment.model.request.CreateCommentRequest;
 import band.gosrock.api.comment.model.response.CreateCommentResponse;
+import band.gosrock.api.comment.model.response.RetrieveCommentCountResponse;
 import band.gosrock.api.comment.model.response.RetrieveCommentListResponse;
 import band.gosrock.api.comment.service.CreateCommentUseCase;
 import band.gosrock.api.comment.service.DeleteCommentUseCase;
+import band.gosrock.api.comment.service.RetrieveCommentCountUseCase;
 import band.gosrock.api.comment.service.RetrieveCommentUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -34,6 +36,8 @@ public class CommentController {
 
     private final DeleteCommentUseCase deleteCommentUseCase;
 
+    private final RetrieveCommentCountUseCase retrieveCommentCountUseCase;
+
     @Operation(summary = "응원글을 생성합니다.")
     @PostMapping
     public CreateCommentResponse postComment(
@@ -53,5 +57,11 @@ public class CommentController {
     @DeleteMapping(value = "/{commentId}")
     public void deleteComment(@PathVariable Long eventId, @PathVariable Long commentId) {
         deleteCommentUseCase.execute(eventId, commentId);
+    }
+
+    @Operation(summary = "응원글 개수를 카운팅합니다.")
+    @GetMapping(value = "/counts")
+    public RetrieveCommentCountResponse getCommentCounts(@PathVariable Long eventId) {
+        return retrieveCommentCountUseCase.execute(eventId);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
@@ -5,10 +5,12 @@ import band.gosrock.api.comment.model.request.CreateCommentRequest;
 import band.gosrock.api.comment.model.response.CreateCommentResponse;
 import band.gosrock.api.comment.model.response.RetrieveCommentCountResponse;
 import band.gosrock.api.comment.model.response.RetrieveCommentListResponse;
+import band.gosrock.api.comment.model.response.RetrieveRandomCommentResponse;
 import band.gosrock.api.comment.service.CreateCommentUseCase;
 import band.gosrock.api.comment.service.DeleteCommentUseCase;
 import band.gosrock.api.comment.service.RetrieveCommentCountUseCase;
 import band.gosrock.api.comment.service.RetrieveCommentUseCase;
+import band.gosrock.api.comment.service.RetrieveRandomCommentUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -38,6 +40,8 @@ public class CommentController {
 
     private final RetrieveCommentCountUseCase retrieveCommentCountUseCase;
 
+    private final RetrieveRandomCommentUseCase retrieveRandomCommentUseCase;
+
     @Operation(summary = "응원글을 생성합니다.")
     @PostMapping
     public CreateCommentResponse postComment(
@@ -63,5 +67,11 @@ public class CommentController {
     @GetMapping(value = "/counts")
     public RetrieveCommentCountResponse getCommentCounts(@PathVariable Long eventId) {
         return retrieveCommentCountUseCase.execute(eventId);
+    }
+
+    @Operation(summary = "응원글을 랜덤으로 뽑아옵니다.")
+    @GetMapping(value = "/random")
+    public RetrieveRandomCommentResponse getRandomComment(@PathVariable Long eventId) {
+        return retrieveRandomCommentUseCase.execute(eventId);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
@@ -5,6 +5,7 @@ import band.gosrock.api.comment.model.request.CreateCommentRequest;
 import band.gosrock.api.comment.model.response.CreateCommentResponse;
 import band.gosrock.api.comment.model.response.RetrieveCommentListResponse;
 import band.gosrock.api.comment.service.CreateCommentUseCase;
+import band.gosrock.api.comment.service.DeleteCommentUseCase;
 import band.gosrock.api.comment.service.RetrieveCommentUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -31,6 +32,8 @@ public class CommentController {
 
     private final RetrieveCommentUseCase retrieveCommentUseCase;
 
+    private final DeleteCommentUseCase deleteCommentUseCase;
+
     @Operation(summary = "응원글을 생성합니다.")
     @PostMapping
     public CreateCommentResponse postComment(
@@ -48,7 +51,7 @@ public class CommentController {
 
     @Operation(summary = "[어드민 기능] 응원글을 삭제합니다.")
     @DeleteMapping(value = "/{commentId}")
-    public Void deleteComment(@PathVariable Long eventId, @PathVariable Long commentId) {
-
+    public void deleteComment(@PathVariable Long eventId, @PathVariable Long commentId) {
+        deleteCommentUseCase.execute(eventId, commentId);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/mapper/CommentMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/mapper/CommentMapper.java
@@ -5,6 +5,7 @@ import band.gosrock.api.comment.model.request.CreateCommentRequest;
 import band.gosrock.api.comment.model.response.CreateCommentResponse;
 import band.gosrock.api.comment.model.response.RetrieveCommentCountResponse;
 import band.gosrock.api.comment.model.response.RetrieveCommentListResponse;
+import band.gosrock.api.comment.model.response.RetrieveRandomCommentResponse;
 import band.gosrock.common.annotation.Mapper;
 import band.gosrock.domain.domains.comment.adaptor.CommentAdaptor;
 import band.gosrock.domain.domains.comment.domain.Comment;
@@ -44,5 +45,9 @@ public class CommentMapper {
 
     public RetrieveCommentCountResponse toRetrieveCommentCountResponse(Long commentCount) {
         return RetrieveCommentCountResponse.of(commentCount);
+    }
+
+    public RetrieveRandomCommentResponse toRetrieveRandomCommentResponse(Comment comment) {
+        return RetrieveRandomCommentResponse.of(comment);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/mapper/CommentMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/mapper/CommentMapper.java
@@ -3,6 +3,7 @@ package band.gosrock.api.comment.mapper;
 
 import band.gosrock.api.comment.model.request.CreateCommentRequest;
 import band.gosrock.api.comment.model.response.CreateCommentResponse;
+import band.gosrock.api.comment.model.response.RetrieveCommentCountResponse;
 import band.gosrock.api.comment.model.response.RetrieveCommentListResponse;
 import band.gosrock.common.annotation.Mapper;
 import band.gosrock.domain.domains.comment.adaptor.CommentAdaptor;
@@ -39,5 +40,9 @@ public class CommentMapper {
     @Transactional(readOnly = true)
     public Comment retrieveComment(Long commentId) {
         return commentAdaptor.queryComment(commentId);
+    }
+
+    public RetrieveCommentCountResponse toRetrieveCommentCountResponse(Long commentCount) {
+        return RetrieveCommentCountResponse.of(commentCount);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/mapper/CommentMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/mapper/CommentMapper.java
@@ -35,4 +35,9 @@ public class CommentMapper {
         Slice<Comment> comments = commentAdaptor.searchComment(commentCondition);
         return RetrieveCommentListResponse.of(comments, currentUserId);
     }
+
+    @Transactional(readOnly = true)
+    public Comment retrieveComment(Long commentId) {
+        return commentAdaptor.queryComment(commentId);
+    }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/model/response/RetrieveCommentCountResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/model/response/RetrieveCommentCountResponse.java
@@ -1,0 +1,16 @@
+package band.gosrock.api.comment.model.response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RetrieveCommentCountResponse {
+
+    private final Long commentCounts;
+
+    public static RetrieveCommentCountResponse of(Long commentCounts) {
+        return RetrieveCommentCountResponse.builder().commentCounts(commentCounts).build();
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/model/response/RetrieveRandomCommentResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/model/response/RetrieveRandomCommentResponse.java
@@ -1,0 +1,20 @@
+package band.gosrock.api.comment.model.response;
+
+
+import band.gosrock.domain.common.vo.CommentInfoVo;
+import band.gosrock.domain.domains.comment.domain.Comment;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RetrieveRandomCommentResponse {
+
+    private final CommentInfoVo commentInfo;
+
+    public static RetrieveRandomCommentResponse of(Comment comment) {
+        return RetrieveRandomCommentResponse.builder()
+                .commentInfo(comment.toCommentInfoVo())
+                .build();
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/DeleteCommentUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/DeleteCommentUseCase.java
@@ -27,7 +27,7 @@ public class DeleteCommentUseCase {
         // 권한 검사
         eventService.checkEventHost(currentUserId, eventId);
         Comment comment = commentMapper.retrieveComment(commentId);
-        commentDomainService.deleteComment(comment);
+        commentDomainService.deleteComment(comment, eventId);
     }
 
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/DeleteCommentUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/DeleteCommentUseCase.java
@@ -1,0 +1,17 @@
+package band.gosrock.api.comment.service;
+
+import band.gosrock.api.comment.mapper.CommentMapper;
+import band.gosrock.api.common.UserUtils;
+import band.gosrock.common.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class DeleteCommentUseCase {
+
+    private final UserUtils userUtils;
+
+    private final CommentMapper commentMapper;
+
+
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/DeleteCommentUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/DeleteCommentUseCase.java
@@ -1,5 +1,6 @@
 package band.gosrock.api.comment.service;
 
+
 import band.gosrock.api.comment.mapper.CommentMapper;
 import band.gosrock.api.common.UserUtils;
 import band.gosrock.common.annotation.UseCase;
@@ -29,5 +30,4 @@ public class DeleteCommentUseCase {
         Comment comment = commentMapper.retrieveComment(commentId);
         commentDomainService.deleteComment(comment, eventId);
     }
-
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/DeleteCommentUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/DeleteCommentUseCase.java
@@ -3,7 +3,11 @@ package band.gosrock.api.comment.service;
 import band.gosrock.api.comment.mapper.CommentMapper;
 import band.gosrock.api.common.UserUtils;
 import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.comment.domain.Comment;
+import band.gosrock.domain.domains.comment.service.CommentDomainService;
+import band.gosrock.domain.domains.event.service.EventService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
@@ -13,5 +17,17 @@ public class DeleteCommentUseCase {
 
     private final CommentMapper commentMapper;
 
+    private final EventService eventService;
+
+    private final CommentDomainService commentDomainService;
+
+    @Transactional
+    public void execute(Long eventId, Long commentId) {
+        Long currentUserId = userUtils.getCurrentUserId();
+        // 권한 검사
+        eventService.checkEventHost(currentUserId, eventId);
+        Comment comment = commentMapper.retrieveComment(commentId);
+        commentDomainService.deleteComment(comment);
+    }
 
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/RetrieveCommentCountUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/RetrieveCommentCountUseCase.java
@@ -1,0 +1,29 @@
+package band.gosrock.api.comment.service;
+
+
+import band.gosrock.api.comment.mapper.CommentMapper;
+import band.gosrock.api.comment.model.response.RetrieveCommentCountResponse;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.comment.adaptor.CommentAdaptor;
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
+import band.gosrock.domain.domains.event.domain.Event;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class RetrieveCommentCountUseCase {
+
+    private final CommentAdaptor commentAdaptor;
+
+    private final CommentMapper commentMapper;
+
+    private final EventAdaptor eventAdaptor;
+
+    @Transactional(readOnly = true)
+    public RetrieveCommentCountResponse execute(Long eventId) {
+        Event event = eventAdaptor.findById(eventId);
+        Long commentCount = commentAdaptor.queryCommentCount(event.getId());
+        return commentMapper.toRetrieveCommentCountResponse(commentCount);
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/RetrieveRandomCommentUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/RetrieveRandomCommentUseCase.java
@@ -1,0 +1,31 @@
+package band.gosrock.api.comment.service;
+
+
+import band.gosrock.api.comment.mapper.CommentMapper;
+import band.gosrock.api.comment.model.response.RetrieveRandomCommentResponse;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.comment.adaptor.CommentAdaptor;
+import band.gosrock.domain.domains.comment.domain.Comment;
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
+import band.gosrock.domain.domains.event.domain.Event;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class RetrieveRandomCommentUseCase {
+
+    private final CommentAdaptor commentAdaptor;
+
+    private final CommentMapper commentMapper;
+
+    private final EventAdaptor eventAdaptor;
+
+    @Transactional(readOnly = true)
+    public RetrieveRandomCommentResponse execute(Long eventId) {
+        Event event = eventAdaptor.findById(eventId);
+        Long countComment = commentAdaptor.queryCommentCount(event.getId());
+        Comment comment = commentAdaptor.queryRandomComment(event.getId(), countComment);
+        return commentMapper.toRetrieveRandomCommentResponse(comment);
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/RetrieveRandomCommentUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/RetrieveRandomCommentUseCase.java
@@ -24,8 +24,7 @@ public class RetrieveRandomCommentUseCase {
     @Transactional(readOnly = true)
     public RetrieveRandomCommentResponse execute(Long eventId) {
         Event event = eventAdaptor.findById(eventId);
-        Long countComment = commentAdaptor.queryCommentCount(event.getId());
-        Comment comment = commentAdaptor.queryRandomComment(event.getId(), countComment);
+        Comment comment = commentAdaptor.queryRandomComment(event.getId());
         return commentMapper.toRetrieveRandomCommentResponse(comment);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/CommentInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/CommentInfoVo.java
@@ -19,6 +19,8 @@ public class CommentInfoVo {
 
     @DateFormat private final LocalDateTime createdAt;
 
+    private final Long eventId;
+
     private final Long userId;
 
     public static CommentInfoVo from(Comment comment) {
@@ -27,6 +29,7 @@ public class CommentInfoVo {
                 .nickName(comment.getNickName())
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
+                .eventId(comment.getEventId())
                 .userId(comment.getUser().getId())
                 .build();
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
@@ -24,4 +24,8 @@ public class CommentAdaptor {
         PageRequest pageRequest = PageRequest.of(0, 20, Sort.by("createdAt").ascending());
         return commentRepository.searchToPage(commentCondition, pageRequest);
     }
+
+    public void delete(Comment comment) {
+
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
@@ -36,7 +36,8 @@ public class CommentAdaptor {
         return commentRepository.countComment(eventId);
     }
 
-    public Comment queryRandomComment(Long eventId, Long countComment) {
+    public Comment queryRandomComment(Long eventId) {
+        Long countComment = queryCommentCount(eventId);
         return commentRepository.queryRandomComment(eventId, countComment);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
@@ -35,4 +35,8 @@ public class CommentAdaptor {
     public Long queryCommentCount(Long eventId) {
         return commentRepository.countComment(eventId);
     }
+
+    public Comment queryRandomComment(Long eventId, Long countComment) {
+        return commentRepository.queryRandomComment(eventId, countComment);
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
@@ -4,6 +4,7 @@ package band.gosrock.domain.domains.comment.adaptor;
 import band.gosrock.common.annotation.Adaptor;
 import band.gosrock.domain.domains.comment.domain.Comment;
 import band.gosrock.domain.domains.comment.dto.condition.CommentCondition;
+import band.gosrock.domain.domains.comment.exception.CommentNotFoundException;
 import band.gosrock.domain.domains.comment.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -25,7 +26,7 @@ public class CommentAdaptor {
         return commentRepository.searchToPage(commentCondition, pageRequest);
     }
 
-    public void delete(Comment comment) {
-
+    public Comment queryComment(Long commentId) {
+        return commentRepository.findById(commentId).orElseThrow(() -> CommentNotFoundException.EXCEPTION);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
@@ -27,6 +27,12 @@ public class CommentAdaptor {
     }
 
     public Comment queryComment(Long commentId) {
-        return commentRepository.findById(commentId).orElseThrow(() -> CommentNotFoundException.EXCEPTION);
+        return commentRepository
+                .findById(commentId)
+                .orElseThrow(() -> CommentNotFoundException.EXCEPTION);
+    }
+
+    public Long queryCommentCount(Long eventId) {
+        return commentRepository.countComment(eventId);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/domain/Comment.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/domain/Comment.java
@@ -6,6 +6,8 @@ import band.gosrock.domain.common.vo.CommentInfoVo;
 import band.gosrock.domain.domains.user.domain.User;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -39,12 +41,16 @@ public class Comment extends BaseTimeEntity {
 
     private Long eventId;
 
+    @Enumerated(EnumType.STRING)
+    private CommentStatus commentStatus;
+
     @Builder
-    public Comment(String content, String nickName, User user, Long eventId) {
+    public Comment(String content, String nickName, User user, Long eventId, CommentStatus commentStatus) {
         this.content = content;
         this.nickName = nickName;
         this.user = user;
         this.eventId = eventId;
+        this.commentStatus = commentStatus;
     }
 
     public static Comment create(String content, String nickName, User user, Long eventId) {
@@ -53,6 +59,7 @@ public class Comment extends BaseTimeEntity {
                 .nickName(nickName)
                 .user(user)
                 .eventId(eventId)
+            .commentStatus(CommentStatus.ACTIVE)
                 .build();
     }
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/domain/Comment.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/domain/Comment.java
@@ -66,4 +66,8 @@ public class Comment extends BaseTimeEntity {
     public CommentInfoVo toCommentInfoVo() {
         return CommentInfoVo.from(this);
     }
+
+    public void delete() {
+        this.commentStatus = CommentStatus.INACTIVE;
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/domain/Comment.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/domain/Comment.java
@@ -3,7 +3,10 @@ package band.gosrock.domain.domains.comment.domain;
 
 import band.gosrock.domain.common.model.BaseTimeEntity;
 import band.gosrock.domain.common.vo.CommentInfoVo;
+import band.gosrock.domain.domains.comment.exception.CommentAlreadyDeleteException;
+import band.gosrock.domain.domains.comment.exception.CommentNotMatchEventException;
 import band.gosrock.domain.domains.user.domain.User;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -68,6 +71,15 @@ public class Comment extends BaseTimeEntity {
     }
 
     public void delete() {
+        if (this.commentStatus == CommentStatus.INACTIVE) {
+            throw CommentAlreadyDeleteException.EXCEPTION;
+        }
         this.commentStatus = CommentStatus.INACTIVE;
+    }
+
+    public void checkEvent(Long eventId) {
+        if (!Objects.equals(eventId, this.eventId)) {
+            throw CommentNotMatchEventException.EXCEPTION;
+        }
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/domain/Comment.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/domain/Comment.java
@@ -48,7 +48,8 @@ public class Comment extends BaseTimeEntity {
     private CommentStatus commentStatus;
 
     @Builder
-    public Comment(String content, String nickName, User user, Long eventId, CommentStatus commentStatus) {
+    public Comment(
+            String content, String nickName, User user, Long eventId, CommentStatus commentStatus) {
         this.content = content;
         this.nickName = nickName;
         this.user = user;
@@ -62,7 +63,7 @@ public class Comment extends BaseTimeEntity {
                 .nickName(nickName)
                 .user(user)
                 .eventId(eventId)
-            .commentStatus(CommentStatus.ACTIVE)
+                .commentStatus(CommentStatus.ACTIVE)
                 .build();
     }
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/domain/CommentStatus.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/domain/CommentStatus.java
@@ -1,0 +1,15 @@
+package band.gosrock.domain.domains.comment.domain;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CommentStatus {
+
+    ACTIVE("ACTIVE"),
+    INACTIVE("INACTIVE");
+
+    private final String value;
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/domain/CommentStatus.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/domain/CommentStatus.java
@@ -1,13 +1,12 @@
 package band.gosrock.domain.domains.comment.domain;
 
-import com.fasterxml.jackson.annotation.JsonValue;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum CommentStatus {
-
     ACTIVE("ACTIVE"),
     INACTIVE("INACTIVE");
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentAlreadyDeleteException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentAlreadyDeleteException.java
@@ -1,0 +1,12 @@
+package band.gosrock.domain.domains.comment.exception;
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class CommentAlreadyDeleteException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new CommentAlreadyDeleteException();
+
+    private CommentAlreadyDeleteException() {
+        super(CommentErrorCode.COMMENT_ALREADY_DELETE);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentAlreadyDeleteException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentAlreadyDeleteException.java
@@ -1,5 +1,6 @@
 package band.gosrock.domain.domains.comment.exception;
 
+
 import band.gosrock.common.exception.DuDoongCodeException;
 
 public class CommentAlreadyDeleteException extends DuDoongCodeException {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentErrorCode.java
@@ -1,0 +1,34 @@
+package band.gosrock.domain.domains.comment.exception;
+
+import static band.gosrock.common.consts.DuDoongStatic.NOT_FOUND;
+
+import band.gosrock.common.annotation.ExplainError;
+import band.gosrock.common.dto.ErrorReason;
+import band.gosrock.common.exception.BaseErrorCode;
+import java.lang.reflect.Field;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CommentErrorCode implements BaseErrorCode {
+    COMMENT_NOT_FOUND(NOT_FOUND, "Comment_404_1", "응원글을 찾을 수 없습니다.");
+
+
+    private Integer status;
+    private String code;
+    private String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.builder().reason(reason).code(code).status(status).build();
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getReason();
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentErrorCode.java
@@ -17,7 +17,8 @@ public enum CommentErrorCode implements BaseErrorCode {
     COMMENT_NOT_FOUND(NOT_FOUND, "Comment_404_1", "응원글을 찾을 수 없습니다."),
     @ExplainError(value = "eventId 경로변수와 commentId가 맞지 않을 때 발생하는 에러입니다.")
     COMMENT_NOT_MATCH_EVENT(BAD_REQUEST, "Comment_400_1", "응원글과 이벤트가 맞지 않습니다."),
-    COMMENT_ALREADY_DELETE(BAD_REQUEST, "Comment_400_2", "이미 삭제된 응원글입니다.");
+    COMMENT_ALREADY_DELETE(BAD_REQUEST, "Comment_400_2", "이미 삭제된 응원글입니다."),
+    RETRIEVE_RANDOM_COMMENT_NOT_FOUND(NOT_FOUND, "Comment_404_2", "랜덤 응원글을 찾을 수 없습니다.");
 
     private Integer status;
     private String code;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentErrorCode.java
@@ -19,7 +19,6 @@ public enum CommentErrorCode implements BaseErrorCode {
     COMMENT_NOT_MATCH_EVENT(BAD_REQUEST, "Comment_400_1", "응원글과 이벤트가 맞지 않습니다."),
     COMMENT_ALREADY_DELETE(BAD_REQUEST, "Comment_400_2", "이미 삭제된 응원글입니다.");
 
-
     private Integer status;
     private String code;
     private String reason;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentErrorCode.java
@@ -1,5 +1,6 @@
 package band.gosrock.domain.domains.comment.exception;
 
+import static band.gosrock.common.consts.DuDoongStatic.BAD_REQUEST;
 import static band.gosrock.common.consts.DuDoongStatic.NOT_FOUND;
 
 import band.gosrock.common.annotation.ExplainError;
@@ -13,7 +14,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum CommentErrorCode implements BaseErrorCode {
-    COMMENT_NOT_FOUND(NOT_FOUND, "Comment_404_1", "응원글을 찾을 수 없습니다.");
+    COMMENT_NOT_FOUND(NOT_FOUND, "Comment_404_1", "응원글을 찾을 수 없습니다."),
+    @ExplainError(value = "eventId 경로변수와 commentId가 맞지 않을 때 발생하는 에러입니다.")
+    COMMENT_NOT_MATCH_EVENT(BAD_REQUEST, "Comment_400_1", "응원글과 이벤트가 맞지 않습니다."),
+    COMMENT_ALREADY_DELETE(BAD_REQUEST, "Comment_400_2", "이미 삭제된 응원글입니다.");
 
 
     private Integer status;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentNotFoundException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.comment.exception;
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class CommentNotFoundException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new CommentNotFoundException();
+
+    private CommentNotFoundException() {
+        super(CommentErrorCode.COMMENT_NOT_FOUND);
+    }
+
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentNotFoundException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentNotFoundException.java
@@ -1,5 +1,6 @@
 package band.gosrock.domain.domains.comment.exception;
 
+
 import band.gosrock.common.exception.DuDoongCodeException;
 
 public class CommentNotFoundException extends DuDoongCodeException {
@@ -9,5 +10,4 @@ public class CommentNotFoundException extends DuDoongCodeException {
     private CommentNotFoundException() {
         super(CommentErrorCode.COMMENT_NOT_FOUND);
     }
-
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentNotMatchEventException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentNotMatchEventException.java
@@ -1,5 +1,6 @@
 package band.gosrock.domain.domains.comment.exception;
 
+
 import band.gosrock.common.exception.DuDoongCodeException;
 
 public class CommentNotMatchEventException extends DuDoongCodeException {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentNotMatchEventException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/CommentNotMatchEventException.java
@@ -1,0 +1,12 @@
+package band.gosrock.domain.domains.comment.exception;
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class CommentNotMatchEventException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new CommentNotMatchEventException();
+
+    private CommentNotMatchEventException() {
+        super(CommentErrorCode.COMMENT_NOT_MATCH_EVENT);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/RetrieveRandomCommentNotFoundException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/exception/RetrieveRandomCommentNotFoundException.java
@@ -1,0 +1,14 @@
+package band.gosrock.domain.domains.comment.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class RetrieveRandomCommentNotFoundException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION =
+            new RetrieveRandomCommentNotFoundException();
+
+    private RetrieveRandomCommentNotFoundException() {
+        super(CommentErrorCode.RETRIEVE_RANDOM_COMMENT_NOT_FOUND);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepository.java
@@ -11,4 +11,6 @@ public interface CommentCustomRepository {
     Slice<Comment> searchToPage(CommentCondition commentCondition, Pageable pageable);
 
     Long countComment(Long eventId);
+
+    Comment queryRandomComment(Long eventId, Long count);
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepository.java
@@ -9,4 +9,6 @@ import org.springframework.data.domain.Slice;
 public interface CommentCustomRepository {
 
     Slice<Comment> searchToPage(CommentCondition commentCondition, Pageable pageable);
+
+    Long countComment(Long eventId);
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ import static band.gosrock.domain.domains.comment.domain.QComment.comment;
 import static band.gosrock.domain.domains.user.domain.QUser.user;
 
 import band.gosrock.domain.domains.comment.domain.Comment;
+import band.gosrock.domain.domains.comment.domain.CommentStatus;
 import band.gosrock.domain.domains.comment.dto.condition.CommentCondition;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -27,7 +28,9 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                         .fetchJoin()
                         .where(
                                 eventIdEq(commentCondition.getEventId()),
-                                lastIdLessThanEqual(commentCondition.getLastId()))
+                                lastIdLessThanEqual(commentCondition.getLastId()),
+                                comment.commentStatus.eq(CommentStatus.ACTIVE)
+                        )
                         .orderBy(comment.id.desc())
                         .limit(pageable.getPageSize() + 1)
                         .fetch();

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepositoryImpl.java
@@ -6,13 +6,18 @@ import static band.gosrock.domain.domains.user.domain.QUser.user;
 import band.gosrock.domain.domains.comment.domain.Comment;
 import band.gosrock.domain.domains.comment.domain.CommentStatus;
 import band.gosrock.domain.domains.comment.dto.condition.CommentCondition;
+import band.gosrock.domain.domains.comment.exception.RetrieveRandomCommentNotFoundException;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.support.PageableExecutionUtils;
 
 @RequiredArgsConstructor
 public class CommentCustomRepositoryImpl implements CommentCustomRepository {
@@ -64,5 +69,32 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                 .from(comment)
                 .where(eventIdEq(eventId), comment.commentStatus.eq(CommentStatus.ACTIVE))
                 .fetchOne();
+    }
+
+    @Override
+    public Comment queryRandomComment(Long eventId, Long countComment) {
+        int idx = (int) (Math.random() * countComment);
+        PageRequest pageRequest = PageRequest.of(idx, 1);
+        List<Comment> comments =
+                queryFactory
+                        .selectFrom(comment)
+                        .where(eventIdEq(eventId), comment.commentStatus.eq(CommentStatus.ACTIVE))
+                        .offset(pageRequest.getOffset())
+                        .limit(1)
+                        .fetch();
+
+        JPAQuery<Long> countQuery =
+                queryFactory
+                        .select(comment.count())
+                        .from(comment)
+                        .where(eventIdEq(eventId), comment.commentStatus.eq(CommentStatus.ACTIVE));
+
+        Page<Comment> commentOfPage =
+                PageableExecutionUtils.getPage(comments, pageRequest, countQuery::fetchOne);
+
+        if (commentOfPage.hasContent()) {
+            return commentOfPage.getContent().get(0);
+        }
+        throw RetrieveRandomCommentNotFoundException.EXCEPTION;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepositoryImpl.java
@@ -10,6 +10,7 @@ import band.gosrock.domain.domains.comment.exception.RetrieveRandomCommentNotFou
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.security.SecureRandom;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -73,7 +74,9 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
 
     @Override
     public Comment queryRandomComment(Long eventId, Long countComment) {
-        int idx = (int) (Math.random() * countComment);
+        SecureRandom secureRandom = new SecureRandom();
+        int idx = (int) (secureRandom.nextFloat(1) * countComment);
+
         PageRequest pageRequest = PageRequest.of(idx, 1);
         List<Comment> comments =
                 queryFactory

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepositoryImpl.java
@@ -29,8 +29,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                         .where(
                                 eventIdEq(commentCondition.getEventId()),
                                 lastIdLessThanEqual(commentCondition.getLastId()),
-                                comment.commentStatus.eq(CommentStatus.ACTIVE)
-                        )
+                                comment.commentStatus.eq(CommentStatus.ACTIVE))
                         .orderBy(comment.id.desc())
                         .limit(pageable.getPageSize() + 1)
                         .fetch();
@@ -56,5 +55,14 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
         }
 
         return new SliceImpl<>(comments, pageable, hasNext);
+    }
+
+    @Override
+    public Long countComment(Long eventId) {
+        return queryFactory
+                .select(comment.count())
+                .from(comment)
+                .where(eventIdEq(eventId), comment.commentStatus.eq(CommentStatus.ACTIVE))
+                .fetchOne();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/service/CommentDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/service/CommentDomainService.java
@@ -1,5 +1,6 @@
 package band.gosrock.domain.domains.comment.service;
 
+
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.domains.comment.domain.Comment;
 import lombok.RequiredArgsConstructor;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/service/CommentDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/service/CommentDomainService.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CommentDomainService {
 
-    public void deleteComment(Comment comment) {
+    public void deleteComment(Comment comment, Long eventId) {
+        comment.checkEvent(eventId);
         comment.delete();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/service/CommentDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/service/CommentDomainService.java
@@ -4,11 +4,13 @@ package band.gosrock.domain.domains.comment.service;
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.domains.comment.domain.Comment;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @DomainService
 @RequiredArgsConstructor
 public class CommentDomainService {
 
+    @Transactional
     public void deleteComment(Comment comment, Long eventId) {
         comment.checkEvent(eventId);
         comment.delete();

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/service/CommentDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/service/CommentDomainService.java
@@ -1,0 +1,14 @@
+package band.gosrock.domain.domains.comment.service;
+
+import band.gosrock.common.annotation.DomainService;
+import band.gosrock.domain.domains.comment.domain.Comment;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class CommentDomainService {
+
+    public void deleteComment(Comment comment) {
+        comment.delete();
+    }
+}


### PR DESCRIPTION
## 개요
- close #207 

## 작업사항
- 응원톡 관련 여러가지 API들을 작성했습니다.
- 응원톡 관련 뷰들이 나와있지가 않아서 티켓 프로젝트 22th를 보고 작성했습니다. [티켓 프로젝트 22 관련 컨트롤러](https://github.com/Gosrock/Ticket-Backend-22nd/blob/dev/src/users/users.controller.ts)
- 삭제 기능은 soft-delete로 구현했습니다. 따라서 ACTIVE / INACTIVE로 나눴고 ACTIVE를 검사하는 로직들을 레포지토리에 추가해줬습니다.
- 또한 삭제기능은 어드민 기능으로 알고 있어서 권한 검사도 추가했습니다.
- 삭제 API의 반환값은 void입니다.
- 갯수 카운팅 API는 왜있는지는 모르겠지만 일단 추가했습니다.
- 랜덤으로 뽑기는 저번 프로젝트에서는 쿼리파라미터로 갯수도 받아서 몇개를 가져올건지도 했던데 아직 확실치 않아 일단 단건 조회로 구현했습니다.
- Spring Data JPA나 QueryDsl은 랜덤 조회가 따로 없고 보통 쿼리로 구현한다했지만 레퍼런스를 뒤져본 결과 좋은 방법을 하나 발견해서 사용했습니다. 

``` java
@Override
    public Comment queryRandomComment(Long eventId, Long countComment) {
        SecureRandom secureRandom = new SecureRandom();
        int idx = (int) (secureRandom.nextFloat(1) * countComment);

        PageRequest pageRequest = PageRequest.of(idx, 1);
        List<Comment> comments =
                queryFactory
                        .selectFrom(comment)
                        .where(eventIdEq(eventId), comment.commentStatus.eq(CommentStatus.ACTIVE))
                        .offset(pageRequest.getOffset())
                        .limit(1)
                        .fetch();

        JPAQuery<Long> countQuery =
                queryFactory
                        .select(comment.count())
                        .from(comment)
                        .where(eventIdEq(eventId), comment.commentStatus.eq(CommentStatus.ACTIVE));

        Page<Comment> commentOfPage =
                PageableExecutionUtils.getPage(comments, pageRequest, countQuery::fetchOne);

        if (commentOfPage.hasContent()) {
            return commentOfPage.getContent().get(0);
        }
        throw RetrieveRandomCommentNotFoundException.EXCEPTION;
    }
```
- 각 한 개의 레코드를 가지는 페이지로 사이즈를 정한 뒤 랜덤으로 페이지 번호를 반환받아 고르는 방식을 사용했습니다.
- 마지막 에러 부분은 정확한 워딩이 생각이 나지 않아서 일단 적어놓았는데 피드백 해주시면 고치겠습니다.

## 변경로직
- 내용을 적어주세요.