### PR TITLE
refactor: 응원톡 랜덤 조회 쿼리 파라미터 추가 및 랜덤 쿼리 위해 nativeQuery로 리팩토링

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @SecurityRequirement(name = "access-token")
@@ -79,7 +80,8 @@ public class CommentController {
     @DisableSwaggerSecurity
     @Operation(summary = "응원글을 랜덤으로 뽑아옵니다.")
     @GetMapping(value = "/random")
-    public RetrieveRandomCommentResponse getRandomComment(@PathVariable Long eventId) {
-        return retrieveRandomCommentUseCase.execute(eventId);
+    public RetrieveRandomCommentResponse getRandomComment(
+            @PathVariable Long eventId, @RequestParam Long offset) {
+        return retrieveRandomCommentUseCase.execute(eventId, offset);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
+import javax.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -81,7 +82,8 @@ public class CommentController {
     @Operation(summary = "응원글을 랜덤으로 뽑아옵니다.")
     @GetMapping(value = "/random")
     public RetrieveRandomCommentResponse getRandomComment(
-            @PathVariable Long eventId, @RequestParam Long offset) {
-        return retrieveRandomCommentUseCase.execute(eventId, offset);
+            @PathVariable Long eventId,
+            @RequestParam @Min(value = 1, message = "limit 값은 0보다 커야 합니다.") Long limit) {
+        return retrieveRandomCommentUseCase.execute(eventId, limit);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/controller/CommentController.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "응원톡 컨트롤러")
 @RestController
 @RequestMapping("/v1/events/{eventId}/comments")
+@Validated
 @RequiredArgsConstructor
 public class CommentController {
 
@@ -83,7 +85,7 @@ public class CommentController {
     @GetMapping(value = "/random")
     public RetrieveRandomCommentResponse getRandomComment(
             @PathVariable Long eventId,
-            @RequestParam @Min(value = 1, message = "limit 값은 0보다 커야 합니다.") Long limit) {
+            @RequestParam @Min(value = 1L, message = "limit 값은 0보다 커야 합니다.") Long limit) {
         return retrieveRandomCommentUseCase.execute(eventId, limit);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/mapper/CommentMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/mapper/CommentMapper.java
@@ -13,6 +13,7 @@ import band.gosrock.domain.domains.comment.domain.Comment;
 import band.gosrock.domain.domains.comment.dto.condition.CommentCondition;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.user.domain.User;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,8 +50,8 @@ public class CommentMapper {
         return RetrieveCommentCountResponse.of(commentCount);
     }
 
-    public RetrieveRandomCommentResponse toRetrieveRandomCommentResponse(Comment comment) {
-        return RetrieveRandomCommentResponse.of(comment);
+    public RetrieveRandomCommentResponse toRetrieveRandomCommentResponse(List<Comment> comments) {
+        return RetrieveRandomCommentResponse.of(comments);
     }
 
     private RetrieveCommentDTO toRetrieveCommentDTO(Comment comment, Long currentUserId) {

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/model/response/RetrieveRandomCommentResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/model/response/RetrieveRandomCommentResponse.java
@@ -3,6 +3,7 @@ package band.gosrock.api.comment.model.response;
 
 import band.gosrock.domain.common.vo.CommentInfoVo;
 import band.gosrock.domain.domains.comment.domain.Comment;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,11 +11,11 @@ import lombok.Getter;
 @Builder
 public class RetrieveRandomCommentResponse {
 
-    private final CommentInfoVo commentInfo;
+    private final List<CommentInfoVo> commentInfos;
 
-    public static RetrieveRandomCommentResponse of(Comment comment) {
+    public static RetrieveRandomCommentResponse of(List<Comment> comments) {
         return RetrieveRandomCommentResponse.builder()
-                .commentInfo(comment.toCommentInfoVo())
+                .commentInfos(comments.stream().map(Comment::toCommentInfoVo).toList())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/RetrieveRandomCommentUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/RetrieveRandomCommentUseCase.java
@@ -23,9 +23,9 @@ public class RetrieveRandomCommentUseCase {
     private final EventAdaptor eventAdaptor;
 
     @Transactional(readOnly = true)
-    public RetrieveRandomCommentResponse execute(Long eventId, Long offset) {
+    public RetrieveRandomCommentResponse execute(Long eventId, Long limit) {
         Event event = eventAdaptor.findById(eventId);
-        List<Comment> comments = commentAdaptor.queryRandomComment(event.getId(), offset);
+        List<Comment> comments = commentAdaptor.queryRandomComment(event.getId(), limit);
         return commentMapper.toRetrieveRandomCommentResponse(comments);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/RetrieveRandomCommentUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/comment/service/RetrieveRandomCommentUseCase.java
@@ -8,6 +8,7 @@ import band.gosrock.domain.domains.comment.adaptor.CommentAdaptor;
 import band.gosrock.domain.domains.comment.domain.Comment;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.Event;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,9 +23,9 @@ public class RetrieveRandomCommentUseCase {
     private final EventAdaptor eventAdaptor;
 
     @Transactional(readOnly = true)
-    public RetrieveRandomCommentResponse execute(Long eventId) {
+    public RetrieveRandomCommentResponse execute(Long eventId, Long offset) {
         Event event = eventAdaptor.findById(eventId);
-        Comment comment = commentAdaptor.queryRandomComment(event.getId());
-        return commentMapper.toRetrieveRandomCommentResponse(comment);
+        List<Comment> comments = commentAdaptor.queryRandomComment(event.getId(), offset);
+        return commentMapper.toRetrieveRandomCommentResponse(comments);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
@@ -6,6 +6,7 @@ import band.gosrock.domain.domains.comment.domain.Comment;
 import band.gosrock.domain.domains.comment.dto.condition.CommentCondition;
 import band.gosrock.domain.domains.comment.exception.CommentNotFoundException;
 import band.gosrock.domain.domains.comment.repository.CommentRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 
@@ -33,8 +34,9 @@ public class CommentAdaptor {
         return commentRepository.countComment(eventId);
     }
 
-    public Comment queryRandomComment(Long eventId) {
+    public List<Comment> queryRandomComment(Long eventId, Long offset) {
         Long countComment = queryCommentCount(eventId);
-        return commentRepository.queryRandomComment(eventId, countComment);
+        //        return commentRepository.queryRandomComment(eventId, countComment, offset);
+        return commentRepository.findAllRandom(eventId, offset);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/adaptor/CommentAdaptor.java
@@ -34,9 +34,9 @@ public class CommentAdaptor {
         return commentRepository.countComment(eventId);
     }
 
-    public List<Comment> queryRandomComment(Long eventId, Long offset) {
+    public List<Comment> queryRandomComment(Long eventId, Long limit) {
         Long countComment = queryCommentCount(eventId);
         //        return commentRepository.queryRandomComment(eventId, countComment, offset);
-        return commentRepository.findAllRandom(eventId, offset);
+        return commentRepository.findAllRandom(eventId, limit);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepository.java
@@ -3,6 +3,7 @@ package band.gosrock.domain.domains.comment.repository;
 
 import band.gosrock.domain.domains.comment.domain.Comment;
 import band.gosrock.domain.domains.comment.dto.condition.CommentCondition;
+import java.util.List;
 import org.springframework.data.domain.Slice;
 
 public interface CommentCustomRepository {
@@ -11,5 +12,5 @@ public interface CommentCustomRepository {
 
     Long countComment(Long eventId);
 
-    Comment queryRandomComment(Long eventId, Long count);
+    List<Comment> queryRandomComment(Long eventId, Long count, Long offset);
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepository.java
@@ -3,7 +3,6 @@ package band.gosrock.domain.domains.comment.repository;
 
 import band.gosrock.domain.domains.comment.domain.Comment;
 import band.gosrock.domain.domains.comment.dto.condition.CommentCondition;
-import java.util.List;
 import org.springframework.data.domain.Slice;
 
 public interface CommentCustomRepository {
@@ -11,6 +10,4 @@ public interface CommentCustomRepository {
     Slice<Comment> searchToPage(CommentCondition commentCondition);
 
     Long countComment(Long eventId);
-
-    List<Comment> queryRandomComment(Long eventId, Long count, Long offset);
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepositoryImpl.java
@@ -7,17 +7,11 @@ import band.gosrock.domain.common.util.SliceUtil;
 import band.gosrock.domain.domains.comment.domain.Comment;
 import band.gosrock.domain.domains.comment.domain.CommentStatus;
 import band.gosrock.domain.domains.comment.dto.condition.CommentCondition;
-import band.gosrock.domain.domains.comment.exception.RetrieveRandomCommentNotFoundException;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.security.SecureRandom;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.support.PageableExecutionUtils;
 
 @RequiredArgsConstructor
 public class CommentCustomRepositoryImpl implements CommentCustomRepository {
@@ -69,34 +63,5 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                 .from(comment)
                 .where(eventIdEq(eventId), comment.commentStatus.eq(CommentStatus.ACTIVE))
                 .fetchOne();
-    }
-
-    @Override
-    public List<Comment> queryRandomComment(Long eventId, Long countComment, Long offset) {
-        SecureRandom secureRandom = new SecureRandom();
-        int idx = (int) (secureRandom.nextFloat(1) * countComment);
-
-        PageRequest pageRequest = PageRequest.of(idx, 1);
-        List<Comment> comments =
-                queryFactory
-                        .selectFrom(comment)
-                        .where(eventIdEq(eventId), comment.commentStatus.eq(CommentStatus.ACTIVE))
-                        .offset(pageRequest.getOffset())
-                        .limit(offset)
-                        .fetch();
-
-        JPAQuery<Long> countQuery =
-                queryFactory
-                        .select(comment.count())
-                        .from(comment)
-                        .where(eventIdEq(eventId), comment.commentStatus.eq(CommentStatus.ACTIVE));
-
-        Page<Comment> commentOfPage =
-                PageableExecutionUtils.getPage(comments, pageRequest, countQuery::fetchOne);
-
-        if (commentOfPage.hasContent()) {
-            return commentOfPage.getContent();
-        }
-        throw RetrieveRandomCommentNotFoundException.EXCEPTION;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentCustomRepositoryImpl.java
@@ -72,7 +72,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
     }
 
     @Override
-    public Comment queryRandomComment(Long eventId, Long countComment) {
+    public List<Comment> queryRandomComment(Long eventId, Long countComment, Long offset) {
         SecureRandom secureRandom = new SecureRandom();
         int idx = (int) (secureRandom.nextFloat(1) * countComment);
 
@@ -82,7 +82,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                         .selectFrom(comment)
                         .where(eventIdEq(eventId), comment.commentStatus.eq(CommentStatus.ACTIVE))
                         .offset(pageRequest.getOffset())
-                        .limit(1)
+                        .limit(offset)
                         .fetch();
 
         JPAQuery<Long> countQuery =
@@ -95,7 +95,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                 PageableExecutionUtils.getPage(comments, pageRequest, countQuery::fetchOne);
 
         if (commentOfPage.hasContent()) {
-            return commentOfPage.getContent().get(0);
+            return commentOfPage.getContent();
         }
         throw RetrieveRandomCommentNotFoundException.EXCEPTION;
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentRepository.java
@@ -17,5 +17,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
                             + "WHERE c.event_id = :eventId "
                             + "ORDER BY RAND() DESC "
                             + "LIMIT :offset")
-    List<Comment> findAllRandom(@Param("eventId") Long eventId, @Param("offset") Long offset);
+    List<Comment> findAllRandom(@Param("eventId") Long eventId, @Param("offset") Long limit);
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/comment/repository/CommentRepository.java
@@ -2,6 +2,20 @@ package band.gosrock.domain.domains.comment.repository;
 
 
 import band.gosrock.domain.domains.comment.domain.Comment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface CommentRepository extends JpaRepository<Comment, Long>, CommentCustomRepository {}
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentCustomRepository {
+
+    @Query(
+            nativeQuery = true,
+            value =
+                    "SELECT * "
+                            + "FROM tbl_comment as c "
+                            + "WHERE c.event_id = :eventId "
+                            + "ORDER BY RAND() DESC "
+                            + "LIMIT :offset")
+    List<Comment> findAllRandom(@Param("eventId") Long eventId, @Param("offset") Long offset);
+}


### PR DESCRIPTION
## 개요
- close #311 

## 작업사항
- 기존 로직에서는 응원톡 랜덤 조회 시 쿼리파라미터를 받지 않고 1개로 고정이었으나 쿼리파라미터를 통해 원하는 갯수 만큼 랜덤으로 가져오도록 리팩토링 했습니다.
- 여러 개의 레코드를 랜덤으로 가져오는 로직을 짜기 위해선 기존의 QueryDsl 로직으로는 불가능하여 native query를 이용하였습니다.

## 변경로직
- 내용을 적어주세요.