### PR TITLE
feat(host) : 호스트 권한 검증 aop

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostQualification.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostQualification.java
@@ -4,6 +4,7 @@ package band.gosrock.api.common.aop;
 import band.gosrock.domain.domains.host.domain.Host;
 import java.util.function.BiConsumer;
 
+/** 각 권한에 맞춰서 host 도메인의 검증메소드를 실행시킵니다. 검증 메소드이므로 biConsumer 를 통해 실행 시킬 함수를 미리 생성해 둡니다. -이찬진 */
 public enum HostQualification {
     MASTER((userId, host) -> host.validateMasterHostUser(userId)),
     MANAGER((userId, host) -> host.validateSuperHostUser(userId)),
@@ -14,6 +15,12 @@ public enum HostQualification {
         this.consumer = consumer;
     }
 
+    /**
+     * 호스트의 검증을 수행하는 메서드
+     *
+     * @param userId
+     * @param host
+     */
     public void validQualification(Long userId, Host host) {
         consumer.accept(userId, host);
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostQualification.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostQualification.java
@@ -1,0 +1,20 @@
+package band.gosrock.api.common.aop;
+
+
+import band.gosrock.domain.domains.host.domain.Host;
+import java.util.function.BiConsumer;
+
+public enum HostQualification {
+    MASTER((userId, host) -> host.validateMasterHostUser(userId)),
+    MANAGER((userId, host) -> host.validateSuperHostUser(userId)),
+    GUEST((userId, host) -> host.validateActiveHostUser(userId));
+    private final BiConsumer<Long, Host> consumer;
+
+    HostQualification(BiConsumer<Long, Host> consumer) {
+        this.consumer = consumer;
+    }
+
+    public void validQualification(Long userId, Host host) {
+        consumer.accept(userId, host);
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRoleAop.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRoleAop.java
@@ -11,6 +11,9 @@ import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
+/**
+ * 호스트 관리자 인가를 위한 aop 입니다 메소드 레벨에서 작동하며 권한 정보를 어노테이션으로 받고 eventId를 인자에서 찾아와 호스트 정보를 불러온뒤 권한 검증을 합니다.
+ */
 @Aspect
 @Component
 @RequiredArgsConstructor
@@ -29,7 +32,7 @@ public class HostRoleAop {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
         HostRolesAllowed annotation = method.getAnnotation(HostRolesAllowed.class);
-        String role = annotation.value();
+        String role = annotation.role();
 
         // 제공된 호스트의 role 이 정의된 세개의 롤과 같은지 확인한다.
         // 없으면 IllegalArgumentException 발생

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRoleAop.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRoleAop.java
@@ -32,7 +32,7 @@ public class HostRoleAop {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
         HostRolesAllowed annotation = method.getAnnotation(HostRolesAllowed.class);
-        String role = annotation.role();
+        String role = annotation.value();
 
         // 제공된 호스트의 role 이 정의된 세개의 롤과 같은지 확인한다.
         // 없으면 IllegalArgumentException 발생

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRoleAop.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRoleAop.java
@@ -1,0 +1,56 @@
+package band.gosrock.api.common.aop;
+
+
+import java.lang.reflect.Method;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnExpression("${ableHostRoleAop:true}")
+public class HostRoleAop {
+    private final HostRoleTransaction hostRoleTransaction;
+
+    /**
+     * master 호스트의 마스터 manager 호스트의 수정,조회 ( 호스트유저도메인의 슈퍼 호스트 ) guest 호스트의 조회권한 (호스트유저도메인의 호스트 )
+     *
+     * @see band.gosrock.domain.domains.host.domain.HostRole
+     */
+    @Around("@annotation(band.gosrock.api.common.aop.HostRolesAllowed)")
+    public Object aop(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        HostRolesAllowed annotation = method.getAnnotation(HostRolesAllowed.class);
+        String role = annotation.value();
+
+        // 제공된 호스트의 role 이 정의된 세개의 롤과 같은지 확인한다.
+        // 없으면 IllegalArgumentException 발생
+        HostQualification hostQualification = HostQualification.valueOf(role);
+
+        String identifier = annotation.eventIdIdentifier();
+        String[] parameterNames = signature.getParameterNames();
+        Object[] args = joinPoint.getArgs();
+        // 이벤트 아이디를 인자에서 얻어온다.
+        Long eventId = getEventId(parameterNames, args, identifier);
+
+        return hostRoleTransaction.proceed(eventId, hostQualification, joinPoint);
+    }
+
+    public Long getEventId(String[] parameterNames, Object[] args, String paramName) {
+        for (int i = 0; i < parameterNames.length; i++) {
+            if (parameterNames[i].equals(paramName)) {
+                // 롱타입이라 가정. 안되면 classCastException 터트림
+                return (Long) args[i];
+            }
+        }
+        throw new IllegalArgumentException();
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRoleTransaction.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRoleTransaction.java
@@ -1,0 +1,35 @@
+package band.gosrock.api.common.aop;
+
+
+import band.gosrock.api.common.UserUtils;
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
+import band.gosrock.domain.domains.event.domain.Event;
+import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
+import band.gosrock.domain.domains.host.domain.Host;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class HostRoleTransaction {
+
+    private final UserUtils userUtils;
+    private final EventAdaptor eventAdaptor;
+
+    private final HostAdaptor hostAdaptor;
+
+    @Transactional(readOnly = true)
+    public Object proceed(Long eventId, HostQualification role, final ProceedingJoinPoint joinPoint)
+            throws Throwable {
+        Long currentUserId = userUtils.getCurrentUserId();
+        Event event = eventAdaptor.findById(eventId);
+        Host host = hostAdaptor.findById(event.getHostId());
+        role.validQualification(currentUserId, host);
+
+        return joinPoint.proceed();
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRoleTransaction.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRoleTransaction.java
@@ -12,6 +12,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+/** 호스트 정보를 트랜잭션 안에서 조회하기 위해서 만든 클래스입니다. 트랜잭션 내에서 캐시 할수 있으면 좋으니 이렇게 만들었습니다. - 이찬진 */
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -19,7 +20,6 @@ public class HostRoleTransaction {
 
     private final UserUtils userUtils;
     private final EventAdaptor eventAdaptor;
-
     private final HostAdaptor hostAdaptor;
 
     @Transactional(readOnly = true)
@@ -29,7 +29,6 @@ public class HostRoleTransaction {
         Event event = eventAdaptor.findById(eventId);
         Host host = hostAdaptor.findById(event.getHostId());
         role.validQualification(currentUserId, host);
-
         return joinPoint.proceed();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRolesAllowed.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRolesAllowed.java
@@ -15,7 +15,7 @@ public @interface HostRolesAllowed {
      *
      * @see HostRoleAop
      */
-    String role();
+    String value();
 
     /** 이벤트 아이디의 식별자. */
     String eventIdIdentifier() default "eventId";

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRolesAllowed.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRolesAllowed.java
@@ -1,0 +1,21 @@
+package band.gosrock.api.common.aop;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HostRolesAllowed {
+    /**
+     * 세가지 값을 가짐 "master","manager","guest" 권한 정보는
+     *
+     * @see HostRoleAop
+     */
+    String value() default "manager";
+
+    /** 이벤트 아이디의 식별자. */
+    String eventIdIdentifier() default "eventId";
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRolesAllowed.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/HostRolesAllowed.java
@@ -6,15 +6,16 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/** HostRoles aop 를 적용하기 위해 다는 어노테이션 - 이찬진 */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface HostRolesAllowed {
     /**
-     * 세가지 값을 가짐 "master","manager","guest" 권한 정보는
+     * 세가지 값을 가짐 "MASTER","MANAGER","GUEST" 권한 정보는
      *
      * @see HostRoleAop
      */
-    String value() default "manager";
+    String role();
 
     /** 이벤트 아이디의 식별자. */
     String eventIdIdentifier() default "eventId";

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/service/UpdateEventDetailUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/service/UpdateEventDetailUseCase.java
@@ -1,7 +1,7 @@
 package band.gosrock.api.event.service;
 
 
-import band.gosrock.api.common.UserUtils;
+import band.gosrock.api.common.aop.HostRolesAllowed;
 import band.gosrock.api.event.model.dto.request.UpdateEventDetailRequest;
 import band.gosrock.api.event.model.dto.response.EventResponse;
 import band.gosrock.api.event.model.mapper.EventMapper;
@@ -9,27 +9,18 @@ import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.event.service.EventService;
-import band.gosrock.domain.domains.host.service.HostService;
-import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
 public class UpdateEventDetailUseCase {
-    private final UserUtils userUtils;
-    private final HostService hostService;
     private final EventService eventService;
     private final EventAdaptor eventAdaptor;
     private final EventMapper eventMapper;
 
-    @Transactional
+    @HostRolesAllowed(role = "MANAGER")
     public EventResponse execute(Long eventId, UpdateEventDetailRequest updateEventDetailRequest) {
-        final User user = userUtils.getCurrentUser();
-        final Long userId = user.getId();
         final Event event = eventAdaptor.findById(eventId);
-        hostService.validateSuperHostUser(event.getHostId(), userId);
-
         return EventResponse.of(
                 eventService.updateEventDetail(
                         event, eventMapper.toEventDetail(updateEventDetailRequest)));

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/service/UpdateEventDetailUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/service/UpdateEventDetailUseCase.java
@@ -10,6 +10,7 @@ import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.event.service.EventService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
@@ -18,6 +19,7 @@ public class UpdateEventDetailUseCase {
     private final EventAdaptor eventAdaptor;
     private final EventMapper eventMapper;
 
+    @Transactional
     @HostRolesAllowed("MANAGER")
     public EventResponse execute(Long eventId, UpdateEventDetailRequest updateEventDetailRequest) {
         final Event event = eventAdaptor.findById(eventId);

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/service/UpdateEventDetailUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/service/UpdateEventDetailUseCase.java
@@ -18,7 +18,7 @@ public class UpdateEventDetailUseCase {
     private final EventAdaptor eventAdaptor;
     private final EventMapper eventMapper;
 
-    @HostRolesAllowed(role = "MANAGER")
+    @HostRolesAllowed("MANAGER")
     public EventResponse execute(Long eventId, UpdateEventDetailRequest updateEventDetailRequest) {
         final Event event = eventAdaptor.findById(eventId);
         return EventResponse.of(

--- a/DuDoong-Common/src/main/java/band/gosrock/common/annotation/Enum.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/annotation/Enum.java
@@ -1,7 +1,7 @@
 package band.gosrock.common.annotation;
 
 
-import band.gosrock.common.annotation.validator.EnumValidator;
+import band.gosrock.common.validator.EnumValidator;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/DuDoong-Common/src/main/java/band/gosrock/common/annotation/Phone.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/annotation/Phone.java
@@ -1,7 +1,7 @@
 package band.gosrock.common.annotation;
 
 
-import band.gosrock.common.annotation.validator.PhoneValidator;
+import band.gosrock.common.validator.PhoneValidator;
 import java.lang.annotation.*;
 import javax.validation.Constraint;
 

--- a/DuDoong-Common/src/main/java/band/gosrock/common/validator/EnumValidator.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/validator/EnumValidator.java
@@ -1,4 +1,4 @@
-package band.gosrock.common.annotation.validator;
+package band.gosrock.common.validator;
 
 
 import band.gosrock.common.annotation.Enum;

--- a/DuDoong-Common/src/main/java/band/gosrock/common/validator/PhoneValidator.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/validator/PhoneValidator.java
@@ -1,4 +1,4 @@
-package band.gosrock.common.annotation.validator;
+package band.gosrock.common.validator;
 
 
 import band.gosrock.common.annotation.Phone;


### PR DESCRIPTION
## 개요
- close #249 

## 작업사항
- 호스트의 권한을 검증할 수 있는 aop 를 개발 했습니다.
- 중복된소스를 줄이고, 명시적으로 선언하는게 눈에도 더 잘보일것 같아서 만들었습니다.

제일 중요한 부분은 아래 부분입니다,
```java
// HostQualification
    MASTER((userId, host) -> host.validateMasterHostUser(userId)),
    MANAGER((userId, host) -> host.validateSuperHostUser(userId)),
    GUEST((userId, host) -> host.validateActiveHostUser(userId));

// biConsumer로 실행시킬 함수 선언
private final BiConsumer<Long, Host> consumer;
```

사용방법
 - before
```java
    @Transactional
    public EventResponse execute(Long eventId, UpdateEventDetailRequest updateEventDetailRequest) {
        final User user = userUtils.getCurrentUser();
        final Long userId = user.getId();
        final Event event = eventAdaptor.findById(eventId);
        hostService.validateSuperHostUser(event.getHostId(), userId);

```
- after
```java
@HostRolesAllowed("MANAGER")
public EventResponse execute(Long eventId, UpdateEventDetailRequest updateEventDetailRequest) {
```
위 세가지 값을 명시적으로 적어주시면 됩니다.

 - 트랜잭션 내부에서 캐시하는 효과를 볼수 있도록
 - HostRoleTransaction 통해서 aop 안에 한 뎁스 더 들어가서 repository에서 값을 불러왔습니다.


## 변경로직
- 내용을 적어주세요.