### PR TITLE
feature : 이벤트 티켓상품 옵션 적용 현황 조회 (어드민용)

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/controller/TicketItemController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/controller/TicketItemController.java
@@ -3,14 +3,8 @@ package band.gosrock.api.ticketItem.controller;
 
 import band.gosrock.api.ticketItem.dto.request.ApplyTicketOptionRequest;
 import band.gosrock.api.ticketItem.dto.request.CreateTicketItemRequest;
-import band.gosrock.api.ticketItem.dto.response.ApplyTicketOptionResponse;
-import band.gosrock.api.ticketItem.dto.response.GetEventTicketItemsResponse;
-import band.gosrock.api.ticketItem.dto.response.GetTicketItemOptionsResponse;
-import band.gosrock.api.ticketItem.dto.response.TicketItemResponse;
-import band.gosrock.api.ticketItem.service.ApplyTicketOptionUseCase;
-import band.gosrock.api.ticketItem.service.CreateTicketItemUseCase;
-import band.gosrock.api.ticketItem.service.GetEventTicketItemsUseCase;
-import band.gosrock.api.ticketItem.service.GetTicketOptionsUseCase;
+import band.gosrock.api.ticketItem.dto.response.*;
+import band.gosrock.api.ticketItem.service.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,6 +23,7 @@ public class TicketItemController {
     public final ApplyTicketOptionUseCase applyTicketOptionUseCase;
     public final GetTicketOptionsUseCase getTicketOptionsUseCase;
     public final GetEventTicketItemsUseCase getEventTicketItemsUseCase;
+    public final GetAppliedOptionGroupsUseCase getAppliedOptionGroupsUseCase;
 
     @Operation(
             summary = "특정 이벤트에 속하는 티켓 상품을 생성합니다.",
@@ -60,5 +55,11 @@ public class TicketItemController {
     public GetTicketItemOptionsResponse getTicketItemOptions(
             @PathVariable Long eventId, @PathVariable Long ticketItemId) {
         return getTicketOptionsUseCase.execute(eventId, ticketItemId);
+    }
+
+    @Operation(summary = "해당 이벤트의 티켓상품 옵션 적용 현황을 모두 조회합니다.")
+    @GetMapping("/appliedOptionGroups")
+    public GetAppliedOptionGroupsResponse getAppliedOptionGroups(@PathVariable Long eventId) {
+        return getAppliedOptionGroupsUseCase.execute(eventId);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/controller/TicketItemController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/controller/TicketItemController.java
@@ -37,7 +37,7 @@ public class TicketItemController {
 
     @Operation(summary = "옵션을 티켓상품에 적용합니다.")
     @PatchMapping("/{ticketItemId}/option")
-    public ApplyTicketOptionResponse applyTicketOption(
+    public GetTicketItemOptionsResponse applyTicketOption(
             @RequestBody @Valid ApplyTicketOptionRequest applyTicketOptionRequest,
             @PathVariable Long eventId,
             @PathVariable Long ticketItemId) {

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/dto/response/AppliedOptionGroupResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/dto/response/AppliedOptionGroupResponse.java
@@ -1,0 +1,32 @@
+package band.gosrock.api.ticketItem.dto.response;
+
+
+import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AppliedOptionGroupResponse {
+
+    @Schema(description = "티켓상품 id")
+    private final Long ticketItemId;
+
+    @Schema(description = "이름")
+    private final String ticketName;
+
+    @Schema(description = "적용된 옵션그룹 리스트")
+    private final List<OptionGroupResponse> optionGroups;
+
+    public static AppliedOptionGroupResponse from(
+            TicketItem ticketItem, List<OptionGroupResponse> optionGroup) {
+
+        return AppliedOptionGroupResponse.builder()
+                .ticketItemId(ticketItem.getId())
+                .ticketName(ticketItem.getName())
+                .optionGroups(optionGroup)
+                .build();
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/dto/response/GetAppliedOptionGroupsResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/dto/response/GetAppliedOptionGroupsResponse.java
@@ -1,0 +1,23 @@
+package band.gosrock.api.ticketItem.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetAppliedOptionGroupsResponse {
+
+    @Schema(description = "적용 현황 리스트")
+    private List<AppliedOptionGroupResponse> appliedOptionGroups;
+
+    public static GetAppliedOptionGroupsResponse from(
+            List<AppliedOptionGroupResponse> appliedOptionGroups) {
+
+        return GetAppliedOptionGroupsResponse.builder()
+                .appliedOptionGroups(appliedOptionGroups)
+                .build();
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/mapper/TicketItemMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/mapper/TicketItemMapper.java
@@ -2,14 +2,15 @@ package band.gosrock.api.ticketItem.mapper;
 
 
 import band.gosrock.api.ticketItem.dto.request.CreateTicketItemRequest;
-import band.gosrock.api.ticketItem.dto.response.GetEventTicketItemsResponse;
-import band.gosrock.api.ticketItem.dto.response.TicketItemResponse;
+import band.gosrock.api.ticketItem.dto.response.*;
 import band.gosrock.common.annotation.Mapper;
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.ticket_item.adaptor.TicketItemAdaptor;
+import band.gosrock.domain.domains.ticket_item.domain.ItemOptionGroup;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,5 +44,25 @@ public class TicketItemMapper {
         List<TicketItem> ticketItems = ticketItemAdaptor.findAllByEventId(event.getId());
         return GetEventTicketItemsResponse.from(
                 ticketItems.stream().map(TicketItemResponse::from).toList());
+    }
+
+    @Transactional(readOnly = true)
+    public GetAppliedOptionGroupsResponse toGetAppliedOptionGroupsResponse(Long eventId) {
+
+        Event event = eventAdaptor.findById(eventId);
+        List<TicketItem> ticketItems = ticketItemAdaptor.findAllByEventId(event.getId());
+        List<AppliedOptionGroupResponse> appliedOptionGroups = new ArrayList<>();
+        ticketItems.forEach(
+                ticketItem ->
+                        appliedOptionGroups.add(
+                                AppliedOptionGroupResponse.from(
+                                        ticketItem,
+                                        ticketItem.getItemOptionGroups().stream()
+                                                .map(ItemOptionGroup::getOptionGroup)
+                                                .toList()
+                                                .stream()
+                                                .map(OptionGroupResponse::from)
+                                                .toList())));
+        return GetAppliedOptionGroupsResponse.from(appliedOptionGroups);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/ApplyTicketOptionUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/ApplyTicketOptionUseCase.java
@@ -3,7 +3,8 @@ package band.gosrock.api.ticketItem.service;
 
 import band.gosrock.api.common.UserUtils;
 import band.gosrock.api.ticketItem.dto.request.ApplyTicketOptionRequest;
-import band.gosrock.api.ticketItem.dto.response.ApplyTicketOptionResponse;
+import band.gosrock.api.ticketItem.dto.response.GetTicketItemOptionsResponse;
+import band.gosrock.api.ticketItem.mapper.TicketOptionMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.Event;
@@ -14,6 +15,7 @@ import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
 import band.gosrock.domain.domains.ticket_item.service.ItemOptionGroupService;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
@@ -24,8 +26,10 @@ public class ApplyTicketOptionUseCase {
     private final HostAdaptor hostAdaptor;
     private final ItemOptionGroupService itemOptionGroupService;
     private final HostService hostService;
+    private final TicketOptionMapper ticketOptionMapper;
 
-    public ApplyTicketOptionResponse execute(
+    @Transactional
+    public GetTicketItemOptionsResponse execute(
             ApplyTicketOptionRequest applyTicketOptionRequest, Long eventId, Long ticketItemId) {
         User user = userUtils.getCurrentUser();
         Event event = eventAdaptor.findById(eventId);
@@ -37,6 +41,7 @@ public class ApplyTicketOptionUseCase {
 
         TicketItem ticketItem =
                 itemOptionGroupService.addItemOptionGroup(ticketItemId, optionGroupId, eventId);
-        return ApplyTicketOptionResponse.from(ticketItem);
+
+        return ticketOptionMapper.toGetTicketItemOptionResponse(eventId, ticketItem.getId());
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/GetAppliedOptionGroupsUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/GetAppliedOptionGroupsUseCase.java
@@ -1,0 +1,19 @@
+package band.gosrock.api.ticketItem.service;
+
+
+import band.gosrock.api.ticketItem.dto.response.GetAppliedOptionGroupsResponse;
+import band.gosrock.api.ticketItem.mapper.TicketItemMapper;
+import band.gosrock.common.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetAppliedOptionGroupsUseCase {
+
+    private final TicketItemMapper ticketItemMapper;
+
+    public GetAppliedOptionGroupsResponse execute(Long eventId) {
+
+        return ticketItemMapper.toGetAppliedOptionGroupsResponse(eventId);
+    }
+}


### PR DESCRIPTION
## 개요
- close #242 

## 작업사항
- 어드민 화면에서 옵션 적용 페이지 내 쓰일 옵션 적용 현황 조회 API 입니다.
```java
"appliedOptionGroups": [
      {
        "ticketItemId": 1,
        "ticketName": "일반 티켓",
        "optionGroups": [
          {
            "optionGroupId": 1,
            "type": "Y/N",
            "name": "뒷풀이 참여 여부",
            "description": "공연이 끝난 후 오케이포차에서 진행하는 뒷풀이에 참여할 것인가요?",
            "options": [
              {
                "optionId": 1,
                "answer": "YES",
                "additionalPrice": "10000원"
              },
              {
                "optionId": 2,
                "answer": "NO",
                "additionalPrice": "0원"
              }
            ]
          },
          {
            "optionGroupId": 3,
            "type": "주관식",
            "name": "추천인이 누구인가요?",
            "description": "추천인 이름을 한명만 적어주세요",
            "options": [
              {
                "optionId": 5,
                "answer": "",
                "additionalPrice": "0원"
              }
            ]
          }
        ]
      },
      {
        "ticketItemId": 2,
        "ticketName": "특별 티켓",
        "optionGroups": []
      }
    ]
```

## 변경로직
- 옵션 적용시 해당 티켓상품에 적용된 총 옵션을 보여주는 것으로  ៖답값 수정