### PR TITLE
feature : 옵션그룹 삭제

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/controller/TicketOptionController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/controller/TicketOptionController.java
@@ -5,6 +5,7 @@ import band.gosrock.api.ticketItem.dto.request.CreateTicketOptionRequest;
 import band.gosrock.api.ticketItem.dto.response.GetEventOptionsResponse;
 import band.gosrock.api.ticketItem.dto.response.OptionGroupResponse;
 import band.gosrock.api.ticketItem.service.CreateTicketOptionUseCase;
+import band.gosrock.api.ticketItem.service.DeleteOptionGroupUseCase;
 import band.gosrock.api.ticketItem.service.GetEventOptionsUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -22,6 +23,7 @@ public class TicketOptionController {
 
     private final CreateTicketOptionUseCase createTicketOptionUseCase;
     private final GetEventOptionsUseCase getEventOptionsUseCase;
+    private final DeleteOptionGroupUseCase deleteOptionGroupUseCase;
 
     @Operation(summary = "해당 이벤트에 속하는 티켓옵션을 생성합니다.")
     @PostMapping
@@ -35,5 +37,12 @@ public class TicketOptionController {
     @GetMapping
     public GetEventOptionsResponse getEventOptions(@PathVariable Long eventId) {
         return getEventOptionsUseCase.execute(eventId);
+    }
+
+    @Operation(summary = "해당 옵션그룹을 삭제합니다.")
+    @PatchMapping("/{optionGroupId}")
+    public GetEventOptionsResponse deleteOptionGroup(
+            @PathVariable Long eventId, @PathVariable Long optionGroupId) {
+        return deleteOptionGroupUseCase.execute(eventId, optionGroupId);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/DeleteOptionGroupUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/DeleteOptionGroupUseCase.java
@@ -1,0 +1,29 @@
+package band.gosrock.api.ticketItem.service;
+
+import static band.gosrock.api.common.aop.hostRole.FindHostFrom.EVENT_ID;
+import static band.gosrock.api.common.aop.hostRole.HostQualification.GUEST;
+
+import band.gosrock.api.common.aop.hostRole.HostRolesAllowed;
+import band.gosrock.api.ticketItem.dto.response.GetEventOptionsResponse;
+import band.gosrock.api.ticketItem.mapper.TicketOptionMapper;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.ticket_item.service.TicketOptionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class DeleteOptionGroupUseCase {
+
+    private final TicketOptionMapper ticketOptionMapper;
+    private final TicketOptionService ticketOptionService;
+
+    @Transactional
+    @HostRolesAllowed(role = GUEST, findHostFrom = EVENT_ID)
+    public GetEventOptionsResponse execute(Long eventId, Long optionGroupId) {
+
+        ticketOptionService.softDeleteOptionGroup(eventId, optionGroupId);
+
+        return ticketOptionMapper.toGetEventOptionResponse(eventId);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/OptionGroup.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/OptionGroup.java
@@ -11,7 +11,6 @@ import band.gosrock.domain.domains.ticket_item.exception.ForbiddenOptionGroupDel
 import band.gosrock.domain.domains.ticket_item.exception.InvalidOptionGroupException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -79,14 +78,9 @@ public class OptionGroup {
     }
 
     public Boolean hasApplication(List<TicketItem> ticketItems) {
-        AtomicBoolean result = new AtomicBoolean(false);
-        ticketItems.forEach(
-                ticketItem -> {
-                    if (ticketItem.hasItemOptionGroup(this.id)) {
-                        result.set(true);
-                    }
-                });
-        return result.get();
+        return ticketItems.stream()
+                .map(ticketItem -> ticketItem.hasItemOptionGroup(this.id))
+                .reduce(Boolean.FALSE, Boolean::logicalOr);
     }
 
     public OptionGroup createTicketOption(Money additionalPrice) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/OptionGroup.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/domain/OptionGroup.java
@@ -7,9 +7,11 @@ import static band.gosrock.domain.domains.ticket_item.domain.OptionGroupType.*;
 
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.event.domain.Event;
+import band.gosrock.domain.domains.ticket_item.exception.ForbiddenOptionGroupDeleteException;
 import band.gosrock.domain.domains.ticket_item.exception.InvalidOptionGroupException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -76,6 +78,17 @@ public class OptionGroup {
         }
     }
 
+    public Boolean hasApplication(List<TicketItem> ticketItems) {
+        AtomicBoolean result = new AtomicBoolean(false);
+        ticketItems.forEach(
+                ticketItem -> {
+                    if (ticketItem.hasItemOptionGroup(this.id)) {
+                        result.set(true);
+                    }
+                });
+        return result.get();
+    }
+
     public OptionGroup createTicketOption(Money additionalPrice) {
         OptionGroupType type = this.getType();
         if (type == TRUE_FALSE) {
@@ -85,5 +98,13 @@ public class OptionGroup {
             this.options.add(Option.create("", ZERO, this));
         }
         return this;
+    }
+
+    public void softDeleteOptionGroup(List<TicketItem> ticketItems) {
+        // 적용된 옵션은 삭제 불가
+        if (this.hasApplication(ticketItems)) {
+            throw ForbiddenOptionGroupDeleteException.EXCEPTION;
+        }
+        this.optionGroupStatus = OptionGroupStatus.DELETED;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/ForbiddenOptionGroupDeleteException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/ForbiddenOptionGroupDeleteException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.ticket_item.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class ForbiddenOptionGroupDeleteException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new ForbiddenOptionGroupDeleteException();
+
+    private ForbiddenOptionGroupDeleteException() {
+        super(TicketItemErrorCode.FORBIDDEN_OPTION_GROUP_DELETE);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/TicketItemErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/exception/TicketItemErrorCode.java
@@ -41,7 +41,10 @@ public enum TicketItemErrorCode implements BaseErrorCode {
     @ExplainError("이미 재고가 감소되어 옵션 변경이 불가능할 경우 발생하는 오류입니다.")
     FORBIDDEN_OPTION_CHANGE(BAD_REQUEST, "Item_Option_Group_400_2", "옵션 변경이 불가능한 상태입니다."),
     @ExplainError("이미 재고가 감소되어 티켓상품 삭제가 불가능할 경우 발생하는 오류입니다.")
-    FORBIDDEN_TICKET_ITEM_DELETE(BAD_REQUEST, "Ticket_Item_400_7", "티켓상품 삭제가 불가능한 상태입니다.");
+    FORBIDDEN_TICKET_ITEM_DELETE(BAD_REQUEST, "Ticket_Item_400_7", "티켓상품 삭제가 불가능한 상태입니다."),
+    @ExplainError("이미 적용되어 옵션그룹 삭제가 불가능할 경우 발생하는 오류입니다.")
+    FORBIDDEN_OPTION_GROUP_DELETE(BAD_REQUEST, "Option_Group_400_2", "옵션그룹 삭제가 불가능한 상태입니다.");
+
     private Integer status;
     private String code;
     private String reason;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/service/TicketItemService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/service/TicketItemService.java
@@ -23,8 +23,7 @@ public class TicketItemService {
         return ticketItemAdaptor.save(ticketItem);
     }
 
-    @Transactional
-    @RedissonLock(LockName = "티켓재고관리", identifier = "ticketItemId")
+    @RedissonLock(LockName = "티켓관리", identifier = "ticketItemId")
     public void softDeleteTicketItem(Long eventId, Long ticketItemId) {
 
         TicketItem ticketItem = ticketItemAdaptor.queryTicketItem(ticketItemId);

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/service/TicketItemService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/service/TicketItemService.java
@@ -23,6 +23,7 @@ public class TicketItemService {
         return ticketItemAdaptor.save(ticketItem);
     }
 
+    @Transactional
     @RedissonLock(LockName = "티켓재고관리", identifier = "ticketItemId")
     public void softDeleteTicketItem(Long eventId, Long ticketItemId) {
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/service/TicketOptionService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/service/TicketOptionService.java
@@ -3,7 +3,10 @@ package band.gosrock.domain.domains.ticket_item.service;
 
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.domains.ticket_item.adaptor.OptionGroupAdaptor;
+import band.gosrock.domain.domains.ticket_item.adaptor.TicketItemAdaptor;
 import band.gosrock.domain.domains.ticket_item.domain.OptionGroup;
+import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,9 +16,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class TicketOptionService {
 
     private final OptionGroupAdaptor optionGroupAdaptor;
+    private final TicketItemAdaptor ticketItemAdaptor;
 
     @Transactional
     public OptionGroup createTicketOption(OptionGroup optionGroup) {
         return optionGroupAdaptor.save(optionGroup);
+    }
+
+    @Transactional
+    public void softDeleteOptionGroup(Long eventId, Long optionGroupId) {
+
+        OptionGroup optionGroup = optionGroupAdaptor.queryOptionGroup(optionGroupId);
+        // 해당 eventId에 속해 있는 옵션그룹이 맞는지 확인
+        optionGroup.validateEventId(eventId);
+
+        List<TicketItem> ticketItems = ticketItemAdaptor.findAllByEventId(eventId);
+        optionGroup.softDeleteOptionGroup(ticketItems);
+        optionGroupAdaptor.save(optionGroup);
     }
 }


### PR DESCRIPTION
## 개요
- close #228 

## 작업사항
- 옵션그룹 삭제 API
- 이미 적용된 내용이 있으면 삭제 불가능
- 티켓상품 삭제시, 적용내역까지 전부 삭제하지 않으므로, 
  적용내역 검증은 존재하는 티켓상품들의 옵션그룹을 통해 검증
- 반환값은 삭제 후 남은 옵션그룹 조회

- @HostRoleAllowed 전체 적용하려고 했는데, 트랜잭션이 달라지는지?? 기존 save후에 다시 조회하는 부분이 따로 동작이 안돼서 
   일단 지금 해당 API만 적용했고, 나머지 부분은 생각좀해보고 적용하겠슴다.

## 변경로직
