### PR TITLE
fix :  500번대 슬랙 알림시 url 받는 위치 수정(해결)

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/config/response/GlobalExceptionHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/config/response/GlobalExceptionHandler.java
@@ -181,7 +181,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                         internalServerError.getReason(),
                         url);
 
-        slackApiProvider.sendError(cachingRequest, e, userId);
+        slackApiProvider.sendError(cachingRequest, e, userId, url);
         return ResponseEntity.status(HttpStatus.valueOf(internalServerError.getStatus()))
                 .body(errorResponse);
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/config/slack/SlackApiProvider.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/config/slack/SlackApiProvider.java
@@ -42,19 +42,19 @@ public class SlackApiProvider {
     private final int MAX_LEN = 500;
 
     @Async
-    public void sendError(ContentCachingRequestWrapper cachingRequest, Exception e, Long userId)
+    public void sendError(
+            ContentCachingRequestWrapper cachingRequest, Exception e, Long userId, String url)
             throws IOException {
         String[] activeProfiles = env.getActiveProfiles();
         List<String> currentProfile = Arrays.stream(activeProfiles).toList();
         if (CollectionUtils.containsAny(sendAlarmProfiles, currentProfile)) {
-            executeSendError(cachingRequest, e, userId);
+            executeSendError(cachingRequest, e, userId, url);
         }
     }
 
     private void executeSendError(
-            ContentCachingRequestWrapper cachingRequest, Exception e, Long userId)
+            ContentCachingRequestWrapper cachingRequest, Exception e, Long userId, String url)
             throws IOException {
-        final String url = cachingRequest.getRequestURL().toString();
         final String method = cachingRequest.getMethod();
         final String body =
                 objectMapper.readTree(cachingRequest.getContentAsByteArray()).toString();


### PR DESCRIPTION
## 개요
- close #270 

## 작업사항
- 아래 오류가 서버쪽에서 나서 url 받는 위치 수정해보았습니다

```java
private void executeSendError(
            ContentCachingRequestWrapper cachingRequest, Exception e, Long userId)
            throws IOException {
        final String url = cachingRequest.getRequestURL().toString(); // 오류나버림
```

```
java.lang.NullPointerException: Cannot invoke "String.indexOf(String)" because "path" is null
        at org.springframework.web.util.UrlPathHelper.getSanitizedPath(UrlPathHelper.java:408) ~[spring-web-5.3.24.jar!/:5.3.24]
        at org.springframework.web.util.UrlPathHelper.decodeAndCleanUriString(UrlPathHelper.java:551) ~[spring-web-5.3.24.jar!/:5.3.24]
        at org.springframework.web.util.UrlPathHelper.getRequestUri(UrlPathHelper.java:438) ~[spring-web-5.3.24.jar!/:5.3.24]
        at org.springframework.web.util.UrlPathHelper.getPathWithinApplication(UrlPathHelper.java:353) ~[spring-web-5.3.24.jar!/:5.3.24]
        at org.springframework.web.filter.ForwardedHeaderFilter$ForwardedPrefixExtractor.initRequestUri(ForwardedHeaderFilter.java:378) ~[spring-web-5.3.24.jar!/:5.3.24]
        at org.springframework.web.filter.ForwardedHeaderFilter$ForwardedPrefixExtractor.recalculatePathsIfNecessary(ForwardedHeaderFilter.java:409) ~[spring-web-5.3.24.jar!/:5.3.24]
        at org.springframework.web.filter.ForwardedHeaderFilter$ForwardedPrefixExtractor.getRequestUrl(ForwardedHeaderFilter.java:401) ~[spring-web-5.3.24.jar!/:5.3.24]
        at org.springframework.web.filter.ForwardedHeaderFilter$ForwardedHeaderExtractingRequest.getRequestURL(ForwardedHeaderFilter.java:288) ~[spring-web-5.3.24.jar!/:5.3.24]
        at javax.servlet.http.HttpServletRequestWrapper.getRequestURL(HttpServletRequestWrapper.java:226) ~[tomcat-embed-core-9.0.70.jar!/:na]
        at band.gosrock.api.config.slack.SlackApiProvider.executeSendError(SlackApiProvider.java:57) ~[classes!/:na]
        at band.gosrock.api.config.slack.SlackApiProvider.sendError(SlackApiProvider.java:50) ~[classes!/:na]
        at band.gosrock.api.config.slack.SlackApiProvider$$FastClassBySpringCGLIB$$61388a1a.invoke(<generated>) ~[classes!/:na]
        at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.24.jar!/:5.3.24]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793) ~[spring-aop-5.3.24.jar!/:5.3.24]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.24.jar!/:5.3.24]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.24.jar!/:5.3.24]
        at org.springframework.aop.interceptor.AsyncExecutionInterceptor.lambda$invoke$0(AsyncExecutionInterceptor.java:115) ~[spring-aop-5.3.24.jar!/:5.3.24]
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1135) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[na:na]
        at java.base/java.lang.Thread.run(Thread.java:831) ~[na:na]

```

## 변경로직
- 내용을 적어주세요.