### PR TITLE
refactor : 카카오 회원가입시 실제 이름 우선 후 없으면 프로필 이름 불러오기

### DIFF
--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/oauth/dto/KakaoInformationResponse.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/oauth/dto/KakaoInformationResponse.java
@@ -58,7 +58,7 @@ public class KakaoInformationResponse {
     }
 
     public String getName() {
-        return kakaoAccount.getName();
+        return kakaoAccount.getName() != null ? kakaoAccount.getName() : properties.getNickname();
     }
 
     public String getProfileUrl() {


### PR DESCRIPTION
## 개요
- close #314 

## 작업사항
- 제목과 같습니다.
- 동의 항목에 프로필은 고정인데
- 이름을 추가 요청 받습니다.
- 해당 부분 이름 우선시 이후 프로필 이름 우선시로 처리했습니다


## 변경로직
- 내용을 적어주세요.