### PR TITLE
refactor : 호스트 및 이벤트 길이 제한 추가

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/model/dto/request/CreateEventRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/model/dto/request/CreateEventRequest.java
@@ -9,6 +9,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @RequiredArgsConstructor
@@ -19,6 +20,7 @@ public class CreateEventRequest {
 
     @Schema(defaultValue = "고스락 제 22회 정기공연", description = "공연 이름")
     @NotBlank(message = "공연 이름을 입력하세요")
+    @Length(max = 25)
     private String name;
 
     @Schema(

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/model/dto/request/UpdateEventBasicRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/model/dto/request/UpdateEventBasicRequest.java
@@ -9,12 +9,14 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @RequiredArgsConstructor
 public class UpdateEventBasicRequest {
     @Schema(defaultValue = "고스락 제 22회 정기공연", description = "공연 이름")
     @NotBlank(message = "공연 이름을 입력하세요")
+    @Length(max = 25)
     private String name;
 
     @Schema(

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/CreateHostRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/CreateHostRequest.java
@@ -4,16 +4,18 @@ package band.gosrock.api.host.model.dto.request;
 import band.gosrock.common.annotation.Phone;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Email;
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 /** 호스트 간편 생성 요청 DTO */
 @Getter
 @RequiredArgsConstructor
 public class CreateHostRequest {
     @Schema(defaultValue = "고스락", description = "호스트 이름")
-    @NotEmpty(message = "호스트 이름을 입력해주세요")
+    @NotBlank(message = "호스트 이름을 입력해주세요")
+    @Length(max = 15)
     private String name;
 
     @Schema(defaultValue = "gosrock@gsrk.com", description = "마스터 이메일")

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/EventBasic.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/EventBasic.java
@@ -2,6 +2,7 @@ package band.gosrock.domain.domains.event.domain;
 
 
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,7 +13,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventBasic {
+    @Column(length = 25)
     private String name;
+
     private LocalDateTime startAt;
     private Long runTime;
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostProfile.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostProfile.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HostProfile {
     // 호스트 이름
+    @Column(length = 15)
     private String name;
 
     // 간단 소개


### PR DESCRIPTION
## 개요
- close #318 

## 작업사항
- 호스트 15자 이벤트 25자 엔티티 제약조건 추가
- 생성 및 업데이트 요청 DTO 에 길이 검증 추가

## 변경로직
- 위와 같음.