### PR TITLE
refactor : SliceParam 제거

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/slice/SliceParam.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/slice/SliceParam.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+@Deprecated
 @Getter
 @AllArgsConstructor
 public class SliceParam {

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/controller/EventController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/controller/EventController.java
@@ -1,7 +1,6 @@
 package band.gosrock.api.event.controller;
 
 
-import band.gosrock.api.common.slice.SliceParam;
 import band.gosrock.api.common.slice.SliceResponse;
 import band.gosrock.api.event.model.dto.request.CreateEventRequest;
 import band.gosrock.api.event.model.dto.request.UpdateEventBasicRequest;
@@ -18,6 +17,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.api.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @SecurityRequirement(name = "access-token")
@@ -35,18 +36,11 @@ public class EventController {
     private final UpdateEventDetailUseCase updateEventDetailUseCase;
     private final UpdateEventStatusUseCase updateEventStatusUseCase;
 
-    //    @Operation(summary = "자신이 관리 중인 이벤트 리스트를 가져옵니다.")
-    //    @GetMapping
-    //    public PageResponse<EventProfileResponse> getAllEventByUser(
-    //            @ParameterObject @PageableDefault(size = 10) Pageable pageable) {
-    //        return readUserHostEventListUseCase.execute(pageable);
-    //    }
-
     @Operation(summary = "자신이 관리 중인 이벤트 리스트를 가져옵니다.")
     @GetMapping
     public SliceResponse<EventProfileResponse> getAllEventByUser(
-            @ParameterObject SliceParam sliceParam) {
-        return readUserHostEventListUseCase.execute(sliceParam);
+            @ParameterObject @PageableDefault(size = 10) Pageable pageable) {
+        return readUserHostEventListUseCase.execute(pageable);
     }
 
     @Operation(summary = "공연 기본 정보를 등록하여, 새로운 이벤트(공연)를 생성합니다")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
@@ -1,7 +1,6 @@
 package band.gosrock.api.event.model.mapper;
 
 
-import band.gosrock.api.common.slice.SliceParam;
 import band.gosrock.api.event.model.dto.request.CreateEventRequest;
 import band.gosrock.api.event.model.dto.request.UpdateEventBasicRequest;
 import band.gosrock.api.event.model.dto.request.UpdateEventDetailRequest;
@@ -83,12 +82,10 @@ public class EventMapper {
         return eventList.map(event -> this.toEventProfileResponse(hostList, event));
     }
 
-    public Slice<EventProfileResponse> toEventProfileResponseSlice(
-            Long userId, SliceParam sliceParam) {
+    public Slice<EventProfileResponse> toEventProfileResponseSlice(Long userId, Pageable pageable) {
         List<Host> hosts = hostAdaptor.findAllByHostUsers_UserId(userId);
         List<Long> hostIds = hosts.stream().map(Host::getId).toList();
-        Slice<Event> events =
-                eventAdaptor.querySliceEventsByHostIdIn(hostIds, sliceParam.toPageable());
+        Slice<Event> events = eventAdaptor.querySliceEventsByHostIdIn(hostIds, pageable);
         return events.map(event -> this.toEventProfileResponse(hosts, event));
     }
 

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/service/ReadUserEventProfilesUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/service/ReadUserEventProfilesUseCase.java
@@ -2,13 +2,13 @@ package band.gosrock.api.event.service;
 
 
 import band.gosrock.api.common.UserUtils;
-import band.gosrock.api.common.slice.SliceParam;
 import band.gosrock.api.common.slice.SliceResponse;
 import band.gosrock.api.event.model.dto.response.EventProfileResponse;
 import band.gosrock.api.event.model.mapper.EventMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
@@ -18,9 +18,9 @@ public class ReadUserEventProfilesUseCase {
     private final UserUtils userUtils;
     private final EventMapper eventMapper;
 
-    public SliceResponse<EventProfileResponse> execute(SliceParam sliceParam) {
+    public SliceResponse<EventProfileResponse> execute(Pageable pageable) {
         final User user = userUtils.getCurrentUser();
         final Long userId = user.getId();
-        return SliceResponse.of(eventMapper.toEventProfileResponseSlice(userId, sliceParam));
+        return SliceResponse.of(eventMapper.toEventProfileResponseSlice(userId, pageable));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
@@ -2,7 +2,6 @@ package band.gosrock.api.host.controller;
 
 
 import band.gosrock.api.common.page.PageResponse;
-import band.gosrock.api.common.slice.SliceParam;
 import band.gosrock.api.common.slice.SliceResponse;
 import band.gosrock.api.host.model.dto.request.*;
 import band.gosrock.api.host.model.dto.response.HostDetailResponse;
@@ -43,8 +42,9 @@ public class HostController {
 
     @Operation(summary = "내가 속한 호스트 리스트를 가져옵니다.")
     @GetMapping
-    public SliceResponse<HostProfileResponse> getAllHosts(@ParameterObject SliceParam sliceParam) {
-        return readHostsUseCase.execute(sliceParam);
+    public SliceResponse<HostProfileResponse> getAllHosts(
+            @ParameterObject @PageableDefault(size = 10) Pageable pageable) {
+        return readHostsUseCase.execute(pageable);
     }
 
     @Operation(summary = "고유 아이디에 해당하는 호스트 정보를 가져옵니다.")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostProfilesUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostProfilesUseCase.java
@@ -2,13 +2,13 @@ package band.gosrock.api.host.service;
 
 
 import band.gosrock.api.common.UserUtils;
-import band.gosrock.api.common.slice.SliceParam;
 import band.gosrock.api.common.slice.SliceResponse;
 import band.gosrock.api.host.model.dto.response.HostProfileResponse;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
@@ -18,13 +18,13 @@ public class ReadHostProfilesUseCase {
     private final UserUtils userUtils;
     private final HostAdaptor hostAdaptor;
 
-    public SliceResponse<HostProfileResponse> execute(SliceParam sliceParam) {
+    public SliceResponse<HostProfileResponse> execute(Pageable pageable) {
         final User user = userUtils.getCurrentUser();
         final Long userId = user.getId();
 
         return SliceResponse.of(
                 hostAdaptor
-                        .querySliceHostsByUserId(userId, sliceParam.toPageable())
+                        .querySliceHostsByUserId(userId, pageable)
                         .map(host -> HostProfileResponse.of(host, userId)));
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/util/QueryDslUtil.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/util/QueryDslUtil.java
@@ -3,6 +3,8 @@ package band.gosrock.domain.common.util;
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.PathBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,5 +33,10 @@ public class QueryDslUtil {
     private static <T> Boolean hasField(Class<? extends T> type, String name) {
         return Arrays.stream(type.getDeclaredFields())
                 .anyMatch(field -> field.getName().equals(name));
+    }
+
+    public static OrderSpecifier<?> getSortedColumn(Order order, Path<?> parent, String fieldName) {
+        Path<Object> fieldPath = Expressions.path(Object.class, parent, fieldName);
+        return new OrderSpecifier(order, fieldPath);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/util/SliceUtil.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/util/SliceUtil.java
@@ -1,0 +1,26 @@
+package band.gosrock.domain.common.util;
+
+
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+public class SliceUtil {
+    // 리스트를 슬라이스로 변환
+    public static <T> Slice<T> valueOf(List<T> contents, Pageable pageable) {
+        boolean hasNext = hasNext(contents, pageable);
+        return new SliceImpl<>(
+                hasNext ? getContent(contents, pageable) : contents, pageable, hasNext);
+    }
+
+    // 다음 페이지 있는지 확인
+    private static <T> boolean hasNext(List<T> content, Pageable pageable) {
+        return pageable.isPaged() && content.size() > pageable.getPageSize();
+    }
+
+    // 데이터 1개 빼고 반환
+    private static <T> List<T> getContent(List<T> content, Pageable pageable) {
+        return content.subList(0, pageable.getPageSize());
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/EventBasicVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/EventBasicVo.java
@@ -1,6 +1,7 @@
 package band.gosrock.domain.common.vo;
 
 
+import band.gosrock.common.annotation.DateFormat;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.event.domain.EventBasic;
 import java.time.LocalDateTime;
@@ -11,7 +12,8 @@ import lombok.Getter;
 @Builder
 public class EventBasicVo {
     private String name;
-    private LocalDateTime startAt;
+    @DateFormat private LocalDateTime startAt;
+    @DateFormat private LocalDateTime endAt;
     private Long runTime;
 
     public static EventBasicVo from(Event event) {
@@ -22,6 +24,7 @@ public class EventBasicVo {
         return EventBasicVo.builder()
                 .name(eventBasic.getName())
                 .startAt(eventBasic.getStartAt())
+                .endAt(event.getEndAt())
                 .runTime(eventBasic.getRunTime())
                 .build();
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/EventProfileVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/EventProfileVo.java
@@ -1,6 +1,7 @@
 package band.gosrock.domain.common.vo;
 
 
+import band.gosrock.common.annotation.DateFormat;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.event.domain.EventStatus;
 import java.time.LocalDateTime;
@@ -16,9 +17,11 @@ public class EventProfileVo {
 
     private String name;
 
-    private LocalDateTime startAt;
+    @DateFormat private LocalDateTime startAt;
 
-    private LocalDateTime endAt;
+    @DateFormat private LocalDateTime endAt;
+
+    private Long runTime;
 
     private String placeName;
 
@@ -34,9 +37,10 @@ public class EventProfileVo {
                 .posterImage(eventDetailVo.getPosterImage())
                 .name(eventBasicVo.getName())
                 .startAt(eventBasicVo.getStartAt())
+                .endAt(event.getEndAt())
+                .runTime(eventBasicVo.getRunTime())
                 .placeName(eventPlaceVo.getPlaceName())
                 .status(event.getStatus())
-                .endAt(event.getEndAt())
                 .build();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/Event.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/Event.java
@@ -59,7 +59,7 @@ public class Event extends BaseTimeEntity {
         if (this.eventBasic == null) {
             return null;
         }
-        return this.getEventBasic().getStartAt().plusMinutes(getEventBasic().getRunTime());
+        return this.getEventBasic().endAt();
     }
 
     public Boolean hasEventBasic() {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/Event.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/Event.java
@@ -165,6 +165,11 @@ public class Event extends BaseTimeEntity {
         this.status = EventStatus.OPEN;
     }
 
+    public void calculate() {
+        // TODO : 오픈할수 있는 상태인지 검증필요함.
+        this.status = EventStatus.CALCULATING;
+    }
+
     public void close() {
         // TODO : 오픈할수 있는 상태인지 검증필요함.
         this.status = EventStatus.OPEN;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/EventBasic.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/EventBasic.java
@@ -20,6 +20,10 @@ public class EventBasic {
         return this.name != null && this.startAt != null && this.runTime != null;
     }
 
+    protected LocalDateTime endAt() {
+        return this.runTime == null ? null : this.startAt.plusMinutes(this.runTime);
+    }
+
     @Builder
     public EventBasic(String name, LocalDateTime startAt, Long runTime) {
         this.name = name;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/EventStatus.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/EventStatus.java
@@ -2,6 +2,7 @@ package band.gosrock.domain.domains.event.domain;
 
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,13 +10,19 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum EventStatus {
     // 준비중
-    PREPARING("PREPARING"),
-    // 진행중
-    OPEN("OPEN"),
-    // 종료
-    CLOSED("CLOSED");
+    PREPARING("PREPARING", "준비중"),
 
-    private final String value;
+    // 진행중
+    OPEN("OPEN", "진행중"),
+
+    // 정산중
+    CALCULATING("CALCULATING", "정산중"),
+
+    // 지난 공연
+    CLOSED("CLOSED", "지난공연");
+
+    private final String name;
+    @JsonValue private final String value;
 
     // Enum Validation 을 위한 코드, enum 에 속하지 않으면 null 리턴
     @JsonCreator

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.java
@@ -2,15 +2,13 @@ package band.gosrock.domain.domains.event.repository;
 
 import static band.gosrock.domain.domains.event.domain.QEvent.event;
 
-import band.gosrock.domain.common.util.QueryDslUtil;
+import band.gosrock.domain.common.util.SliceUtil;
 import band.gosrock.domain.domains.event.domain.Event;
-import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 
 @RequiredArgsConstructor
 public class EventCustomRepositoryImpl implements EventCustomRepository {
@@ -19,24 +17,14 @@ public class EventCustomRepositoryImpl implements EventCustomRepository {
 
     @Override
     public Slice<Event> querySliceEventsByHostIdIn(List<Long> hostId, Pageable pageable) {
-        OrderSpecifier[] orders = QueryDslUtil.getOrderSpecifiers(Event.class, pageable);
         List<Event> events =
                 queryFactory
                         .selectFrom(event)
                         .where(event.hostId.in(hostId))
-                        .orderBy(orders)
+                        .orderBy(event.id.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize() + 1)
                         .fetch();
-        return checkLastPage(events, pageable);
-    }
-
-    private Slice<Event> checkLastPage(List<Event> events, Pageable pageable) {
-        boolean hasNext = false;
-        if (events.size() > pageable.getPageSize()) {
-            hasNext = true;
-            events.remove(pageable.getPageSize());
-        }
-        return new SliceImpl<>(events, pageable, hasNext);
+        return SliceUtil.valueOf(events, pageable);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/service/EventService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/service/EventService.java
@@ -40,6 +40,7 @@ public class EventService {
         // todo :: 이벤트 상태 변경시 검증 필요
         if (status == EventStatus.OPEN) event.open();
         else if (status == EventStatus.CLOSED) event.close();
+        else if (status == EventStatus.CALCULATING) event.calculate();
         else if (status == EventStatus.PREPARING) event.prepare();
         return eventRepository.save(event);
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepositoryImpl.java
@@ -3,15 +3,13 @@ package band.gosrock.domain.domains.host.repository;
 import static band.gosrock.domain.domains.host.domain.QHost.host;
 import static band.gosrock.domain.domains.host.domain.QHostUser.hostUser;
 
-import band.gosrock.domain.common.util.QueryDslUtil;
+import band.gosrock.domain.common.util.SliceUtil;
 import band.gosrock.domain.domains.host.domain.Host;
-import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 
 @RequiredArgsConstructor
 public class HostCustomRepositoryImpl implements HostCustomRepository {
@@ -20,26 +18,16 @@ public class HostCustomRepositoryImpl implements HostCustomRepository {
 
     @Override
     public Slice<Host> querySliceHostsByUserId(Long userId, Pageable pageable) {
-        OrderSpecifier[] orders = QueryDslUtil.getOrderSpecifiers(Host.class, pageable);
-        List<Host> comments =
+        List<Host> hosts =
                 queryFactory
                         .select(host)
                         .from(host, hostUser)
                         .where(hostUser.userId.eq(userId), host.hostUsers.contains(hostUser))
                         .offset(pageable.getOffset())
-                        .orderBy(orders)
+                        .orderBy(host.id.desc())
                         .limit(pageable.getPageSize() + 1)
                         .fetch();
 
-        return checkLastPage(comments, pageable);
-    }
-
-    private Slice<Host> checkLastPage(List<Host> hosts, Pageable pageable) {
-        boolean hasNext = false;
-        if (hosts.size() > pageable.getPageSize()) {
-            hasNext = true;
-            hosts.remove(pageable.getPageSize());
-        }
-        return new SliceImpl<>(hosts, pageable, hasNext);
+        return SliceUtil.valueOf(hosts, pageable);
     }
 }


### PR DESCRIPTION
## 개요
- close #279 

## 작업사항
- SliceParam 을 Pageable 로 대체했습니다 (Deprecated)
- Host 와 Event Slice 정렬 순서를 id desc 로 다시 고정하였습니다
- 이벤트 응답 VO 에 `@DateFormat` 누락 분 적용하였습니다
- endAt 계산 시 runTime 없을 때 NullPointException 해결하였습니다

```
    @Override
    public Slice<Event> querySliceEventsByHostIdIn(List<Long> hostId, Pageable pageable) {
        List<Event> events =
                queryFactory
                        .selectFrom(event)
                        .where(event.hostId.in(hostId))
                        .orderBy(event.id.desc())
                        .offset(pageable.getOffset())
                        .limit(pageable.getPageSize() + 1)
                        .fetch();
        return SliceUtil.valueOf(events, pageable);
    }
```
- List -> Slice 바꾸는 변환 로직이 많이 중복되어서 SliceUtil.valueOf 정적 메서드 만들었습니다

`CALCULATING("CALCULATING", "정산중")`
- 이벤트 상태에 정산중을 추가했습니다

## 변경로직
- 내용을 적어주세요.