### PR TITLE
refactor : host role Host 용 생성, 어노테이션 필드 리팩토링

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/FindHostFrom.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/FindHostFrom.java
@@ -1,0 +1,16 @@
+package band.gosrock.api.common.aop.hostRole;
+
+
+import lombok.Getter;
+
+@Getter
+public enum FindHostFrom {
+    HOST_ID("hostId"),
+    EVENT_ID("eventId");
+
+    private final String identifier;
+
+    FindHostFrom(String identifier) {
+        this.identifier = identifier;
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostCallTransactionFactory.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostCallTransactionFactory.java
@@ -1,0 +1,20 @@
+package band.gosrock.api.common.aop.hostRole;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class HostCallTransactionFactory {
+
+    private final HostRoleEventTransaction hostRoleEventTransaction;
+    private final HostRoleHostTransaction hostRoleHostTransaction;
+
+    public HostRoleCallTransaction getCallTransaction(FindHostFrom findHostFrom) {
+        if (findHostFrom == FindHostFrom.HOST_ID) {
+            return hostRoleHostTransaction;
+        }
+        return hostRoleEventTransaction;
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostQualification.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostQualification.java
@@ -1,4 +1,4 @@
-package band.gosrock.api.common.aop;
+package band.gosrock.api.common.aop.hostRole;
 
 
 import band.gosrock.domain.domains.host.domain.Host;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleAop.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleAop.java
@@ -35,7 +35,7 @@ public class HostRoleAop {
         HostQualification hostQualification = annotation.role();
         // 제공된 호스트의 role 이 정의된 세개의 롤과 같은지 확인한다.
         // 없으면 IllegalArgumentException 발생
-        FindHostFrom findHostFrom = annotation.findhostFrom();
+        FindHostFrom findHostFrom = annotation.findHostFrom();
         String identifier = findHostFrom.getIdentifier();
 
         String[] parameterNames = signature.getParameterNames();

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleAop.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleAop.java
@@ -1,4 +1,4 @@
-package band.gosrock.api.common.aop;
+package band.gosrock.api.common.aop.hostRole;
 
 
 import java.lang.reflect.Method;
@@ -20,34 +20,35 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @ConditionalOnExpression("${ableHostRoleAop:true}")
 public class HostRoleAop {
-    private final HostRoleTransaction hostRoleTransaction;
+    private final HostCallTransactionFactory hostCallTransactionFactory;
 
     /**
      * master 호스트의 마스터 manager 호스트의 수정,조회 ( 호스트유저도메인의 슈퍼 호스트 ) guest 호스트의 조회권한 (호스트유저도메인의 호스트 )
      *
      * @see band.gosrock.domain.domains.host.domain.HostRole
      */
-    @Around("@annotation(band.gosrock.api.common.aop.HostRolesAllowed)")
+    @Around("@annotation(band.gosrock.api.common.aop.hostRole.HostRolesAllowed)")
     public Object aop(final ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
         HostRolesAllowed annotation = method.getAnnotation(HostRolesAllowed.class);
-        String role = annotation.value();
-
+        HostQualification hostQualification = annotation.role();
         // 제공된 호스트의 role 이 정의된 세개의 롤과 같은지 확인한다.
         // 없으면 IllegalArgumentException 발생
-        HostQualification hostQualification = HostQualification.valueOf(role);
+        FindHostFrom findHostFrom = annotation.findhostFrom();
+        String identifier = findHostFrom.getIdentifier();
 
-        String identifier = annotation.eventIdIdentifier();
         String[] parameterNames = signature.getParameterNames();
         Object[] args = joinPoint.getArgs();
-        // 이벤트 아이디를 인자에서 얻어온다.
-        Long eventId = getEventId(parameterNames, args, identifier);
 
-        return hostRoleTransaction.proceed(eventId, hostQualification, joinPoint);
+        Long id = getId(parameterNames, args, identifier);
+
+        return hostCallTransactionFactory
+                .getCallTransaction(findHostFrom)
+                .proceed(id, hostQualification, joinPoint);
     }
 
-    public Long getEventId(String[] parameterNames, Object[] args, String paramName) {
+    public Long getId(String[] parameterNames, Object[] args, String paramName) {
         for (int i = 0; i < parameterNames.length; i++) {
             if (parameterNames[i].equals(paramName)) {
                 // 롱타입이라 가정. 안되면 classCastException 터트림

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleCallTransaction.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleCallTransaction.java
@@ -1,0 +1,9 @@
+package band.gosrock.api.common.aop.hostRole;
+
+
+import org.aspectj.lang.ProceedingJoinPoint;
+
+public interface HostRoleCallTransaction {
+    Object proceed(Long id, HostQualification role, final ProceedingJoinPoint joinPoint)
+            throws Throwable;
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleEventTransaction.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleEventTransaction.java
@@ -1,4 +1,4 @@
-package band.gosrock.api.common.aop;
+package band.gosrock.api.common.aop.hostRole;
 
 
 import band.gosrock.api.common.UserUtils;
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class HostRoleTransaction {
+public class HostRoleEventTransaction implements HostRoleCallTransaction {
 
     private final UserUtils userUtils;
     private final EventAdaptor eventAdaptor;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleHostTransaction.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleHostTransaction.java
@@ -1,0 +1,30 @@
+package band.gosrock.api.common.aop.hostRole;
+
+
+import band.gosrock.api.common.UserUtils;
+import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
+import band.gosrock.domain.domains.host.domain.Host;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 호스트 정보를 트랜잭션 안에서 조회하기 위해서 만든 클래스입니다. 트랜잭션 내에서 캐시 할수 있으면 좋으니 이렇게 만들었습니다. - 이찬진 */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class HostRoleHostTransaction implements HostRoleCallTransaction {
+
+    private final UserUtils userUtils;
+    private final HostAdaptor hostAdaptor;
+
+    @Transactional(readOnly = true)
+    public Object proceed(Long hostId, HostQualification role, final ProceedingJoinPoint joinPoint)
+            throws Throwable {
+        Long currentUserId = userUtils.getCurrentUserId();
+        Host host = hostAdaptor.findById(hostId);
+        role.validQualification(currentUserId, host);
+        return joinPoint.proceed();
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRolesAllowed.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRolesAllowed.java
@@ -1,4 +1,4 @@
-package band.gosrock.api.common.aop;
+package band.gosrock.api.common.aop.hostRole;
 
 
 import java.lang.annotation.ElementType;
@@ -15,8 +15,7 @@ public @interface HostRolesAllowed {
      *
      * @see HostRoleAop
      */
-    String value();
+    HostQualification role();
 
-    /** 이벤트 아이디의 식별자. */
-    String eventIdIdentifier() default "eventId";
+    FindHostFrom findhostFrom();
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRolesAllowed.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRolesAllowed.java
@@ -17,5 +17,5 @@ public @interface HostRolesAllowed {
      */
     HostQualification role();
 
-    FindHostFrom findhostFrom();
+    FindHostFrom findHostFrom();
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/service/UpdateEventDetailUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/service/UpdateEventDetailUseCase.java
@@ -22,7 +22,7 @@ public class UpdateEventDetailUseCase {
     private final EventMapper eventMapper;
 
     @Transactional
-    @HostRolesAllowed(role = MANAGER, findhostFrom = EVENT_ID)
+    @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID)
     public EventResponse execute(Long eventId, UpdateEventDetailRequest updateEventDetailRequest) {
         final Event event = eventAdaptor.findById(eventId);
         return EventResponse.of(

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/service/UpdateEventDetailUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/service/UpdateEventDetailUseCase.java
@@ -1,7 +1,9 @@
 package band.gosrock.api.event.service;
 
+import static band.gosrock.api.common.aop.hostRole.FindHostFrom.EVENT_ID;
+import static band.gosrock.api.common.aop.hostRole.HostQualification.MANAGER;
 
-import band.gosrock.api.common.aop.HostRolesAllowed;
+import band.gosrock.api.common.aop.hostRole.HostRolesAllowed;
 import band.gosrock.api.event.model.dto.request.UpdateEventDetailRequest;
 import band.gosrock.api.event.model.dto.response.EventResponse;
 import band.gosrock.api.event.model.mapper.EventMapper;
@@ -20,7 +22,7 @@ public class UpdateEventDetailUseCase {
     private final EventMapper eventMapper;
 
     @Transactional
-    @HostRolesAllowed("MANAGER")
+    @HostRolesAllowed(role = MANAGER, findhostFrom = EVENT_ID)
     public EventResponse execute(Long eventId, UpdateEventDetailRequest updateEventDetailRequest) {
         final Event event = eventAdaptor.findById(eventId);
         return EventResponse.of(

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
@@ -1,7 +1,9 @@
 package band.gosrock.api.host.service;
 
+import static band.gosrock.api.common.aop.hostRole.FindHostFrom.HOST_ID;
+import static band.gosrock.api.common.aop.hostRole.HostQualification.MANAGER;
 
-import band.gosrock.api.common.UserUtils;
+import band.gosrock.api.common.aop.hostRole.HostRolesAllowed;
 import band.gosrock.api.host.model.dto.request.UpdateHostSlackRequest;
 import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.api.host.model.mapper.HostMapper;
@@ -9,28 +11,21 @@ import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.host.service.HostService;
-import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
 public class UpdateHostSlackUrlUseCase {
-    private final UserUtils userUtils;
     private final HostService hostService;
     private final HostAdaptor hostAdaptor;
     private final HostMapper hostMapper;
 
     @Transactional
+    @HostRolesAllowed(role = MANAGER, findhostFrom = HOST_ID)
     public HostDetailResponse execute(Long hostId, UpdateHostSlackRequest updateHostSlackRequest) {
-        // 존재하는 유저인지 검증
-        final User user = userUtils.getCurrentUser();
-        final Long userId = user.getId();
-
         final Host host = hostAdaptor.findById(hostId);
         final String slackUrl = updateHostSlackRequest.getSlackUrl();
-        // 슈퍼 호스트 검증
-        host.validateSuperHostUser(userId);
         return hostMapper.toHostDetailResponse(hostService.updateHostSlackUrl(host, slackUrl));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
@@ -22,7 +22,7 @@ public class UpdateHostSlackUrlUseCase {
     private final HostMapper hostMapper;
 
     @Transactional
-    @HostRolesAllowed(role = MANAGER, findhostFrom = HOST_ID)
+    @HostRolesAllowed(role = MANAGER, findHostFrom = HOST_ID)
     public HostDetailResponse execute(Long hostId, UpdateHostSlackRequest updateHostSlackRequest) {
         final Host host = hostAdaptor.findById(hostId);
         final String slackUrl = updateHostSlackRequest.getSlackUrl();


### PR DESCRIPTION
## 개요
이전 작업사항 
- https://github.com/Gosrock/DuDoong-Backend/pull/256
관련 이슈
- close #254 

## 작업사항
- hostId 로도 찾아올수 있게끔 만들었습니다.
- 캐시가 되니깐 밑에서 뭐 호스트랑 이벤트 불러와도 디비 안거칩니다!


## 변경로직
- 사용 방법이 좀 변했습니다
- 보니깐 이넘값도 어노테이션으로 넘겨줄수 있더라고요
그래서 스트링에서 받던걸 이넘으로 넘겼습니다.

HostQualification 이랑 FindHostFrom  입니당

```java
// 이벤트 용
 @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID)
    public EventResponse execute(Long eventId, UpdateEventDetailRequest updateEventDetailRequest) {
// 호스트 용
  @HostRolesAllowed(role = MANAGER, findHostFrom = HOST_ID)
    public HostDetailResponse execute(Long hostId, UpdateHostSlackRequest updateHostSlackRequest)
```