### PR TITLE
feat : image url 발급 api 추가

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/config/converter/GenderEnumConverter.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/config/converter/GenderEnumConverter.java
@@ -1,0 +1,9 @@
+package band.gosrock.api.config.converter;
+
+// @Component
+// class FilEnumConverter implements Converter<String, ImageFileExtension> {
+////    @Override
+////    public ImageFileExtension convert(String value) {
+////        return ImageFileExtension.convert(value);
+////    }
+// }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/config/converter/GenderEnumConverter.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/config/converter/GenderEnumConverter.java
@@ -1,9 +1,0 @@
-package band.gosrock.api.config.converter;
-
-// @Component
-// class FilEnumConverter implements Converter<String, ImageFileExtension> {
-////    @Override
-////    public ImageFileExtension convert(String value) {
-////        return ImageFileExtension.convert(value);
-////    }
-// }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/model/dto/request/UpdateEventDetailRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/model/dto/request/UpdateEventDetailRequest.java
@@ -21,7 +21,7 @@ public class UpdateEventDetailRequest {
     @NotEmpty
     private String posterImageKey;
 
-    //TODO : 기획에서 제거 예정?
+    // TODO : 기획에서 제거 예정?
     @ArraySchema(
             arraySchema =
                     @Schema(

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/model/dto/request/UpdateEventDetailRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/model/dto/request/UpdateEventDetailRequest.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.Getter;
@@ -16,10 +17,11 @@ import org.hibernate.validator.constraints.URL;
 public class UpdateEventDetailRequest {
 
     // 포스터 이미지 url
-    @Schema(defaultValue = "https://s3.dudoong.com/image", description = "포스터 이미지 url")
-    @URL(message = "올바른 url 형식을 입력하세요")
-    private String posterImage;
+    @Schema(defaultValue = "test/event/5/aa.jpeg", description = "포스터 이미지 key")
+    @NotEmpty
+    private String posterImageKey;
 
+    //TODO : 기획에서 제거 예정?
     @ArraySchema(
             arraySchema =
                     @Schema(

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
@@ -8,6 +8,7 @@ import band.gosrock.api.event.model.dto.response.EventChecklistResponse;
 import band.gosrock.api.event.model.dto.response.EventDetailResponse;
 import band.gosrock.api.event.model.dto.response.EventProfileResponse;
 import band.gosrock.common.annotation.Mapper;
+import band.gosrock.domain.common.vo.ImageVo;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.event.domain.EventBasic;
@@ -50,7 +51,7 @@ public class EventMapper {
 
     public EventDetail toEventDetail(UpdateEventDetailRequest updateEventDetailRequest) {
         return EventDetail.builder()
-                .posterImage(updateEventDetailRequest.getPosterImage())
+                .posterImageKey(updateEventDetailRequest.getPosterImageKey())
                 .detailImages(updateEventDetailRequest.getDetailImages())
                 .content(updateEventDetailRequest.getContent())
                 .build();

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
@@ -8,7 +8,6 @@ import band.gosrock.api.event.model.dto.response.EventChecklistResponse;
 import band.gosrock.api.event.model.dto.response.EventDetailResponse;
 import band.gosrock.api.event.model.dto.response.EventProfileResponse;
 import band.gosrock.common.annotation.Mapper;
-import band.gosrock.domain.common.vo.ImageVo;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.event.domain.EventBasic;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostRequest.java
@@ -8,7 +8,6 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.validator.constraints.URL;
 
 /** 호스트 정보 변경 요청 DTO */
 @Getter

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostRequest.java
@@ -4,6 +4,7 @@ package band.gosrock.api.host.model.dto.request;
 import band.gosrock.common.annotation.Phone;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -13,9 +14,9 @@ import org.hibernate.validator.constraints.URL;
 @Getter
 @RequiredArgsConstructor
 public class UpdateHostRequest {
-    @Schema(defaultValue = "https://s3.dudoong.com/img", description = "호스트 프로필 이미지")
-    @URL(message = "올바른 형식의 URL 을 입력해주세요")
-    private String profileImageUrl;
+    @Schema(defaultValue = "test/host/5/aa.jpg", description = "호스트 프로필 이미지")
+    @NotEmpty
+    private String profileImageKey;
 
     @Schema(defaultValue = "고슬고슬고스락", description = "호스트 간단 소개")
     @NotNull(message = "간단 소개를 입력해주세요")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/HostProfileResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/HostProfileResponse.java
@@ -1,6 +1,7 @@
 package band.gosrock.api.host.model.dto.response;
 
 
+import band.gosrock.domain.common.vo.ImageVo;
 import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.host.domain.HostRole;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -21,7 +22,7 @@ public class HostProfileResponse {
     private final String introduce;
 
     @Schema(description = "호스트 프로필 이미지")
-    private final String profileImageUrl;
+    private final ImageVo profileImageUrl;
 
     @Schema(description = "속한 호스트에서의 역할")
     private HostRole role;
@@ -34,7 +35,7 @@ public class HostProfileResponse {
                 .hostId(host.getId())
                 .name(host.getProfile().getName())
                 .introduce(host.getProfile().getIntroduce())
-                .profileImageUrl(host.getProfile().getProfileImageUrl())
+                .profileImageUrl(host.getProfile().getProfileImage())
                 .role(host.getHostUserByUserId(userId).getRole())
                 .isMaster(host.getMasterUserId().equals(userId))
                 .build();

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
@@ -40,7 +40,7 @@ public class HostMapper {
     public HostProfile toHostProfile(UpdateHostRequest updateHostRequest) {
         return HostProfile.builder()
                 .introduce(updateHostRequest.getIntroduce())
-                .profileImageUrl(updateHostRequest.getProfileImageUrl())
+                .profileImageKey(updateHostRequest.getProfileImageKey())
                 .contactEmail(updateHostRequest.getContactEmail())
                 .contactNumber(updateHostRequest.getContactNumber())
                 .build();

--- a/DuDoong-Api/src/main/java/band/gosrock/api/image/controller/ImageController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/image/controller/ImageController.java
@@ -1,0 +1,37 @@
+package band.gosrock.api.image.controller;
+
+
+import band.gosrock.api.image.dto.ImageUrlResponse;
+import band.gosrock.api.image.service.GetImageUploadUrlUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SecurityRequirement(name = "access-token")
+@Tag(name = "이미지 관련 컨트롤러")
+@RestController
+@RequestMapping("/v1")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final GetImageUploadUrlUseCase getImageUploadUrlUseCase;
+
+    @Operation(summary = "이벤트 관련 이미지 업로드 url 요청할수 있는 api 입니다.")
+    @PostMapping(value = "/events/{eventId}/images")
+    public ImageUrlResponse getIssuedTickets(
+            @PathVariable Long eventId) {
+        return getImageUploadUrlUseCase.forEvent(eventId);
+    }
+
+    @Operation(summary = "호스트 관련 이미지 업로드 url 요청할수 있는 api 입니다.")
+    @PostMapping(value = "/hosts/{hostId}/images")
+    public ImageUrlResponse patchIssuedTicketStatus(
+            @PathVariable Long hostId) {
+        return getImageUploadUrlUseCase.forHost(hostId);
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/image/controller/ImageController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/image/controller/ImageController.java
@@ -23,15 +23,13 @@ public class ImageController {
 
     @Operation(summary = "이벤트 관련 이미지 업로드 url 요청할수 있는 api 입니다.")
     @PostMapping(value = "/events/{eventId}/images")
-    public ImageUrlResponse getIssuedTickets(
-            @PathVariable Long eventId) {
+    public ImageUrlResponse getIssuedTickets(@PathVariable Long eventId) {
         return getImageUploadUrlUseCase.forEvent(eventId);
     }
 
     @Operation(summary = "호스트 관련 이미지 업로드 url 요청할수 있는 api 입니다.")
     @PostMapping(value = "/hosts/{hostId}/images")
-    public ImageUrlResponse patchIssuedTicketStatus(
-            @PathVariable Long hostId) {
+    public ImageUrlResponse patchIssuedTicketStatus(@PathVariable Long hostId) {
         return getImageUploadUrlUseCase.forHost(hostId);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/image/controller/ImageController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/image/controller/ImageController.java
@@ -3,6 +3,7 @@ package band.gosrock.api.image.controller;
 
 import band.gosrock.api.image.dto.ImageUrlResponse;
 import band.gosrock.api.image.service.GetImageUploadUrlUseCase;
+import band.gosrock.infrastructure.config.s3.ImageFileExtension;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @SecurityRequirement(name = "access-token")
@@ -23,13 +25,15 @@ public class ImageController {
 
     @Operation(summary = "이벤트 관련 이미지 업로드 url 요청할수 있는 api 입니다.")
     @PostMapping(value = "/events/{eventId}/images")
-    public ImageUrlResponse getIssuedTickets(@PathVariable Long eventId) {
-        return getImageUploadUrlUseCase.forEvent(eventId);
+    public ImageUrlResponse getIssuedTickets(
+            @PathVariable Long eventId, @RequestParam ImageFileExtension imageFileExtension) {
+        return getImageUploadUrlUseCase.forEvent(eventId, imageFileExtension);
     }
 
     @Operation(summary = "호스트 관련 이미지 업로드 url 요청할수 있는 api 입니다.")
     @PostMapping(value = "/hosts/{hostId}/images")
-    public ImageUrlResponse patchIssuedTicketStatus(@PathVariable Long hostId) {
-        return getImageUploadUrlUseCase.forHost(hostId);
+    public ImageUrlResponse patchIssuedTicketStatus(
+            @PathVariable Long hostId, @RequestParam ImageFileExtension imageFileExtension) {
+        return getImageUploadUrlUseCase.forHost(hostId, imageFileExtension);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/image/dto/ImageUrlRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/image/dto/ImageUrlRequest.java
@@ -1,0 +1,14 @@
+package band.gosrock.api.image.dto;
+
+
+import band.gosrock.common.annotation.Enum;
+import band.gosrock.infrastructure.config.s3.ImageFileExtension;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImageUrlRequest {
+
+    @Enum private ImageFileExtension imageFileExtension;
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/image/dto/ImageUrlResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/image/dto/ImageUrlResponse.java
@@ -12,8 +12,13 @@ public class ImageUrlResponse {
 
     private final String presignedUrl;
     private final String key;
+    private final ImageVo url;
 
-    public static ImageUrlResponse from(ImageUrlDto urlDto){
-        return ImageUrlResponse.builder().presignedUrl(urlDto.getUrl()).key(urlDto.getKey()).build();
+    public static ImageUrlResponse from(ImageUrlDto urlDto) {
+        return ImageUrlResponse.builder()
+                .presignedUrl(urlDto.getUrl())
+                .key(urlDto.getKey())
+                .url(ImageVo.valueOf(urlDto.getKey()))
+                .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/image/dto/ImageUrlResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/image/dto/ImageUrlResponse.java
@@ -1,0 +1,19 @@
+package band.gosrock.api.image.dto;
+
+
+import band.gosrock.domain.common.vo.ImageVo;
+import band.gosrock.infrastructure.config.s3.ImageUrlDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ImageUrlResponse {
+
+    private final String presignedUrl;
+    private final String key;
+
+    public static ImageUrlResponse from(ImageUrlDto urlDto){
+        return ImageUrlResponse.builder().presignedUrl(urlDto.getUrl()).key(urlDto.getKey()).build();
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/image/service/GetImageUploadUrlUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/image/service/GetImageUploadUrlUseCase.java
@@ -7,6 +7,7 @@ import static band.gosrock.api.common.aop.hostRole.HostQualification.MANAGER;
 import band.gosrock.api.common.aop.hostRole.HostRolesAllowed;
 import band.gosrock.api.image.dto.ImageUrlResponse;
 import band.gosrock.common.annotation.UseCase;
+import band.gosrock.infrastructure.config.s3.ImageFileExtension;
 import band.gosrock.infrastructure.config.s3.S3UploadPresignedUrlService;
 import lombok.RequiredArgsConstructor;
 
@@ -17,14 +18,14 @@ public class GetImageUploadUrlUseCase {
     private final S3UploadPresignedUrlService presignedUrlService;
 
     @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID)
-    public ImageUrlResponse forEvent(Long eventId) {
+    public ImageUrlResponse forEvent(Long eventId, ImageFileExtension imageFileExtension) {
 
-        return ImageUrlResponse.from(presignedUrlService.forEvent(eventId, "jpeg"));
+        return ImageUrlResponse.from(presignedUrlService.forEvent(eventId, imageFileExtension));
     }
 
     @HostRolesAllowed(role = MANAGER, findHostFrom = HOST_ID)
-    public ImageUrlResponse forHost(Long hostId) {
+    public ImageUrlResponse forHost(Long hostId, ImageFileExtension imageFileExtension) {
 
-        return ImageUrlResponse.from(presignedUrlService.forEvent(hostId, "jpeg"));
+        return ImageUrlResponse.from(presignedUrlService.forHost(hostId, imageFileExtension));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/image/service/GetImageUploadUrlUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/image/service/GetImageUploadUrlUseCase.java
@@ -7,8 +7,6 @@ import static band.gosrock.api.common.aop.hostRole.HostQualification.MANAGER;
 import band.gosrock.api.common.aop.hostRole.HostRolesAllowed;
 import band.gosrock.api.image.dto.ImageUrlResponse;
 import band.gosrock.common.annotation.UseCase;
-import band.gosrock.domain.common.vo.ImageVo;
-import band.gosrock.infrastructure.config.s3.ImageUrlDto;
 import band.gosrock.infrastructure.config.s3.S3UploadPresignedUrlService;
 import lombok.RequiredArgsConstructor;
 
@@ -18,13 +16,13 @@ public class GetImageUploadUrlUseCase {
 
     private final S3UploadPresignedUrlService presignedUrlService;
 
-    @HostRolesAllowed(role = MANAGER,findHostFrom = EVENT_ID)
+    @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID)
     public ImageUrlResponse forEvent(Long eventId) {
 
         return ImageUrlResponse.from(presignedUrlService.forEvent(eventId, "jpeg"));
     }
 
-    @HostRolesAllowed(role = MANAGER,findHostFrom = HOST_ID)
+    @HostRolesAllowed(role = MANAGER, findHostFrom = HOST_ID)
     public ImageUrlResponse forHost(Long hostId) {
 
         return ImageUrlResponse.from(presignedUrlService.forEvent(hostId, "jpeg"));

--- a/DuDoong-Api/src/main/java/band/gosrock/api/image/service/GetImageUploadUrlUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/image/service/GetImageUploadUrlUseCase.java
@@ -1,0 +1,32 @@
+package band.gosrock.api.image.service;
+
+import static band.gosrock.api.common.aop.hostRole.FindHostFrom.EVENT_ID;
+import static band.gosrock.api.common.aop.hostRole.FindHostFrom.HOST_ID;
+import static band.gosrock.api.common.aop.hostRole.HostQualification.MANAGER;
+
+import band.gosrock.api.common.aop.hostRole.HostRolesAllowed;
+import band.gosrock.api.image.dto.ImageUrlResponse;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.common.vo.ImageVo;
+import band.gosrock.infrastructure.config.s3.ImageUrlDto;
+import band.gosrock.infrastructure.config.s3.S3UploadPresignedUrlService;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetImageUploadUrlUseCase {
+
+    private final S3UploadPresignedUrlService presignedUrlService;
+
+    @HostRolesAllowed(role = MANAGER,findHostFrom = EVENT_ID)
+    public ImageUrlResponse forEvent(Long eventId) {
+
+        return ImageUrlResponse.from(presignedUrlService.forEvent(eventId, "jpeg"));
+    }
+
+    @HostRolesAllowed(role = MANAGER,findHostFrom = HOST_ID)
+    public ImageUrlResponse forHost(Long hostId) {
+
+        return ImageUrlResponse.from(presignedUrlService.forEvent(hostId, "jpeg"));
+    }
+}

--- a/DuDoong-Common/src/main/java/band/gosrock/common/consts/DuDoongStatic.java
+++ b/DuDoong-Common/src/main/java/band/gosrock/common/consts/DuDoongStatic.java
@@ -23,6 +23,8 @@ public class DuDoongStatic {
     public static final Long MINIMUM_PAYMENT_WON = 1000L;
     public static final Long ZERO = 0L;
 
+    public static final String assetDomain = "https://asset.dudoong.com/";
+
     public static final String KAKAO_OAUTH_QUERY_STRING =
             "/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code";
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/dto/ProfileViewDto.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/dto/ProfileViewDto.java
@@ -1,6 +1,7 @@
 package band.gosrock.domain.common.dto;
 
 
+import band.gosrock.domain.common.vo.ImageVo;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,12 +9,12 @@ import lombok.Getter;
 @Getter
 public class ProfileViewDto {
     private final Long id;
-    private final String profileImage;
+    private final ImageVo profileImage;
     private final String name;
 
     @Builder
     public ProfileViewDto(
-            Long id, String email, String phoneNumber, String profileImage, String name) {
+            Long id, String email, String phoneNumber, ImageVo profileImage, String name) {
         this.id = id;
         this.profileImage = profileImage;
         this.name = name;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/EventDetailVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/EventDetailVo.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 @Builder
 public class EventDetailVo {
     // 포스터 이미지
-    private String posterImage;
+    private ImageVo posterImage;
 
     // todo :: 디테일 이미지를 EventDetailImage 로 받기
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/EventProfileVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/EventProfileVo.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 public class EventProfileVo {
     private Long eventId;
 
-    private String posterImage;
+    private ImageVo posterImage;
 
     private String name;
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostInfoVo.java
@@ -14,7 +14,7 @@ public class HostInfoVo {
 
     private final String introduce;
 
-    private final String profileImageUrl;
+    private final ImageVo profileImageUrl;
 
     private final String contactEmail;
 
@@ -27,7 +27,7 @@ public class HostInfoVo {
                 .hostId(host.getId())
                 .name(host.getProfile().getName())
                 .introduce(host.getProfile().getIntroduce())
-                .profileImageUrl(host.getProfile().getProfileImageUrl())
+                .profileImageUrl(host.getProfile().getProfileImage())
                 .contactEmail(host.getProfile().getContactEmail())
                 .contactNumber(host.getProfile().getContactNumber())
                 .build();

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/ImageVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/ImageVo.java
@@ -4,17 +4,34 @@ import static band.gosrock.common.consts.DuDoongStatic.assetDomain;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import javax.persistence.Embeddable;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
 public class ImageVo {
 
-    private String key;
+    private String imageKey;
 
     @JsonValue
     public String url(){
-        return assetDomain + key;
+        if(imageKey == null){
+            return null;
+        }
+        if(imageKey.contains("kakao")){
+            return imageKey;
+        }
+        return assetDomain + imageKey;
     }
+
+    public ImageVo(String key) {
+        this.imageKey = key;
+    }
+
+    public static ImageVo valueOf(String key){
+        return new ImageVo(key);
+    };
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/ImageVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/ImageVo.java
@@ -5,7 +5,6 @@ import static band.gosrock.common.consts.DuDoongStatic.assetDomain;
 import com.fasterxml.jackson.annotation.JsonValue;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,13 +16,16 @@ public class ImageVo {
     private String imageKey;
 
     @JsonValue
-    public String url(){
-        if(imageKey == null){
+    public String generateImageUrl() {
+        // imageKey 널값 대응
+        if (imageKey == null) {
             return null;
         }
-        if(imageKey.contains("kakao")){
+        // 카카오 이미지로 회원가입한경우 대응
+        if (imageKey.contains("kakao")) {
             return imageKey;
         }
+        // 현재 도메인 대응
         return assetDomain + imageKey;
     }
 
@@ -31,7 +33,7 @@ public class ImageVo {
         this.imageKey = key;
     }
 
-    public static ImageVo valueOf(String key){
+    public static ImageVo valueOf(String key) {
         return new ImageVo(key);
-    };
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/ImageVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/ImageVo.java
@@ -1,0 +1,20 @@
+package band.gosrock.domain.common.vo;
+
+import static band.gosrock.common.consts.DuDoongStatic.assetDomain;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import javax.persistence.Embeddable;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Embeddable
+public class ImageVo {
+
+    private String key;
+
+    @JsonValue
+    public String url(){
+        return assetDomain + key;
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserInfoVo.java
@@ -17,7 +17,7 @@ public class UserInfoVo {
 
     private final String phoneNumber;
 
-    private final String profileImage;
+    private final ImageVo profileImage;
 
     public static UserInfoVo from(User user) {
         return UserInfoVo.builder()

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserProfileVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserProfileVo.java
@@ -15,7 +15,7 @@ public class UserProfileVo {
 
     private final String email;
 
-    private final String profileImage;
+    private final ImageVo profileImage;
 
     public static UserProfileVo from(User user) {
         return UserProfileVo.builder()

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/EventDetail.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/EventDetail.java
@@ -19,8 +19,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventDetail {
     // 포스터 이미지
-    @Embedded
-    private ImageVo posterImage;
+    @Embedded private ImageVo posterImage;
 
     // todo :: 디테일 이미지를 EventDetailImage 로 받기
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/EventDetail.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/EventDetail.java
@@ -1,11 +1,13 @@
 package band.gosrock.domain.domains.event.domain;
 
 
+import band.gosrock.domain.common.vo.ImageVo;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
 import javax.persistence.FetchType;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,7 +19,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventDetail {
     // 포스터 이미지
-    private String posterImage;
+    @Embedded
+    private ImageVo posterImage;
 
     // todo :: 디테일 이미지를 EventDetailImage 로 받기
 
@@ -34,8 +37,8 @@ public class EventDetail {
     }
 
     @Builder
-    public EventDetail(String posterImage, List<String> detailImages, String content) {
-        this.posterImage = posterImage;
+    public EventDetail(String posterImageKey, List<String> detailImages, String content) {
+        this.posterImage = ImageVo.valueOf(posterImageKey);
         this.detailImages = detailImages;
         this.content = content;
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
@@ -124,7 +124,7 @@ public class Host extends BaseTimeEntity {
     public Host(
             String name,
             String introduce,
-            String profileImageUrl,
+            String profileImageKey,
             String contactEmail,
             String contactNumber,
             String slackUrl,
@@ -133,7 +133,7 @@ public class Host extends BaseTimeEntity {
                 HostProfile.builder()
                         .name(name)
                         .introduce(introduce)
-                        .profileImageUrl(profileImageUrl)
+                        .profileImageKey(profileImageKey)
                         .contactEmail(contactEmail)
                         .contactNumber(contactNumber)
                         .build();

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostProfile.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostProfile.java
@@ -1,8 +1,10 @@
 package band.gosrock.domain.domains.host.domain;
 
 
+import band.gosrock.domain.common.vo.ImageVo;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +21,8 @@ public class HostProfile {
     private String introduce;
 
     // 프로필 이미지 url
-    private String profileImageUrl;
+    @Embedded
+    private ImageVo profileImage;
 
     // 대표자 이메일
     private String contactEmail;
@@ -29,7 +32,7 @@ public class HostProfile {
     private String contactNumber;
 
     protected void updateProfile(HostProfile hostProfile) {
-        this.profileImageUrl = hostProfile.getProfileImageUrl();
+        this.profileImage = hostProfile.getProfileImage();
         this.introduce = hostProfile.getIntroduce();
         this.contactEmail = hostProfile.getContactEmail();
         this.contactNumber = hostProfile.getContactNumber();
@@ -39,12 +42,12 @@ public class HostProfile {
     public HostProfile(
             String name,
             String introduce,
-            String profileImageUrl,
+            String profileImageKey,
             String contactEmail,
             String contactNumber) {
         this.name = name;
         this.introduce = introduce;
-        this.profileImageUrl = profileImageUrl;
+        this.profileImage = ImageVo.valueOf(profileImageKey);
         this.contactEmail = contactEmail;
         this.contactNumber = contactNumber;
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostProfile.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostProfile.java
@@ -21,8 +21,7 @@ public class HostProfile {
     private String introduce;
 
     // 프로필 이미지 url
-    @Embedded
-    private ImageVo profileImage;
+    @Embedded private ImageVo profileImage;
 
     // 대표자 이메일
     private String contactEmail;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/Profile.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/Profile.java
@@ -17,8 +17,7 @@ public class Profile {
     private String email;
 
     private String phoneNumber;
-    @Embedded
-    private ImageVo profileImage;
+    @Embedded private ImageVo profileImage;
 
     @Builder
     public Profile(String name, String email, String phoneNumber, String profileImage) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/Profile.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/Profile.java
@@ -1,7 +1,9 @@
 package band.gosrock.domain.domains.user.domain;
 
 
+import band.gosrock.domain.common.vo.ImageVo;
 import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,14 +17,14 @@ public class Profile {
     private String email;
 
     private String phoneNumber;
-
-    private String profileImage;
+    @Embedded
+    private ImageVo profileImage;
 
     @Builder
     public Profile(String name, String email, String phoneNumber, String profileImage) {
         this.name = name;
         this.email = email;
         this.phoneNumber = phoneNumber;
-        this.profileImage = profileImage;
+        this.profileImage = ImageVo.valueOf(profileImage);
     }
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/s3/ImageFileExtension.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/s3/ImageFileExtension.java
@@ -1,0 +1,17 @@
+package band.gosrock.infrastructure.config.s3;
+
+
+import lombok.Getter;
+
+@Getter
+public enum ImageFileExtension {
+    JPEG("jpeg"),
+    JPG("jpeg"),
+    PNG("png");
+
+    ImageFileExtension(String uploadExtension) {
+        this.uploadExtension = uploadExtension;
+    }
+
+    private final String uploadExtension;
+}

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/s3/ImageUrlDto.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/s3/ImageUrlDto.java
@@ -1,0 +1,17 @@
+package band.gosrock.infrastructure.config.s3;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ImageUrlDto {
+
+    private final String url;
+    private final String key;
+    private final String baseUrl;
+
+    public static ImageUrlDto of(String url, String key){
+        return ImageUrlDto.builder().key(key).url(url).build();
+    }
+}

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/s3/ImageUrlDto.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/s3/ImageUrlDto.java
@@ -1,5 +1,6 @@
 package band.gosrock.infrastructure.config.s3;
 
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,7 +12,7 @@ public class ImageUrlDto {
     private final String key;
     private final String baseUrl;
 
-    public static ImageUrlDto of(String url, String key){
+    public static ImageUrlDto of(String url, String key) {
         return ImageUrlDto.builder().key(key).url(url).build();
     }
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/s3/S3UploadPresignedUrlService.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/s3/S3UploadPresignedUrlService.java
@@ -28,8 +28,8 @@ public class S3UploadPresignedUrlService {
     @Value("${aws.s3.base-url}")
     private String baseUrl;
 
-    public ImageUrlDto forUser(Long userId, String fileExtension) {
-        String fixedFileExtension = getFixedFileExtension(fileExtension);
+    public ImageUrlDto forUser(Long userId, ImageFileExtension fileExtension) {
+        String fixedFileExtension = fileExtension.getUploadExtension();
         String fileName = getForUserFileName(userId, fixedFileExtension);
         log.info(fileName);
         URL url =
@@ -38,8 +38,8 @@ public class S3UploadPresignedUrlService {
         return ImageUrlDto.of(url.toString(), fileName);
     }
 
-    public ImageUrlDto forHost(Long hostId, String fileExtension) {
-        String fixedFileExtension = getFixedFileExtension(fileExtension);
+    public ImageUrlDto forHost(Long hostId, ImageFileExtension fileExtension) {
+        String fixedFileExtension = fileExtension.getUploadExtension();
         String fileName = getForHostFileName(hostId, fixedFileExtension);
         log.info(fileName);
         URL url =
@@ -48,19 +48,14 @@ public class S3UploadPresignedUrlService {
         return ImageUrlDto.of(url.toString(), fileName);
     }
 
-    public ImageUrlDto forEvent(Long eventId, String fileExtension) {
-        String fixedFileExtension = getFixedFileExtension(fileExtension);
+    public ImageUrlDto forEvent(Long eventId, ImageFileExtension fileExtension) {
+        String fixedFileExtension = fileExtension.getUploadExtension();
         String fileName = getForEventFileName(eventId, fixedFileExtension);
         log.info(fileName);
         URL url =
                 amazonS3.generatePresignedUrl(
                         getGeneratePreSignedUrlRequest(bucket, fileName, fixedFileExtension));
         return ImageUrlDto.of(url.toString(), fileName);
-    }
-
-    private String getFixedFileExtension(String fileExtension) {
-        validFileExtension(fileExtension);
-        return changeJpgToJpeg(fileExtension);
     }
 
     private String getForUserFileName(Long userId, String fileExtension) {

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/s3/S3UploadPresignedUrlService.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/s3/S3UploadPresignedUrlService.java
@@ -12,7 +12,6 @@ import java.util.Date;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -33,24 +32,30 @@ public class S3UploadPresignedUrlService {
         String fixedFileExtension = getFixedFileExtension(fileExtension);
         String fileName = getForUserFileName(userId, fixedFileExtension);
         log.info(fileName);
-        URL url = amazonS3.generatePresignedUrl(getGeneratePreSignedUrlRequest(bucket, fileName, fixedFileExtension));
-        return ImageUrlDto.of(url.toString(),fileName);
+        URL url =
+                amazonS3.generatePresignedUrl(
+                        getGeneratePreSignedUrlRequest(bucket, fileName, fixedFileExtension));
+        return ImageUrlDto.of(url.toString(), fileName);
     }
 
     public ImageUrlDto forHost(Long hostId, String fileExtension) {
         String fixedFileExtension = getFixedFileExtension(fileExtension);
         String fileName = getForHostFileName(hostId, fixedFileExtension);
         log.info(fileName);
-        URL url = amazonS3.generatePresignedUrl(getGeneratePreSignedUrlRequest(bucket, fileName, fixedFileExtension));
-        return ImageUrlDto.of(url.toString(),fileName);
+        URL url =
+                amazonS3.generatePresignedUrl(
+                        getGeneratePreSignedUrlRequest(bucket, fileName, fixedFileExtension));
+        return ImageUrlDto.of(url.toString(), fileName);
     }
 
     public ImageUrlDto forEvent(Long eventId, String fileExtension) {
         String fixedFileExtension = getFixedFileExtension(fileExtension);
         String fileName = getForEventFileName(eventId, fixedFileExtension);
         log.info(fileName);
-        URL url = amazonS3.generatePresignedUrl(getGeneratePreSignedUrlRequest(bucket, fileName, fixedFileExtension));
-        return ImageUrlDto.of(url.toString(),fileName);
+        URL url =
+                amazonS3.generatePresignedUrl(
+                        getGeneratePreSignedUrlRequest(bucket, fileName, fixedFileExtension));
+        return ImageUrlDto.of(url.toString(), fileName);
     }
 
     private String getFixedFileExtension(String fileExtension) {
@@ -70,22 +75,22 @@ public class S3UploadPresignedUrlService {
 
     private String getForHostFileName(Long hostId, String fileExtension) {
         return baseUrl
-            + "/host/"
-            + hostId.toString()
-            + "/"
-            + UUID.randomUUID()
-            + "."
-            + fileExtension;
+                + "/host/"
+                + hostId.toString()
+                + "/"
+                + UUID.randomUUID()
+                + "."
+                + fileExtension;
     }
 
     private String getForEventFileName(Long eventId, String fileExtension) {
         return baseUrl
-            + "/event/"
-            + eventId.toString()
-            + "/"
-            + UUID.randomUUID()
-            + "."
-            + fileExtension;
+                + "/event/"
+                + eventId.toString()
+                + "/"
+                + UUID.randomUUID()
+                + "."
+                + fileExtension;
     }
 
     private String changeJpgToJpeg(String fileExtension) {


### PR DESCRIPTION
## 개요
- close #131 

## 작업사항
- s3 프레사인 url 발급 api
- cloudFront 적용 ( https://asset.dudoong.com )
- 클라이언트들한텐 이미지 키값만 받아오면됩니다. 앞에 도메인 은 동적으로 붙여서 내려줍니다.
- 키 생성방식
- {환경 : prod,staging,test} /{종류 : user , host ,event}/ {해당아이디 }/{uuid}.{확장자 : jpeg , png}

## 변경로직
- image Vo 를 만들었습니당.
- 이벤트의 3장 디테일 이미지는 빠질것같아서 안건들였슴니다
- 뭔가 안돌아간다..하면 그냥 디비 밀어주세요..