### PR TITLE
refactor : 이벤트 오픈 api 분리

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/controller/EventController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/controller/EventController.java
@@ -36,6 +36,7 @@ public class EventController {
     private final UpdateEventBasicUseCase updateEventBasicUseCase;
     private final UpdateEventDetailUseCase updateEventDetailUseCase;
     private final UpdateEventStatusUseCase updateEventStatusUseCase;
+    private final OpenEventUseCase openEventStatusUseCase;
 
     @Operation(summary = "자신이 관리 중인 이벤트 리스트를 가져옵니다.")
     @GetMapping
@@ -79,7 +80,13 @@ public class EventController {
         return updateEventDetailUseCase.execute(eventId, updateEventDetailRequest);
     }
 
-    @Operation(summary = "공연 상태를 변경합니다.")
+    @Operation(summary = "공연을 오픈 상태로 변경합니다. 모든 체크리스트를 달성해야 합니다.")
+    @PatchMapping("/{eventId}/open")
+    public EventResponse updateEventStatus(@PathVariable Long eventId) {
+        return openEventStatusUseCase.execute(eventId);
+    }
+
+    @Operation(summary = "공연 상태를 변경합니다. (OPEN 제외)")
     @PatchMapping("/{eventId}/status")
     public EventResponse updateEventStatus(
             @PathVariable Long eventId,

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/service/OpenEventUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/service/OpenEventUseCase.java
@@ -9,7 +9,6 @@ import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.event.service.EventService;
-import band.gosrock.domain.domains.ticket_item.service.TicketItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,16 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class OpenEventUseCase {
     private final EventService eventService;
     private final EventAdaptor eventAdaptor;
-    private final TicketItemService ticketItemService;
 
     @Transactional
     @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID)
     public EventResponse execute(Long eventId) {
         final Event event = eventAdaptor.findById(eventId);
-        eventService.validateEventBasicExistence(event);
-        eventService.validateEventDetailExistence(event);
-        ticketItemService.validateExistenceByEventId(eventId);
-
         return EventResponse.of(eventService.openEvent(event));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/service/OpenEventUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/service/OpenEventUseCase.java
@@ -8,9 +8,8 @@ import band.gosrock.api.event.model.dto.response.EventResponse;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.Event;
-import band.gosrock.domain.domains.event.exception.CannotOpenEventException;
 import band.gosrock.domain.domains.event.service.EventService;
-import band.gosrock.domain.domains.ticket_item.adaptor.TicketItemAdaptor;
+import band.gosrock.domain.domains.ticket_item.service.TicketItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,19 +18,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class OpenEventUseCase {
     private final EventService eventService;
     private final EventAdaptor eventAdaptor;
-    private final TicketItemAdaptor ticketItemAdaptor;
+    private final TicketItemService ticketItemService;
 
     @Transactional
     @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID)
     public EventResponse execute(Long eventId) {
         final Event event = eventAdaptor.findById(eventId);
-        final Boolean hasBasic = event.hasEventBasic() && event.hasEventPlace();
-        final Boolean hasDetail = event.hasEventDetail();
-        final Boolean hasTicketItem = ticketItemAdaptor.existsByEventId(event.getId());
-        if (hasBasic && hasDetail && hasTicketItem) {
-            return EventResponse.of(eventService.openEvent(event));
-        }
-        // 체크리스트를 달성하지 않으면 이벤트를 열 수 없음
-        throw CannotOpenEventException.EXCEPTION;
+        eventService.validateEventBasicExistence(event);
+        eventService.validateEventDetailExistence(event);
+        ticketItemService.validateExistenceByEventId(eventId);
+
+        return EventResponse.of(eventService.openEvent(event));
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/service/OpenEventUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/service/OpenEventUseCase.java
@@ -1,0 +1,37 @@
+package band.gosrock.api.event.service;
+
+import static band.gosrock.api.common.aop.hostRole.FindHostFrom.EVENT_ID;
+import static band.gosrock.api.common.aop.hostRole.HostQualification.MANAGER;
+
+import band.gosrock.api.common.aop.hostRole.HostRolesAllowed;
+import band.gosrock.api.event.model.dto.response.EventResponse;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
+import band.gosrock.domain.domains.event.domain.Event;
+import band.gosrock.domain.domains.event.exception.CannotOpenEventException;
+import band.gosrock.domain.domains.event.service.EventService;
+import band.gosrock.domain.domains.ticket_item.adaptor.TicketItemAdaptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class OpenEventUseCase {
+    private final EventService eventService;
+    private final EventAdaptor eventAdaptor;
+    private final TicketItemAdaptor ticketItemAdaptor;
+
+    @Transactional
+    @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID)
+    public EventResponse execute(Long eventId) {
+        final Event event = eventAdaptor.findById(eventId);
+        final Boolean hasBasic = event.hasEventBasic() && event.hasEventPlace();
+        final Boolean hasDetail = event.hasEventDetail();
+        final Boolean hasTicketItem = ticketItemAdaptor.existsByEventId(event.getId());
+        if (hasBasic && hasDetail && hasTicketItem) {
+            return EventResponse.of(eventService.openEvent(event));
+        }
+        // 체크리스트를 달성하지 않으면 이벤트를 열 수 없음
+        throw CannotOpenEventException.EXCEPTION;
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/Event.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/Event.java
@@ -3,10 +3,7 @@ package band.gosrock.domain.domains.event.domain;
 
 import band.gosrock.domain.common.model.BaseTimeEntity;
 import band.gosrock.domain.common.vo.*;
-import band.gosrock.domain.domains.event.exception.CannotModifyEventBasicException;
-import band.gosrock.domain.domains.event.exception.EventCannotEndBeforeStartException;
-import band.gosrock.domain.domains.event.exception.EventNotOpenException;
-import band.gosrock.domain.domains.event.exception.EventTicketingTimeIsPassedException;
+import band.gosrock.domain.domains.event.exception.*;
 import java.time.LocalDateTime;
 import javax.persistence.*;
 import lombok.AccessLevel;
@@ -156,22 +153,23 @@ public class Event extends BaseTimeEntity {
     }
 
     public void prepare() {
-        // TODO : 오픈할수 있는 상태인지 검증필요함.
+        if (this.status == EventStatus.PREPARING) throw AlreadyPreparingStatusException.EXCEPTION;
         this.status = EventStatus.PREPARING;
     }
 
     public void open() {
-        // TODO : 오픈할수 있는 상태인지 검증필요함.
+        if (this.status == EventStatus.OPEN) throw AlreadyOpenStatusException.EXCEPTION;
         this.status = EventStatus.OPEN;
     }
 
     public void calculate() {
-        // TODO : 오픈할수 있는 상태인지 검증필요함.
+        if (this.status == EventStatus.CALCULATING)
+            throw AlreadyCalculatingStatusException.EXCEPTION;
         this.status = EventStatus.CALCULATING;
     }
 
     public void close() {
-        // TODO : 오픈할수 있는 상태인지 검증필요함.
-        this.status = EventStatus.OPEN;
+        if (this.status == EventStatus.CLOSED) throw AlreadyCloseStatusException.EXCEPTION;
+        this.status = EventStatus.CLOSED;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/AlreadyCalculatingStatusException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/AlreadyCalculatingStatusException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.event.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class AlreadyCalculatingStatusException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new AlreadyCalculatingStatusException();
+
+    private AlreadyCalculatingStatusException() {
+        super(EventErrorCode.ALREADY_CALCULATING_STATUS);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/AlreadyCloseStatusException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/AlreadyCloseStatusException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.event.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class AlreadyCloseStatusException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new AlreadyCloseStatusException();
+
+    private AlreadyCloseStatusException() {
+        super(EventErrorCode.ALREADY_CLOSE_STATUS);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/AlreadyOpenStatusException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/AlreadyOpenStatusException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.event.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class AlreadyOpenStatusException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new AlreadyOpenStatusException();
+
+    private AlreadyOpenStatusException() {
+        super(EventErrorCode.ALREADY_OPEN_STATUS);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/AlreadyPreparingStatusException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/AlreadyPreparingStatusException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.event.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class AlreadyPreparingStatusException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new AlreadyPreparingStatusException();
+
+    private AlreadyPreparingStatusException() {
+        super(EventErrorCode.ALREADY_PREPARING_STATUS);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/CannotOpenEventException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/CannotOpenEventException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.event.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class CannotOpenEventException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new CannotOpenEventException();
+
+    private CannotOpenEventException() {
+        super(EventErrorCode.CANNOT_OPEN_EVENT);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/EventErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/EventErrorCode.java
@@ -15,14 +15,21 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum EventErrorCode implements BaseErrorCode {
     EVENT_NOT_FOUND(NOT_FOUND, "Event_404_1", "이벤트를 찾을 수 없습니다."),
+
     HOST_NOT_AUTH_EVENT(BAD_REQUEST, "Event_400_1", "Host Not Auth Event."),
-
     EVENT_CANNOT_END_BEFORE_START(BAD_REQUEST, "Event_400_2", "시작 시각은 종료 시각보다 빨라야 합니다."),
-
     EVENT_URL_NAME_ALREADY_EXIST(BAD_REQUEST, "Event_400_3", "중복된 URL 표시 이름입니다."),
     CANNOT_MODIFY_EVENT_BASIC(BAD_REQUEST, "Event_400_4", "이벤트 기본 정보는 수정할 수 없습니다."),
     EVENT_NOT_OPEN(BAD_REQUEST, "Event_400_5", "아직 오픈되지 않은 이벤트에는 접근할 수 없습니다."),
-    EVENT_TICKETING_TIME_IS_PASSED(BAD_REQUEST, "Event_400_6", "이벤트 시작시간이 지나 티켓팅을 할 수 없습니다.");
+    EVENT_TICKETING_TIME_IS_PASSED(BAD_REQUEST, "Event_400_6", "이벤트 시작시간이 지나 티켓팅을 할 수 없습니다."),
+    CANNOT_OPEN_EVENT(BAD_REQUEST, "Event_400_7", "이벤트 오픈 조건을 충족하지 않았습니다."),
+    ALREADY_OPEN_STATUS(BAD_REQUEST, "Event_400_8", "이미 오픈 중인 이벤트입니다."),
+    ALREADY_CALCULATING_STATUS(BAD_REQUEST, "Event_400_9", "이미 정산중인 이벤트입니다."),
+    ALREADY_CLOSE_STATUS(BAD_REQUEST, "Event_400_10", "이미 닫은 이벤트입니다."),
+    ALREADY_PREPARING_STATUS(BAD_REQUEST, "Event_400_11", "이미 준비중인 이벤트입니다."),
+
+    USE_OTHER_API(BAD_REQUEST, "Event_400_8", "잘못된 접근입니다.");
+
     private Integer status;
     private String code;
     private String reason;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/UseOtherApiException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/exception/UseOtherApiException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.event.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class UseOtherApiException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new UseOtherApiException();
+
+    private UseOtherApiException() {
+        super(EventErrorCode.USE_OTHER_API);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/service/EventService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/service/EventService.java
@@ -4,6 +4,7 @@ package band.gosrock.domain.domains.event.service;
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.*;
+import band.gosrock.domain.domains.event.exception.CannotOpenEventException;
 import band.gosrock.domain.domains.event.exception.UseOtherApiException;
 import band.gosrock.domain.domains.event.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,18 @@ public class EventService {
         return eventRepository.save(event);
     }
 
+    public void validateEventBasicExistence(Event event) {
+        if (!event.hasEventBasic() || !event.hasEventPlace()) {
+            throw CannotOpenEventException.EXCEPTION;
+        }
+    }
+
+    public void validateEventDetailExistence(Event event) {
+        if (!event.hasEventDetail()) {
+            throw CannotOpenEventException.EXCEPTION;
+        }
+    }
+
     public Event openEvent(Event event) {
         event.open();
         return eventRepository.save(event);
@@ -44,9 +57,7 @@ public class EventService {
     public Event updateEventStatus(Event event, EventStatus status) {
         if (status == EventStatus.OPEN) {
             throw UseOtherApiException.EXCEPTION; // open 은 다른 API 강제
-        }
-        // todo :: 이벤트 상태 변경시 검증 필요
-        else if (status == EventStatus.CLOSED) event.close();
+        } else if (status == EventStatus.CLOSED) event.close();
         else if (status == EventStatus.CALCULATING) event.calculate();
         else if (status == EventStatus.PREPARING) event.prepare();
         return eventRepository.save(event);

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/service/EventService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/service/EventService.java
@@ -4,7 +4,7 @@ package band.gosrock.domain.domains.event.service;
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.*;
-import band.gosrock.domain.domains.event.exception.HostNotAuthEventException;
+import band.gosrock.domain.domains.event.exception.UseOtherApiException;
 import band.gosrock.domain.domains.event.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,19 +36,19 @@ public class EventService {
         return eventRepository.save(event);
     }
 
+    public Event openEvent(Event event) {
+        event.open();
+        return eventRepository.save(event);
+    }
+
     public Event updateEventStatus(Event event, EventStatus status) {
+        if (status == EventStatus.OPEN) {
+            throw UseOtherApiException.EXCEPTION; // open 은 다른 API 강제
+        }
         // todo :: 이벤트 상태 변경시 검증 필요
-        if (status == EventStatus.OPEN) event.open();
         else if (status == EventStatus.CLOSED) event.close();
         else if (status == EventStatus.CALCULATING) event.calculate();
         else if (status == EventStatus.PREPARING) event.prepare();
         return eventRepository.save(event);
-    }
-
-    public void checkEventHost(Long hostId, Long eventId) {
-        Event event = eventAdaptor.findById(eventId);
-        if (!event.getHostId().equals(hostId)) {
-            throw HostNotAuthEventException.EXCEPTION;
-        }
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/service/EventService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/service/EventService.java
@@ -7,6 +7,7 @@ import band.gosrock.domain.domains.event.domain.*;
 import band.gosrock.domain.domains.event.exception.CannotOpenEventException;
 import band.gosrock.domain.domains.event.exception.UseOtherApiException;
 import band.gosrock.domain.domains.event.repository.EventRepository;
+import band.gosrock.domain.domains.ticket_item.service.TicketItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class EventService {
     private final EventRepository eventRepository;
     private final EventAdaptor eventAdaptor;
+    private final TicketItemService ticketItemService;
 
     public Event createEvent(Event event) {
         return eventRepository.save(event);
@@ -50,6 +52,9 @@ public class EventService {
     }
 
     public Event openEvent(Event event) {
+        this.validateEventBasicExistence(event);
+        this.validateEventDetailExistence(event);
+        ticketItemService.validateExistenceByEventId(event.getId());
         event.open();
         return eventRepository.save(event);
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/service/TicketItemService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/ticket_item/service/TicketItemService.java
@@ -5,6 +5,7 @@ import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.common.aop.redissonLock.RedissonLock;
 import band.gosrock.domain.domains.ticket_item.adaptor.TicketItemAdaptor;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.ticket_item.exception.InvalidTicketItemException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,12 @@ public class TicketItemService {
             ticketItem.validateTicketPrice();
         }
         return ticketItemAdaptor.save(ticketItem);
+    }
+
+    public void validateExistenceByEventId(Long eventId) {
+        if (!ticketItemAdaptor.existsByEventId(eventId)) {
+            throw InvalidTicketItemException.EXCEPTION;
+        }
     }
 
     @RedissonLock(LockName = "티켓관리", identifier = "ticketItemId")


### PR DESCRIPTION
## 개요
- close #301 

## 작업사항
- 이벤트 오픈 요청 시 이벤트 체크리스트를 달성해야 열리도록 검증 로직 추가했습니다
- 이벤트 status 변경과 이벤트 open API 를 분리했습니다
- 각 status 별 이미 있는 상태값에 대해 중복 요청 시 예외 처리를 추가했습니다

## 변경로직
- 내용을 적어주세요.