### PR TITLE
feat : QueryDslUtil 및 무한 스크롤 적용

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/slice/SliceParam.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/slice/SliceParam.java
@@ -1,0 +1,41 @@
+package band.gosrock.api.common.slice;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@Getter
+@AllArgsConstructor
+public class SliceParam {
+    @Schema(description = "lastId 부터 원소를 불러옵니다")
+    @Min(value = -1)
+    private Long lastId;
+
+    @Schema(description = "한 번 조회당 원소 개수")
+    @Positive
+    private Integer size;
+
+    @Schema(description = "정렬 조건")
+    private String sort;
+
+    @Schema(description = "정렬 순서 (ASC | DESC)")
+    private Sort.Direction direction;
+
+    public Pageable toPageable() {
+        // RequestParam 에 빈 값은 null 로 할당되어 검증 필요
+        if (size == null) size = 10;
+        if (direction == null) direction = Sort.Direction.DESC;
+        if (sort == null) sort = "id";
+        return PageRequest.of(0, size, Sort.by(direction, sort));
+    }
+
+    public static Pageable pageableOf(SliceParam sliceParam) {
+        return sliceParam.toPageable();
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/slice/SliceParam.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/slice/SliceParam.java
@@ -2,7 +2,6 @@ package band.gosrock.api.common.slice;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,26 +12,27 @@ import org.springframework.data.domain.Sort;
 @Getter
 @AllArgsConstructor
 public class SliceParam {
-    @Schema(description = "lastId 부터 원소를 불러옵니다")
-    @Min(value = -1)
-    private Long lastId;
+    @Schema(description = "현재 조회하려는 페이지")
+    @Positive
+    private Integer page;
 
-    @Schema(description = "한 번 조회당 원소 개수")
+    @Schema(description = "한 번 조회당 레코드 개수 (default: 10)")
     @Positive
     private Integer size;
 
-    @Schema(description = "정렬 조건")
+    @Schema(description = "정렬 조건 프로퍼티 (default: \"id\")")
     private String sort;
 
-    @Schema(description = "정렬 순서 (ASC | DESC)")
+    @Schema(description = "정렬 순서 (ASC | DESC) (default: DESC)")
     private Sort.Direction direction;
 
     public Pageable toPageable() {
         // RequestParam 에 빈 값은 null 로 할당되어 검증 필요
+        if (page == null) page = 0;
         if (size == null) size = 10;
-        if (direction == null) direction = Sort.Direction.DESC;
         if (sort == null) sort = "id";
-        return PageRequest.of(0, size, Sort.by(direction, sort));
+        if (direction == null) direction = Sort.Direction.DESC;
+        return PageRequest.of(page, size, Sort.by(direction, sort));
     }
 
     public static Pageable pageableOf(SliceParam sliceParam) {

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/slice/SliceResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/slice/SliceResponse.java
@@ -4,9 +4,12 @@ package band.gosrock.api.common.slice;
 import java.util.List;
 import org.springframework.data.domain.Slice;
 
-public record SliceResponse<T>(List<T> content, int size, boolean hasNext) {
+public record SliceResponse<T>(List<T> content, long page, int size, boolean hasNext) {
     public static <T> SliceResponse<T> of(Slice<T> slice) {
         return new SliceResponse<>(
-                slice.getContent(), slice.getNumberOfElements(), slice.hasNext());
+                slice.getContent(),
+                slice.getNumber(),
+                slice.getNumberOfElements(),
+                slice.hasNext());
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/slice/SliceResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/slice/SliceResponse.java
@@ -1,0 +1,12 @@
+package band.gosrock.api.common.slice;
+
+
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record SliceResponse<T>(List<T> content, int size, boolean hasNext) {
+    public static <T> SliceResponse<T> of(Slice<T> slice) {
+        return new SliceResponse<>(
+                slice.getContent(), slice.getNumberOfElements(), slice.hasNext());
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/controller/EventController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/controller/EventController.java
@@ -1,7 +1,8 @@
 package band.gosrock.api.event.controller;
 
 
-import band.gosrock.api.common.page.PageResponse;
+import band.gosrock.api.common.slice.SliceParam;
+import band.gosrock.api.common.slice.SliceResponse;
 import band.gosrock.api.event.model.dto.request.CreateEventRequest;
 import band.gosrock.api.event.model.dto.request.UpdateEventBasicRequest;
 import band.gosrock.api.event.model.dto.request.UpdateEventDetailRequest;
@@ -17,8 +18,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.api.annotations.ParameterObject;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @SecurityRequirement(name = "access-token")
@@ -36,11 +35,18 @@ public class EventController {
     private final UpdateEventDetailUseCase updateEventDetailUseCase;
     private final UpdateEventStatusUseCase updateEventStatusUseCase;
 
+    //    @Operation(summary = "자신이 관리 중인 이벤트 리스트를 가져옵니다.")
+    //    @GetMapping
+    //    public PageResponse<EventProfileResponse> getAllEventByUser(
+    //            @ParameterObject @PageableDefault(size = 10) Pageable pageable) {
+    //        return readUserHostEventListUseCase.execute(pageable);
+    //    }
+
     @Operation(summary = "자신이 관리 중인 이벤트 리스트를 가져옵니다.")
     @GetMapping
-    public PageResponse<EventProfileResponse> getAllEventByUser(
-            @ParameterObject @PageableDefault(size = 10) Pageable pageable) {
-        return readUserHostEventListUseCase.execute(pageable);
+    public SliceResponse<EventProfileResponse> getAllEventByUser(
+            @ParameterObject SliceParam sliceParam) {
+        return readUserHostEventListUseCase.execute(sliceParam);
     }
 
     @Operation(summary = "공연 기본 정보를 등록하여, 새로운 이벤트(공연)를 생성합니다")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
@@ -1,6 +1,7 @@
 package band.gosrock.api.event.model.mapper;
 
 
+import band.gosrock.api.common.slice.SliceParam;
 import band.gosrock.api.event.model.dto.request.CreateEventRequest;
 import band.gosrock.api.event.model.dto.request.UpdateEventBasicRequest;
 import band.gosrock.api.event.model.dto.request.UpdateEventDetailRequest;
@@ -20,6 +21,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
 
 @Mapper
@@ -79,6 +81,16 @@ public class EventMapper {
         List<Long> hostIds = hostList.stream().map(Host::getId).toList();
         Page<Event> eventList = eventAdaptor.findAllByHostIdIn(hostIds, pageable);
         return eventList.map(event -> this.toEventProfileResponse(hostList, event));
+    }
+
+    public Slice<EventProfileResponse> toEventProfileResponseSlice(
+            Long userId, SliceParam sliceParam) {
+        List<Host> hosts = hostAdaptor.findAllByHostUsers_UserId(userId);
+        List<Long> hostIds = hosts.stream().map(Host::getId).toList();
+        Slice<Event> events =
+                eventAdaptor.querySliceByHostIdIn(
+                        hostIds, sliceParam.getLastId(), sliceParam.toPageable());
+        return events.map(event -> this.toEventProfileResponse(hosts, event));
     }
 
     private EventProfileResponse toEventProfileResponse(List<Host> hostList, Event event) {

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
@@ -88,7 +88,7 @@ public class EventMapper {
         List<Host> hosts = hostAdaptor.findAllByHostUsers_UserId(userId);
         List<Long> hostIds = hosts.stream().map(Host::getId).toList();
         Slice<Event> events =
-                eventAdaptor.querySliceByHostIdIn(
+                eventAdaptor.querySliceEventsByHostIdIn(
                         hostIds, sliceParam.getLastId(), sliceParam.toPageable());
         return events.map(event -> this.toEventProfileResponse(hosts, event));
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
@@ -88,8 +88,7 @@ public class EventMapper {
         List<Host> hosts = hostAdaptor.findAllByHostUsers_UserId(userId);
         List<Long> hostIds = hosts.stream().map(Host::getId).toList();
         Slice<Event> events =
-                eventAdaptor.querySliceEventsByHostIdIn(
-                        hostIds, sliceParam.getLastId(), sliceParam.toPageable());
+                eventAdaptor.querySliceEventsByHostIdIn(hostIds, sliceParam.toPageable());
         return events.map(event -> this.toEventProfileResponse(hosts, event));
     }
 

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/service/ReadUserEventProfilesUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/service/ReadUserEventProfilesUseCase.java
@@ -2,13 +2,13 @@ package band.gosrock.api.event.service;
 
 
 import band.gosrock.api.common.UserUtils;
-import band.gosrock.api.common.page.PageResponse;
+import band.gosrock.api.common.slice.SliceParam;
+import band.gosrock.api.common.slice.SliceResponse;
 import band.gosrock.api.event.model.dto.response.EventProfileResponse;
 import band.gosrock.api.event.model.mapper.EventMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
@@ -18,9 +18,9 @@ public class ReadUserEventProfilesUseCase {
     private final UserUtils userUtils;
     private final EventMapper eventMapper;
 
-    public PageResponse<EventProfileResponse> execute(Pageable pageable) {
+    public SliceResponse<EventProfileResponse> execute(SliceParam sliceParam) {
         final User user = userUtils.getCurrentUser();
         final Long userId = user.getId();
-        return PageResponse.of(eventMapper.toEventProfileResponsePage(userId, pageable));
+        return SliceResponse.of(eventMapper.toEventProfileResponseSlice(userId, sliceParam));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
@@ -2,6 +2,8 @@ package band.gosrock.api.host.controller;
 
 
 import band.gosrock.api.common.page.PageResponse;
+import band.gosrock.api.common.slice.SliceParam;
+import band.gosrock.api.common.slice.SliceResponse;
 import band.gosrock.api.host.model.dto.request.*;
 import band.gosrock.api.host.model.dto.response.HostDetailResponse;
 import band.gosrock.api.host.model.dto.response.HostEventProfileResponse;
@@ -39,11 +41,18 @@ public class HostController {
     private final InviteHostUseCase inviteHostUseCase;
     private final JoinHostUseCase joinHostUseCase;
 
+    // todo :: 제거
+    //    @Operation(summary = "내가 속한 호스트 리스트를 가져옵니다.")
+    //    @GetMapping
+    //    public PageResponse<HostProfileResponse> getAllHosts(
+    //            @ParameterObject @PageableDefault(size = 10) Pageable pageable) {
+    //        return readHostsUseCase.execute(pageable);
+    //    }
+
     @Operation(summary = "내가 속한 호스트 리스트를 가져옵니다.")
     @GetMapping
-    public PageResponse<HostProfileResponse> getAllHosts(
-            @ParameterObject @PageableDefault(size = 10) Pageable pageable) {
-        return readHostsUseCase.execute(pageable);
+    public SliceResponse<HostProfileResponse> getAllHosts(@ParameterObject SliceParam sliceParam) {
+        return readHostsUseCase.execute(sliceParam);
     }
 
     @Operation(summary = "고유 아이디에 해당하는 호스트 정보를 가져옵니다.")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
@@ -41,14 +41,6 @@ public class HostController {
     private final InviteHostUseCase inviteHostUseCase;
     private final JoinHostUseCase joinHostUseCase;
 
-    // todo :: 제거
-    //    @Operation(summary = "내가 속한 호스트 리스트를 가져옵니다.")
-    //    @GetMapping
-    //    public PageResponse<HostProfileResponse> getAllHosts(
-    //            @ParameterObject @PageableDefault(size = 10) Pageable pageable) {
-    //        return readHostsUseCase.execute(pageable);
-    //    }
-
     @Operation(summary = "내가 속한 호스트 리스트를 가져옵니다.")
     @GetMapping
     public SliceResponse<HostProfileResponse> getAllHosts(@ParameterObject SliceParam sliceParam) {

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/HostProfileResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/response/HostProfileResponse.java
@@ -4,6 +4,7 @@ package band.gosrock.api.host.model.dto.response;
 import band.gosrock.domain.common.vo.ImageVo;
 import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.host.domain.HostRole;
+import band.gosrock.domain.domains.host.domain.HostUser;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,14 +31,19 @@ public class HostProfileResponse {
     @Schema(description = "이 호스트의 마스터인지 여부")
     private final Boolean isMaster;
 
+    @Schema(description = "이 호스트 초대를 수락했는지 여부")
+    private final Boolean active;
+
     public static HostProfileResponse of(Host host, Long userId) {
+        HostUser hostUser = host.getHostUserByUserId(userId);
         return HostProfileResponse.builder()
                 .hostId(host.getId())
                 .name(host.getProfile().getName())
                 .introduce(host.getProfile().getIntroduce())
                 .profileImageUrl(host.getProfile().getProfileImage())
-                .role(host.getHostUserByUserId(userId).getRole())
+                .role(hostUser.getRole())
                 .isMaster(host.getMasterUserId().equals(userId))
+                .active(hostUser.getActive())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostProfilesUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostProfilesUseCase.java
@@ -24,7 +24,7 @@ public class ReadHostProfilesUseCase {
 
         return SliceResponse.of(
                 hostAdaptor
-                        .querySliceHostByUserId(
+                        .querySliceHostsByUserId(
                                 userId, sliceParam.getLastId(), sliceParam.toPageable())
                         .map(host -> HostProfileResponse.of(host, userId)));
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostProfilesUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostProfilesUseCase.java
@@ -2,13 +2,13 @@ package band.gosrock.api.host.service;
 
 
 import band.gosrock.api.common.UserUtils;
-import band.gosrock.api.common.page.PageResponse;
+import band.gosrock.api.common.slice.SliceParam;
+import band.gosrock.api.common.slice.SliceResponse;
 import band.gosrock.api.host.model.dto.response.HostProfileResponse;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
@@ -18,13 +18,14 @@ public class ReadHostProfilesUseCase {
     private final UserUtils userUtils;
     private final HostAdaptor hostAdaptor;
 
-    public PageResponse<HostProfileResponse> execute(Pageable pageable) {
+    public SliceResponse<HostProfileResponse> execute(SliceParam sliceParam) {
         final User user = userUtils.getCurrentUser();
         final Long userId = user.getId();
 
-        return PageResponse.of(
+        return SliceResponse.of(
                 hostAdaptor
-                        .findAllByHostUsers_UserId(userId, pageable)
+                        .querySliceHostByUserId(
+                                userId, sliceParam.getLastId(), sliceParam.toPageable())
                         .map(host -> HostProfileResponse.of(host, userId)));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostProfilesUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostProfilesUseCase.java
@@ -24,8 +24,7 @@ public class ReadHostProfilesUseCase {
 
         return SliceResponse.of(
                 hostAdaptor
-                        .querySliceHostsByUserId(
-                                userId, sliceParam.getLastId(), sliceParam.toPageable())
+                        .querySliceHostsByUserId(userId, sliceParam.toPageable())
                         .map(host -> HostProfileResponse.of(host, userId)));
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/util/QueryDslUtil.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/util/QueryDslUtil.java
@@ -1,0 +1,35 @@
+package band.gosrock.domain.common.util;
+
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+/** QueryDsl 에서 compileQuerydsl 빌드를 통해 생성된 클래스 객체 타입을 받아 Sort 의 대상이 되는 Q타입 클래스 객체 리스트를 전달 */
+public class QueryDslUtil {
+    public static <T> OrderSpecifier[] getOrderSpecifiers(
+            Class<? extends T> type, Pageable pageable) {
+        final String variable = type.getSimpleName().toLowerCase();
+        final List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+        final PathBuilder<T> entityPath = new PathBuilder<>(type, variable);
+        for (Sort.Order order : pageable.getSort()) {
+            // 존재하지 않는 필드명 검사 - 필드에 없으면 무시됨
+            if (hasField(type, order.getProperty())) {
+                PathBuilder<Object> path = entityPath.get(order.getProperty());
+                orderSpecifiers.add(
+                        new OrderSpecifier(Order.valueOf(order.getDirection().name()), path));
+            }
+        }
+        return orderSpecifiers.toArray(OrderSpecifier[]::new);
+    }
+
+    private static <T> Boolean hasField(Class<? extends T> type, String name) {
+        return Arrays.stream(type.getDeclaredFields())
+                .anyMatch(field -> field.getName().equals(name));
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/adaptor/EventAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/adaptor/EventAdaptor.java
@@ -5,12 +5,13 @@ import band.gosrock.common.annotation.Adaptor;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.event.exception.EventNotFoundException;
 import band.gosrock.domain.domains.event.repository.EventRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Adaptor
 @RequiredArgsConstructor
@@ -33,8 +34,9 @@ public class EventAdaptor {
     }
 
     @Transactional(readOnly = true)
-    public Slice<Event> querySliceByHostIdIn(List<Long> hostId, Long lastId, Pageable pageable) {
-        return eventRepository.querySliceEventByHostIdIn(hostId, lastId, pageable);
+    public Slice<Event> querySliceEventsByHostIdIn(
+            List<Long> hostId, Long lastId, Pageable pageable) {
+        return eventRepository.querySliceEventsByHostIdIn(hostId, lastId, pageable);
     }
 
     public List<Event> findAllByIds(List<Long> ids) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/adaptor/EventAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/adaptor/EventAdaptor.java
@@ -5,13 +5,12 @@ import band.gosrock.common.annotation.Adaptor;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.event.exception.EventNotFoundException;
 import band.gosrock.domain.domains.event.repository.EventRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Adaptor
 @RequiredArgsConstructor

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/adaptor/EventAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/adaptor/EventAdaptor.java
@@ -33,9 +33,8 @@ public class EventAdaptor {
     }
 
     @Transactional(readOnly = true)
-    public Slice<Event> querySliceEventsByHostIdIn(
-            List<Long> hostId, Long lastId, Pageable pageable) {
-        return eventRepository.querySliceEventsByHostIdIn(hostId, lastId, pageable);
+    public Slice<Event> querySliceEventsByHostIdIn(List<Long> hostId, Pageable pageable) {
+        return eventRepository.querySliceEventsByHostIdIn(hostId, pageable);
     }
 
     public List<Event> findAllByIds(List<Long> ids) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/adaptor/EventAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/adaptor/EventAdaptor.java
@@ -9,6 +9,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.transaction.annotation.Transactional;
 
 @Adaptor
 @RequiredArgsConstructor
@@ -28,6 +30,11 @@ public class EventAdaptor {
 
     public Page<Event> findAllByHostIdIn(List<Long> hostId, Pageable pageable) {
         return eventRepository.findAllByHostIdIn(hostId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<Event> querySliceByHostIdIn(List<Long> hostId, Long lastId, Pageable pageable) {
+        return eventRepository.querySliceEventByHostIdIn(hostId, lastId, pageable);
     }
 
     public List<Event> findAllByIds(List<Long> ids) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface EventCustomRepository {
-    Slice<Event> querySliceEventByHostIdIn(List<Long> hostId, Long lastId, Pageable pageable);
+    Slice<Event> querySliceEventsByHostIdIn(List<Long> hostId, Long lastId, Pageable pageable);
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepository.java
@@ -1,0 +1,11 @@
+package band.gosrock.domain.domains.event.repository;
+
+
+import band.gosrock.domain.domains.event.domain.Event;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface EventCustomRepository {
+    Slice<Event> querySliceEventByHostIdIn(List<Long> hostId, Long lastId, Pageable pageable);
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface EventCustomRepository {
-    Slice<Event> querySliceEventsByHostIdIn(List<Long> hostId, Long lastId, Pageable pageable);
+    Slice<Event> querySliceEventsByHostIdIn(List<Long> hostId, Pageable pageable);
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.java
@@ -19,7 +19,7 @@ public class EventCustomRepositoryImpl implements EventCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<Event> querySliceEventByHostIdIn(
+    public Slice<Event> querySliceEventsByHostIdIn(
             List<Long> hostId, Long lastId, Pageable pageable) {
         OrderSpecifier[] orders = QueryDslUtil.getOrderSpecifiers(Event.class, pageable);
         List<Event> events =

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.java
@@ -1,0 +1,48 @@
+package band.gosrock.domain.domains.event.repository;
+
+import static band.gosrock.domain.domains.event.domain.QEvent.event;
+
+import band.gosrock.domain.common.util.QueryDslUtil;
+import band.gosrock.domain.domains.event.domain.Event;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+@RequiredArgsConstructor
+public class EventCustomRepositoryImpl implements EventCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Event> querySliceEventByHostIdIn(
+            List<Long> hostId, Long lastId, Pageable pageable) {
+        OrderSpecifier[] orders = QueryDslUtil.getOrderSpecifiers(Event.class, pageable);
+        List<Event> events =
+                queryFactory
+                        .selectFrom(event)
+                        .where(event.hostId.in(hostId), lastIdLessThanEqual(lastId))
+                        .orderBy(orders)
+                        .limit(pageable.getPageSize() + 1)
+                        .fetch();
+
+        return checkLastPage(events, pageable);
+    }
+
+    private BooleanExpression lastIdLessThanEqual(Long lastId) {
+        return lastId == null ? null : event.id.loe(lastId);
+    }
+
+    private Slice<Event> checkLastPage(List<Event> events, Pageable pageable) {
+        boolean hasNext = false;
+        if (events.size() > pageable.getPageSize()) {
+            hasNext = true;
+            events.remove(pageable.getPageSize());
+        }
+        return new SliceImpl<>(events, pageable, hasNext);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.java
@@ -25,16 +25,15 @@ public class EventCustomRepositoryImpl implements EventCustomRepository {
         List<Event> events =
                 queryFactory
                         .selectFrom(event)
-                        .where(event.hostId.in(hostId), lastIdLessThanEqual(lastId))
+                        .where(event.hostId.in(hostId), lastIdLessThan(lastId))
                         .orderBy(orders)
                         .limit(pageable.getPageSize() + 1)
                         .fetch();
-
         return checkLastPage(events, pageable);
     }
 
-    private BooleanExpression lastIdLessThanEqual(Long lastId) {
-        return lastId == null ? null : event.id.loe(lastId);
+    private BooleanExpression lastIdLessThan(Long lastId) {
+        return lastId == null ? null : event.id.lt(lastId);
     }
 
     private Slice<Event> checkLastPage(List<Event> events, Pageable pageable) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.java
@@ -5,7 +5,6 @@ import static band.gosrock.domain.domains.event.domain.QEvent.event;
 import band.gosrock.domain.common.util.QueryDslUtil;
 import band.gosrock.domain.domains.event.domain.Event;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,21 +18,17 @@ public class EventCustomRepositoryImpl implements EventCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<Event> querySliceEventsByHostIdIn(
-            List<Long> hostId, Long lastId, Pageable pageable) {
+    public Slice<Event> querySliceEventsByHostIdIn(List<Long> hostId, Pageable pageable) {
         OrderSpecifier[] orders = QueryDslUtil.getOrderSpecifiers(Event.class, pageable);
         List<Event> events =
                 queryFactory
                         .selectFrom(event)
-                        .where(event.hostId.in(hostId), lastIdLessThan(lastId))
+                        .where(event.hostId.in(hostId))
                         .orderBy(orders)
+                        .offset(pageable.getOffset())
                         .limit(pageable.getPageSize() + 1)
                         .fetch();
         return checkLastPage(events, pageable);
-    }
-
-    private BooleanExpression lastIdLessThan(Long lastId) {
-        return lastId == null ? null : event.id.lt(lastId);
     }
 
     private Slice<Event> checkLastPage(List<Event> events, Pageable pageable) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
-public interface EventRepository extends CrudRepository<Event, Long> {
+public interface EventRepository extends CrudRepository<Event, Long>, EventCustomRepository {
     List<Event> findAll();
 
     Page<Event> findAllByHostId(Long hostId, Pageable pageable);

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/adaptor/HostAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/adaptor/HostAdaptor.java
@@ -5,10 +5,12 @@ import band.gosrock.common.annotation.Adaptor;
 import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.host.exception.HostNotFoundException;
 import band.gosrock.domain.domains.host.repository.HostRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
 
 @Adaptor
 @RequiredArgsConstructor
@@ -17,6 +19,11 @@ public class HostAdaptor {
 
     public Host findById(Long hostId) {
         return hostRepository.findById(hostId).orElseThrow(() -> HostNotFoundException.EXCEPTION);
+    }
+
+    /** 자신이 속해있는 호스트 리스트를 무한스크롤로 가져오는 쿼리 요청 */
+    public Slice<Host> querySliceHostByUserId(Long userId, Long lastId, Pageable pageable) {
+        return hostRepository.querySliceHostByUserId(userId, lastId, pageable);
     }
 
     /** 자신이 마스터인 호스트 리스트를 가져오는 쿼리 요청 */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/adaptor/HostAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/adaptor/HostAdaptor.java
@@ -21,8 +21,8 @@ public class HostAdaptor {
     }
 
     /** 자신이 속해있는 호스트 리스트를 무한스크롤로 가져오는 쿼리 요청 */
-    public Slice<Host> querySliceHostsByUserId(Long userId, Long lastId, Pageable pageable) {
-        return hostRepository.querySliceHostsByUserId(userId, lastId, pageable);
+    public Slice<Host> querySliceHostsByUserId(Long userId, Pageable pageable) {
+        return hostRepository.querySliceHostsByUserId(userId, pageable);
     }
 
     /** 자신이 마스터인 호스트 리스트를 가져오는 쿼리 요청 */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/adaptor/HostAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/adaptor/HostAdaptor.java
@@ -5,12 +5,11 @@ import band.gosrock.common.annotation.Adaptor;
 import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.host.exception.HostNotFoundException;
 import band.gosrock.domain.domains.host.repository.HostRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-
-import java.util.List;
 
 @Adaptor
 @RequiredArgsConstructor

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/adaptor/HostAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/adaptor/HostAdaptor.java
@@ -21,8 +21,8 @@ public class HostAdaptor {
     }
 
     /** 자신이 속해있는 호스트 리스트를 무한스크롤로 가져오는 쿼리 요청 */
-    public Slice<Host> querySliceHostByUserId(Long userId, Long lastId, Pageable pageable) {
-        return hostRepository.querySliceHostByUserId(userId, lastId, pageable);
+    public Slice<Host> querySliceHostsByUserId(Long userId, Long lastId, Pageable pageable) {
+        return hostRepository.querySliceHostsByUserId(userId, lastId, pageable);
     }
 
     /** 자신이 마스터인 호스트 리스트를 가져오는 쿼리 요청 */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepository.java
@@ -1,0 +1,10 @@
+package band.gosrock.domain.domains.host.repository;
+
+
+import band.gosrock.domain.domains.host.domain.Host;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface HostCustomRepository {
+    Slice<Host> querySliceHostByUserId(Long id, Long lastId, Pageable pageable);
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface HostCustomRepository {
-    Slice<Host> querySliceHostByUserId(Long id, Long lastId, Pageable pageable);
+    Slice<Host> querySliceHostsByUserId(Long id, Long lastId, Pageable pageable);
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface HostCustomRepository {
-    Slice<Host> querySliceHostsByUserId(Long id, Long lastId, Pageable pageable);
+    Slice<Host> querySliceHostsByUserId(Long id, Pageable pageable);
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
@@ -38,12 +38,12 @@ public class HostCustomRepositoryImpl implements HostCustomRepository {
         return lastId == null ? null : host.id.loe(lastId);
     }
 
-    private Slice<Host> checkLastPage(List<Host> comments, Pageable pageable) {
+    private Slice<Host> checkLastPage(List<Host> hosts, Pageable pageable) {
         boolean hasNext = false;
-        if (comments.size() > pageable.getPageSize()) {
+        if (hosts.size() > pageable.getPageSize()) {
             hasNext = true;
-            comments.remove(pageable.getPageSize());
+            hosts.remove(pageable.getPageSize());
         }
-        return new SliceImpl<>(comments, pageable, hasNext);
+        return new SliceImpl<>(hosts, pageable, hasNext);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
@@ -1,18 +1,17 @@
 package band.gosrock.domain.domains.host.repository;
 
+import static band.gosrock.domain.domains.host.domain.QHost.host;
+import static band.gosrock.domain.domains.host.domain.QHostUser.hostUser;
+
 import band.gosrock.domain.common.util.QueryDslUtil;
 import band.gosrock.domain.domains.host.domain.Host;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
-
-import java.util.List;
-
-import static band.gosrock.domain.domains.host.domain.QHost.host;
-import static band.gosrock.domain.domains.host.domain.QHostUser.hostUser;
 
 @RequiredArgsConstructor
 public class HostCustomRepositoryImpl implements HostCustomRepository {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
@@ -1,19 +1,18 @@
 package band.gosrock.domain.domains.host.repository;
 
+import static band.gosrock.domain.domains.host.domain.QHost.host;
+import static band.gosrock.domain.domains.host.domain.QHostUser.hostUser;
+
 import band.gosrock.domain.common.util.QueryDslUtil;
 import band.gosrock.domain.domains.host.domain.Host;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
-
-import java.util.List;
-
-import static band.gosrock.domain.domains.host.domain.QHost.host;
-import static band.gosrock.domain.domains.host.domain.QHostUser.hostUser;
 
 @RequiredArgsConstructor
 public class HostCustomRepositoryImpl implements HostCustomRepository {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
@@ -20,7 +20,7 @@ public class HostCustomRepositoryImpl implements HostCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<Host> querySliceHostByUserId(Long userId, Long lastId, Pageable pageable) {
+    public Slice<Host> querySliceHostsByUserId(Long userId, Long lastId, Pageable pageable) {
         OrderSpecifier[] orders = QueryDslUtil.getOrderSpecifiers(Host.class, pageable);
         List<Host> comments =
                 queryFactory

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
@@ -1,16 +1,19 @@
 package band.gosrock.domain.domains.host.repository;
 
-import static band.gosrock.domain.domains.host.domain.QHost.host;
-import static band.gosrock.domain.domains.host.domain.QHostUser.hostUser;
-
+import band.gosrock.domain.common.util.QueryDslUtil;
 import band.gosrock.domain.domains.host.domain.Host;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+import static band.gosrock.domain.domains.host.domain.QHost.host;
+import static band.gosrock.domain.domains.host.domain.QHostUser.hostUser;
 
 @RequiredArgsConstructor
 public class HostCustomRepositoryImpl implements HostCustomRepository {
@@ -19,6 +22,7 @@ public class HostCustomRepositoryImpl implements HostCustomRepository {
 
     @Override
     public Slice<Host> querySliceHostByUserId(Long userId, Long lastId, Pageable pageable) {
+        OrderSpecifier[] orders = QueryDslUtil.getOrderSpecifiers(Host.class, pageable);
         List<Host> comments =
                 queryFactory
                         .select(host)
@@ -27,7 +31,7 @@ public class HostCustomRepositoryImpl implements HostCustomRepository {
                                 hostUser.userId.eq(userId),
                                 host.hostUsers.contains(hostUser),
                                 lastIdLessThanEqual(lastId))
-                        .orderBy(host.id.desc())
+                        .orderBy(orders)
                         .limit(pageable.getPageSize() + 1)
                         .fetch();
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
@@ -1,18 +1,19 @@
 package band.gosrock.domain.domains.host.repository;
 
-import static band.gosrock.domain.domains.host.domain.QHost.host;
-import static band.gosrock.domain.domains.host.domain.QHostUser.hostUser;
-
 import band.gosrock.domain.common.util.QueryDslUtil;
 import band.gosrock.domain.domains.host.domain.Host;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+import static band.gosrock.domain.domains.host.domain.QHost.host;
+import static band.gosrock.domain.domains.host.domain.QHostUser.hostUser;
 
 @RequiredArgsConstructor
 public class HostCustomRepositoryImpl implements HostCustomRepository {
@@ -29,7 +30,7 @@ public class HostCustomRepositoryImpl implements HostCustomRepository {
                         .where(
                                 hostUser.userId.eq(userId),
                                 host.hostUsers.contains(hostUser),
-                                lastIdLessThanEqual(lastId))
+                                lastIdLessThan(lastId))
                         .orderBy(orders)
                         .limit(pageable.getPageSize() + 1)
                         .fetch();
@@ -37,8 +38,8 @@ public class HostCustomRepositoryImpl implements HostCustomRepository {
         return checkLastPage(comments, pageable);
     }
 
-    private BooleanExpression lastIdLessThanEqual(Long lastId) {
-        return lastId == null ? null : host.id.loe(lastId);
+    private BooleanExpression lastIdLessThan(Long lastId) {
+        return lastId == null ? null : host.id.lt(lastId);
     }
 
     private Slice<Host> checkLastPage(List<Host> hosts, Pageable pageable) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
@@ -1,0 +1,49 @@
+package band.gosrock.domain.domains.host.repository;
+
+import static band.gosrock.domain.domains.host.domain.QHost.host;
+import static band.gosrock.domain.domains.host.domain.QHostUser.hostUser;
+
+import band.gosrock.domain.domains.host.domain.Host;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+@RequiredArgsConstructor
+public class HostCustomRepositoryImpl implements HostCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Host> querySliceHostByUserId(Long userId, Long lastId, Pageable pageable) {
+        List<Host> comments =
+                queryFactory
+                        .select(host)
+                        .from(host, hostUser)
+                        .where(
+                                hostUser.userId.eq(userId),
+                                host.hostUsers.contains(hostUser),
+                                lastIdLessThanEqual(lastId))
+                        .orderBy(host.id.desc())
+                        .limit(pageable.getPageSize() + 1)
+                        .fetch();
+
+        return checkLastPage(comments, pageable);
+    }
+
+    private BooleanExpression lastIdLessThanEqual(Long lastId) {
+        return lastId == null ? null : host.id.loe(lastId);
+    }
+
+    private Slice<Host> checkLastPage(List<Host> comments, Pageable pageable) {
+        boolean hasNext = false;
+        if (comments.size() > pageable.getPageSize()) {
+            hasNext = true;
+            comments.remove(pageable.getPageSize());
+        }
+        return new SliceImpl<>(comments, pageable, hasNext);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
-public interface HostRepository extends CrudRepository<Host, Long> {
+public interface HostRepository extends CrudRepository<Host, Long>, HostCustomRepository {
     List<Host> findAllByMasterUserId(Long userId);
 
     List<Host> findAllByHostUsers_UserId(Long userId);


### PR DESCRIPTION
## 개요
- close #272 

## 작업사항
- 호스트와 이벤트 조회 api 에 무한 스크롤 적용하였습니다
- SliceResponse 정의
- SliceParam 정의

```
    public SliceResponse<HostProfileResponse> execute(SliceParam sliceParam) {
        final User user = userUtils.getCurrentUser();
        final Long userId = user.getId();

        return SliceResponse.of(
                hostAdaptor
                        .querySliceHostByUserId(
                                userId, sliceParam.getLastId(), sliceParam.toPageable())
                        .map(host -> HostProfileResponse.of(host, userId)));
    }
```
- 사용은 `sliceParam.toPageable()` 메소드로 repository 에 적용해주면 됩니다

- QueryDsl Order By 적용을 위한 QueryDslUtil 구현

```
    @Override
    public Slice<Host> querySliceHostsByUserId(Long userId, Pageable pageable) {
        OrderSpecifier[] orders = QueryDslUtil.getOrderSpecifiers(Host.class, pageable);
        List<Host> comments =
                queryFactory
                        .select(host)
                        .from(host, hostUser)
                        .where(hostUser.userId.eq(userId), host.hostUsers.contains(hostUser))
                        .offset(pageable.getOffset())
                        .orderBy(orders)
                        .limit(pageable.getPageSize() + 1)
                        .fetch();

        return checkLastPage(comments, pageable);
    }
``` 
- 이런 식으로 QueryDsl 에서 OrderBy 사용하고 싶어서 유틸 클래스 정의했습니다
- 사용법은 위에 처럼 해당 엔티티 클래스와 Sort.by 적용한 pageable 넣어주면 됩니다
- 자동으로 리플렉션 해서 클래스 필드 이름과 일치하는 값이 있는지 확인하고 없으면 무시합니다

![image](https://user-images.githubusercontent.com/72291860/216284254-bcb91328-505b-442c-915a-3a34dbe65140.png)

- 호스트 조회 응답값에 초대 수락 여부 표시하는 active 필드 추가

## 변경로직
- 위와 같음