### PR TITLE
refactor : 주문 승인 후 티켓 발급 과정에서 오류시 보상트랜잭션 실행 ( 민준이 추가작업 예정 )

### DIFF
--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/adaptor/IssuedCouponAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/adaptor/IssuedCouponAdaptor.java
@@ -31,9 +31,9 @@ public class IssuedCouponAdaptor {
                         });
     }
 
-    public IssuedCoupon query(Long couponCampaignId) {
+    public IssuedCoupon query(Long issuedCouponId) {
         return issuedCouponRepository
-                .findById(couponCampaignId)
+                .findById(issuedCouponId)
                 .orElseThrow(() -> CouponNotFoundException.EXCEPTION);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/service/RecoveryCouponService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/service/RecoveryCouponService.java
@@ -13,10 +13,10 @@ public class RecoveryCouponService {
     private final IssuedCouponAdaptor issuedCouponAdaptor;
 
     @RedissonLock(LockName = "쿠폰", identifier = "couponId")
-    public Long execute(Long userId, Long couponId) {
-        IssuedCoupon coupon = issuedCouponAdaptor.query(couponId);
+    public Long execute(Long userId, Long issuedCouponId) {
+        IssuedCoupon coupon = issuedCouponAdaptor.query(issuedCouponId);
         coupon.validMine(userId);
         coupon.recovery();
-        return couponId;
+        return issuedCouponId;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/service/UseCouponService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/coupon/service/UseCouponService.java
@@ -14,10 +14,10 @@ public class UseCouponService {
     private final IssuedCouponAdaptor issuedCouponAdaptor;
 
     @RedissonLock(LockName = "쿠폰", identifier = "couponId")
-    public Long execute(Long userId, Long couponId) {
-        IssuedCoupon coupon = issuedCouponAdaptor.query(couponId);
+    public Long execute(Long userId, Long issuedCouponId) {
+        IssuedCoupon coupon = issuedCouponAdaptor.query(issuedCouponId);
         coupon.validMine(userId);
         coupon.use();
-        return couponId;
+        return issuedCouponId;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -44,14 +44,14 @@ public class IssuedTicketDomainService {
     이미 발급된 티켓 취소 로직
      */
     @RedissonLock(LockName = "티켓관리", identifier = "itemId")
-    public void doneOrderEventAfterRollBackWithdrawIssuedTickets(Long itemId,
-        String orderUuid) {
+    public void doneOrderEventAfterRollBackWithdrawIssuedTickets(Long itemId, String orderUuid) {
         List<IssuedTicket> failIssuedTickets = issuedTicketAdaptor.findAllByOrderUuid(orderUuid);
         TicketItem ticketItem = ticketItemAdaptor.queryTicketItem(itemId);
-        failIssuedTickets.forEach(issuedTicket -> {
-            ticketItem.increaseQuantity(1L);
-            issuedTicket.cancel();
-        });
+        failIssuedTickets.forEach(
+                issuedTicket -> {
+                    ticketItem.increaseQuantity(1L);
+                    issuedTicket.cancel();
+                });
     }
 
     @Transactional

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -39,6 +39,21 @@ public class IssuedTicketDomainService {
                 });
     }
 
+    /*
+    주문 승인 과정 중 티켓 아이템의 상태가 변해서 주문이 취소되는 경우
+    이미 발급된 티켓 취소 로직
+     */
+    @RedissonLock(LockName = "티켓관리", identifier = "itemId")
+    public void doneOrderEventAfterRollBackWithdrawIssuedTickets(Long itemId,
+        String orderUuid) {
+        List<IssuedTicket> failIssuedTickets = issuedTicketAdaptor.findAllByOrderUuid(orderUuid);
+        TicketItem ticketItem = ticketItemAdaptor.queryTicketItem(itemId);
+        failIssuedTickets.forEach(issuedTicket -> {
+            ticketItem.increaseQuantity(1L);
+            issuedTicket.cancel();
+        });
+    }
+
     @Transactional
     public IssuedTicketInfoVo processingEntranceIssuedTicket(
             Long eventId, Long currentUserId, Long issuedTicketId) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandler.java
@@ -5,9 +5,8 @@ import band.gosrock.domain.common.events.order.DoneOrderEvent;
 import band.gosrock.domain.domains.issuedTicket.service.IssuedTicketDomainService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
@@ -16,9 +15,7 @@ public class OrderEventHandler {
 
     private final IssuedTicketDomainService issuedTicketDomainService;
 
-    @TransactionalEventListener(
-            classes = DoneOrderEvent.class,
-            phase = TransactionPhase.BEFORE_COMMIT)
+    @EventListener(classes = DoneOrderEvent.class)
     public void handleDoneOrderEvent(DoneOrderEvent doneOrderEvent) {
         log.info(doneOrderEvent.getOrderUuid() + "주문 상태 완료, 티켓 생성작업 진행");
         issuedTicketDomainService.createIssuedTicket(

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -199,8 +199,9 @@ public class Order extends BaseTimeEntity {
     /** 결제 방식의 주문을 승인 합니다. */
     public void confirmPayment(
             LocalDateTime approvedAt, PgPaymentInfo pgPaymentInfo, OrderValidator orderValidator) {
-        Events.raise(DoneOrderEvent.from(this));
         orderValidator.validCanConfirmPayment(this);
+        Events.raise(DoneOrderEvent.from(this));
+        orderValidator.validOptionNotChangeAfterDoneOrderEvent(this);
         orderStatus = OrderStatus.CONFIRM;
         this.approvedAt = approvedAt;
         this.pgPaymentInfo = pgPaymentInfo;
@@ -208,8 +209,9 @@ public class Order extends BaseTimeEntity {
 
     /** 승인 방식의 주문을 승인합니다. */
     public void approve(OrderValidator orderValidator) {
-        Events.raise(DoneOrderEvent.from(this));
         orderValidator.validCanApproveOrder(this);
+        Events.raise(DoneOrderEvent.from(this));
+        orderValidator.validOptionNotChangeAfterDoneOrderEvent(this);
         this.approvedAt = LocalDateTime.now();
         this.orderStatus = OrderStatus.APPROVED;
     }
@@ -217,8 +219,9 @@ public class Order extends BaseTimeEntity {
     /** 선착순 방식의 0원 결제입니다. */
     public void freeConfirm(Long currentUserId, OrderValidator orderValidator) {
         orderValidator.validOwner(this, currentUserId);
-        Events.raise(DoneOrderEvent.from(this));
         orderValidator.validCanFreeConfirm(this);
+        Events.raise(DoneOrderEvent.from(this));
+        orderValidator.validOptionNotChangeAfterDoneOrderEvent(this);
         this.approvedAt = LocalDateTime.now();
         this.orderStatus = OrderStatus.APPROVED;
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -199,28 +199,28 @@ public class Order extends BaseTimeEntity {
     /** 결제 방식의 주문을 승인 합니다. */
     public void confirmPayment(
             LocalDateTime approvedAt, PgPaymentInfo pgPaymentInfo, OrderValidator orderValidator) {
+        Events.raise(DoneOrderEvent.from(this));
         orderValidator.validCanConfirmPayment(this);
         orderStatus = OrderStatus.CONFIRM;
         this.approvedAt = approvedAt;
         this.pgPaymentInfo = pgPaymentInfo;
-        Events.raise(DoneOrderEvent.from(this));
     }
 
     /** 승인 방식의 주문을 승인합니다. */
     public void approve(OrderValidator orderValidator) {
+        Events.raise(DoneOrderEvent.from(this));
         orderValidator.validCanApproveOrder(this);
         this.approvedAt = LocalDateTime.now();
         this.orderStatus = OrderStatus.APPROVED;
-        Events.raise(DoneOrderEvent.from(this));
     }
 
     /** 선착순 방식의 0원 결제입니다. */
     public void freeConfirm(Long currentUserId, OrderValidator orderValidator) {
         orderValidator.validOwner(this, currentUserId);
+        Events.raise(DoneOrderEvent.from(this));
         orderValidator.validCanFreeConfirm(this);
         this.approvedAt = LocalDateTime.now();
         this.orderStatus = OrderStatus.APPROVED;
-        Events.raise(DoneOrderEvent.from(this));
     }
 
     /** 관리자가 주문을 취소 시킵니다 */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -199,9 +199,8 @@ public class Order extends BaseTimeEntity {
     /** 결제 방식의 주문을 승인 합니다. */
     public void confirmPayment(
             LocalDateTime approvedAt, PgPaymentInfo pgPaymentInfo, OrderValidator orderValidator) {
-        orderValidator.validCanConfirmPayment(this);
         Events.raise(DoneOrderEvent.from(this));
-        orderValidator.validOptionNotChangeAfterDoneOrderEvent(this);
+        orderValidator.validCanConfirmPayment(this);
         orderStatus = OrderStatus.CONFIRM;
         this.approvedAt = approvedAt;
         this.pgPaymentInfo = pgPaymentInfo;
@@ -209,9 +208,8 @@ public class Order extends BaseTimeEntity {
 
     /** 승인 방식의 주문을 승인합니다. */
     public void approve(OrderValidator orderValidator) {
-        orderValidator.validCanApproveOrder(this);
         Events.raise(DoneOrderEvent.from(this));
-        orderValidator.validOptionNotChangeAfterDoneOrderEvent(this);
+        orderValidator.validCanApproveOrder(this);
         this.approvedAt = LocalDateTime.now();
         this.orderStatus = OrderStatus.APPROVED;
     }
@@ -219,9 +217,8 @@ public class Order extends BaseTimeEntity {
     /** 선착순 방식의 0원 결제입니다. */
     public void freeConfirm(Long currentUserId, OrderValidator orderValidator) {
         orderValidator.validOwner(this, currentUserId);
-        orderValidator.validCanFreeConfirm(this);
         Events.raise(DoneOrderEvent.from(this));
-        orderValidator.validOptionNotChangeAfterDoneOrderEvent(this);
+        orderValidator.validCanFreeConfirm(this);
         this.approvedAt = LocalDateTime.now();
         this.orderStatus = OrderStatus.APPROVED;
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/validator/OrderValidator.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/validator/OrderValidator.java
@@ -63,6 +63,7 @@ public class OrderValidator {
     /** 모든 질문지 ( 옵션그룹 )에 응답했는지 검증합니다. ( 변화 했는지 검증 ) */
     public void validOptionNotChange(Order order, TicketItem item) {
         List<OrderLineItem> orderLineItems = order.getOrderLineItems();
+
         List<Long> itemsOptionGroupIds = item.getOptionGroupIds();
         orderLineItems.forEach(
                 orderLineItem -> {
@@ -71,6 +72,11 @@ public class OrderValidator {
                         throw OrderItemOptionChangedException.EXCEPTION;
                     }
                 });
+    }
+
+    public void validOptionNotChangeAfterDoneOrderEvent(Order order) {
+        TicketItem item = getItem(order);
+        validOptionNotChange(order, item);
     }
 
     /** 승인 가능한 주문인지 검증합니다. */
@@ -107,7 +113,6 @@ public class OrderValidator {
         validStatusCanRefund(getOrderStatus(order));
         validCanWithDraw(order);
     }
-
     /** ----------------------재료가 될 검증 메서드 ---------------------------- */
 
     /** 주문을 완료할 수 있는지에 대한 공통검증 */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/handler/ConfirmOrderFailHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/handler/ConfirmOrderFailHandler.java
@@ -32,7 +32,11 @@ public class ConfirmOrderFailHandler {
 
         Order order = orderAdaptor.findByOrderUuid(doneOrderEvent.getOrderUuid());
         order.fail();
-        if (doneOrderEvent.getOrderMethod().isPayment()) {
+        // TODO : 쿠폰을 함께한 결제라면 쿠폰 원상 복구
+
+        // TODO : 티켓 취소
+
+        if (order.isPaid()) {
             log.info(
                     doneOrderEvent.getOrderUuid()
                             + ":"

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/handler/ConfirmOrderFailHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/handler/ConfirmOrderFailHandler.java
@@ -3,12 +3,10 @@ package band.gosrock.domain.domains.order.service.handler;
 
 import band.gosrock.domain.common.events.order.DoneOrderEvent;
 import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.service.IssuedTicketDomainService;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.service.WithdrawPaymentService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -41,7 +39,7 @@ public class ConfirmOrderFailHandler {
         // TODO : 쿠폰을 함께한 결제라면 쿠폰 원상 복구
 
         issuedTicketDomainService.doneOrderEventAfterRollBackWithdrawIssuedTickets(
-            doneOrderEvent.getItemId(), doneOrderEvent.getOrderUuid());
+                doneOrderEvent.getItemId(), doneOrderEvent.getOrderUuid());
 
         if (order.isPaid()) {
             log.info(

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/handler/ConfirmOrderFailHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/handler/ConfirmOrderFailHandler.java
@@ -40,10 +40,8 @@ public class ConfirmOrderFailHandler {
         order.fail();
         // TODO : 쿠폰을 함께한 결제라면 쿠폰 원상 복구
 
-        List<IssuedTicket> failIssuedTickets =
-                issuedTicketAdaptor.findAllByOrderUuid(doneOrderEvent.getOrderUuid());
-        issuedTicketDomainService.withdrawIssuedTicket(
-                doneOrderEvent.getItemId(), failIssuedTickets);
+        issuedTicketDomainService.doneOrderEventAfterRollBackWithdrawIssuedTickets(
+            doneOrderEvent.getItemId(), doneOrderEvent.getOrderUuid());
 
         if (order.isPaid()) {
             log.info(


### PR DESCRIPTION
## 개요
- close #233 

## 작업사항
- 이슈 내용대로 옵션 수정으로 인한 주문 가격이 괴리가 벌어질 상황을 원천차단하기위해
- 티켓발급이 먼저 락을 잡도록 유도하는 코드를 작성했습니다.
- 주문 쪽에서 밸리데이션 시점이 
- 티켓발급이든 옵션 수정이든 `티켓관리` 락이 수행된 이후에 작업이되므로 논리적으로 안전해졌습니다.

1. 티켓발급이 먼저수행 -> 옵션 수정 불가 상태
2. 옵션 수정이 먼저수행 -> 티켓 발급 -> 주문에서 검증시 옵션이랑 괴리발생 -> 주문 도메인 실패 -> 발급된티켓 & 쿠폰 보상 트랜잭션 실행 순 입니다.

-------

## 작업사항 - 민준
- ConfirmOrderFailHandler에 티켓 취소 로직 추가해놓았습니다.
- 기존 발급 티켓 도메인 서비스에 있던 티켓 취소 로직을 사용하려 했으나 찬진님의 조언 덕분에 티켓 쿼리 자체도 락으로 넣어서 새로운 로직을 작성했습니다.
- 쿠폰 복구 로직 작성되면 머지하면 될 것 같습니다!
- @gengminy @ImNM 

-------

## 작업사항 - 채린
- 주문 실패 시 쿠폰 복구 로직 추가했습니다.
- 이제 리뷰 시작하고 머지하면 될 것 같아용
 @gengminy @ImNM @sanbonai06   


## 변경로직
- 내용을 적어주세요.