### PR TITLE
refactor : 전화번호  libphonenumber 적용

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/UserUtils.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/UserUtils.java
@@ -17,7 +17,6 @@ public class UserUtils {
     }
 
     public User getCurrentUser() {
-        User user = userAdaptor.queryUser(getCurrentUserId());
-        return user;
+        return userAdaptor.queryUser(getCurrentUserId());
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/util/PhoneNumberInstance.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/util/PhoneNumberInstance.java
@@ -1,0 +1,7 @@
+package band.gosrock.domain.common.util;
+
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+
+public class PhoneNumberInstance {
+    public static final PhoneNumberUtil instance = PhoneNumberUtil.getInstance();
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/util/PhoneNumberInstance.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/util/PhoneNumberInstance.java
@@ -1,5 +1,6 @@
 package band.gosrock.domain.common.util;
 
+
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 
 public class PhoneNumberInstance {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/PhoneNumberVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/PhoneNumberVo.java
@@ -1,0 +1,69 @@
+package band.gosrock.domain.common.vo;
+
+
+import band.gosrock.domain.common.util.PhoneNumberInstance;
+import com.google.i18n.phonenumbers.NumberParseException;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberFormat;
+import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PhoneNumberVo {
+
+    // +1
+    private String countryCode;
+    // 2015550123
+    private String nationalNumber;
+
+    @Builder
+    public PhoneNumberVo(String countryCode, String nationalNumber) {
+        this.countryCode = countryCode;
+        this.nationalNumber = nationalNumber;
+    }
+
+    public PhoneNumberVo valueOf(String rawPhoneNumber) throws NumberParseException {
+        PhoneNumberUtil instance = PhoneNumberInstance.instance;
+        PhoneNumber phoneNumber = instance.parse(rawPhoneNumber, "KR");
+
+        return PhoneNumberVo.builder().nationalNumber(
+            String.valueOf(phoneNumber.getNationalNumber())).countryCode(
+            String.valueOf(phoneNumber.getCountryCode())).build();
+    }
+
+    public String getNumberToParse() {
+        return countryCode + " " + nationalNumber;
+    }
+
+    /**
+     * 010-xxxx-xxxx format
+     */
+    public String getNationalFormat() throws NumberParseException {
+        PhoneNumberUtil instance = PhoneNumberInstance.instance;
+        PhoneNumber phoneNumber = instance.parse(getNumberToParse(), "KR");
+        return instance.format(phoneNumber, PhoneNumberFormat.NATIONAL);
+    }
+
+    /**
+     * +82 10-xxxx-xxxx format
+     */
+    public String getInternationalFormat() throws NumberParseException {
+        PhoneNumberUtil instance = PhoneNumberInstance.instance;
+        PhoneNumber phoneNumber = instance.parse(getNumberToParse(), "KR");
+        return instance.format(phoneNumber, PhoneNumberFormat.INTERNATIONAL);
+    }
+
+    /**
+     * 01000000000 format
+     */
+    public String getNaverSmsToNumber() throws NumberParseException {
+        String nationalFormat = this.getNationalFormat();
+        return nationalFormat.replaceAll("-","");
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/PhoneNumberVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/PhoneNumberVo.java
@@ -32,38 +32,33 @@ public class PhoneNumberVo {
         PhoneNumberUtil instance = PhoneNumberInstance.instance;
         PhoneNumber phoneNumber = instance.parse(rawPhoneNumber, "KR");
 
-        return PhoneNumberVo.builder().nationalNumber(
-            String.valueOf(phoneNumber.getNationalNumber())).countryCode(
-            String.valueOf(phoneNumber.getCountryCode())).build();
+        return PhoneNumberVo.builder()
+                .nationalNumber(String.valueOf(phoneNumber.getNationalNumber()))
+                .countryCode(String.valueOf(phoneNumber.getCountryCode()))
+                .build();
     }
 
     public String getNumberToParse() {
         return countryCode + " " + nationalNumber;
     }
 
-    /**
-     * 010-xxxx-xxxx format
-     */
+    /** 010-xxxx-xxxx format */
     public String getNationalFormat() throws NumberParseException {
         PhoneNumberUtil instance = PhoneNumberInstance.instance;
         PhoneNumber phoneNumber = instance.parse(getNumberToParse(), "KR");
         return instance.format(phoneNumber, PhoneNumberFormat.NATIONAL);
     }
 
-    /**
-     * +82 10-xxxx-xxxx format
-     */
+    /** +82 10-xxxx-xxxx format */
     public String getInternationalFormat() throws NumberParseException {
         PhoneNumberUtil instance = PhoneNumberInstance.instance;
         PhoneNumber phoneNumber = instance.parse(getNumberToParse(), "KR");
         return instance.format(phoneNumber, PhoneNumberFormat.INTERNATIONAL);
     }
 
-    /**
-     * 01000000000 format
-     */
+    /** 01000000000 format */
     public String getNaverSmsToNumber() throws NumberParseException {
         String nationalFormat = this.getNationalFormat();
-        return nationalFormat.replaceAll("-","");
+        return nationalFormat.replaceAll("-", "");
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/UserInfoVo.java
@@ -16,7 +16,7 @@ public class UserInfoVo {
 
     private final String email;
 
-    private final String phoneNumber;
+    private final PhoneNumberVo phoneNumber;
 
     private final ImageVo profileImage;
 
@@ -28,7 +28,7 @@ public class UserInfoVo {
                 .userName(user.getProfile().getName())
                 .email(user.getProfile().getEmail())
                 .profileImage(user.getProfile().getProfileImage())
-                .phoneNumber(user.getProfile().getPhoneNumber())
+                .phoneNumber(user.getProfile().getPhoneNumberVo())
                 .createdAt(user.getCreatedAt())
                 .build();
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketUserInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketUserInfoVo.java
@@ -1,6 +1,7 @@
 package band.gosrock.domain.domains.issuedTicket.domain;
 
 
+import band.gosrock.domain.common.vo.PhoneNumberVo;
 import band.gosrock.domain.domains.user.domain.User;
 import javax.persistence.Embeddable;
 import lombok.Builder;
@@ -16,10 +17,10 @@ public class IssuedTicketUserInfoVo {
 
     private String userName;
 
-    private String phoneNumber;
+    private PhoneNumberVo phoneNumber;
 
     @Builder
-    public IssuedTicketUserInfoVo(Long userId, String userName, String phoneNumber) {
+    public IssuedTicketUserInfoVo(Long userId, String userName, PhoneNumberVo phoneNumber) {
         this.userId = userId;
         this.userName = userName;
         this.phoneNumber = phoneNumber;
@@ -29,7 +30,7 @@ public class IssuedTicketUserInfoVo {
         return IssuedTicketUserInfoVo.builder()
                 .userId(user.getId())
                 .userName(user.getProfile().getName())
-                .phoneNumber(user.getProfile().getPhoneNumber())
+                .phoneNumber(user.getProfile().getPhoneNumberVo())
                 .build();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/repository/IssuedTicketCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/repository/IssuedTicketCustomRepositoryImpl.java
@@ -94,7 +94,9 @@ public class IssuedTicketCustomRepositoryImpl implements IssuedTicketCustomRepos
     }
 
     private BooleanExpression phoneNumberContains(String phoneNumber) {
-        return phoneNumber == null ? null : issuedTicket.userInfo.phoneNumber.contains(phoneNumber);
+        return phoneNumber == null
+                ? null
+                : issuedTicket.userInfo.phoneNumber.phoneNumber.contains(phoneNumber);
     }
 
     private BooleanExpression issuedTicketStatusNotCanceled() {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/repository/condition/AdminTableSearchType.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/repository/condition/AdminTableSearchType.java
@@ -7,7 +7,8 @@ import java.util.function.Function;
 
 /** 어드민 테이블의 검색어 지정 ( 전화번호 이름 검색 ) 을 지원하기 위함. */
 public enum AdminTableSearchType {
-    PHONE(user.profile.phoneNumber::contains),
+    // 검색 형식은 지원... 저장 형식이 이럼 xxxx-xxxx
+    PHONE(user.profile.phoneNumberVo.phoneNumber::contains),
     NAME(user.profile.name::contains);
 
     private final Function<String, BooleanExpression> expression;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/Profile.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/Profile.java
@@ -2,6 +2,7 @@ package band.gosrock.domain.domains.user.domain;
 
 
 import band.gosrock.domain.common.vo.ImageVo;
+import band.gosrock.domain.common.vo.PhoneNumberVo;
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
 import lombok.AccessLevel;
@@ -16,14 +17,14 @@ public class Profile {
     private String name;
     private String email;
 
-    private String phoneNumber;
+    @Embedded private PhoneNumberVo phoneNumberVo;
     @Embedded private ImageVo profileImage;
 
     @Builder
     public Profile(String name, String email, String phoneNumber, String profileImage) {
         this.name = name;
         this.email = email;
-        this.phoneNumber = phoneNumber;
+        this.phoneNumberVo = PhoneNumberVo.valueOf(phoneNumber);
         this.profileImage = ImageVo.valueOf(profileImage);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/exception/UserErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/exception/UserErrorCode.java
@@ -22,7 +22,8 @@ public enum UserErrorCode implements BaseErrorCode {
     @ExplainError("탈퇴한 유저로 접근하려는 경우")
     USER_ALREADY_DELETED(FORBIDDEN, "USER_403_2", "이미 지워진 유저입니다."),
     @ExplainError("유저 정보를 찾을 수 없는 경우")
-    USER_NOT_FOUND(NOT_FOUND, "USER_404_1", "유저 정보를 찾을 수 없습니다.");
+    USER_NOT_FOUND(NOT_FOUND, "USER_404_1", "유저 정보를 찾을 수 없습니다."),
+    USER_PHONE_INVALID(BAD_REQUEST, "USER_400_2", "유저의 휴대폰 전화번호가 올바르지않습니다. 두둥 관리자에게 문의주세요");
 
     private Integer status;
     private String code;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/exception/UserPhoneNumberInvalidException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/exception/UserPhoneNumberInvalidException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.user.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class UserPhoneNumberInvalidException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new UserPhoneNumberInvalidException();
+
+    private UserPhoneNumberInvalidException() {
+        super(UserErrorCode.USER_PHONE_INVALID);
+    }
+}

--- a/DuDoong-Infrastructure/build.gradle
+++ b/DuDoong-Infrastructure/build.gradle
@@ -17,4 +17,6 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-thymeleaf'
     api 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
     api group: 'software.amazon.awssdk', name: 'ses', version: "2.19.29"
+
+    api 'com.googlecode.libphonenumber:libphonenumber:8.13.5'
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/oauth/dto/KakaoInformationResponse.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/oauth/dto/KakaoInformationResponse.java
@@ -3,6 +3,10 @@ package band.gosrock.infrastructure.outer.api.oauth.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.google.i18n.phonenumbers.NumberParseException;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberFormat;
+import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -63,5 +67,26 @@ public class KakaoInformationResponse {
 
     public String getProfileUrl() {
         return kakaoAccount.getProfileImageUrl();
+    }
+
+    public static void main(String[] args) throws NumberParseException {
+        String s = "82 10-9476-8640";
+        PhoneNumberUtil instance = PhoneNumberUtil.getInstance();
+
+        PhoneNumber phoneNumber = instance.parseAndKeepRawInput(s,"KR");
+        System.out.println(instance.getExampleNumber("US"));
+
+        System.out.println(phoneNumber.getCountryCode());
+        System.out.println(phoneNumber.getNationalNumber());
+        System.out.println(phoneNumber.getCountryCodeSource());
+        System.out.println(phoneNumber.getExtension());
+        System.out.println(phoneNumber.getNumberOfLeadingZeros());
+        System.out.println(phoneNumber.getCountryCode());
+        System.out.println(phoneNumber.getPreferredDomesticCarrierCode());
+//        PhoneNumberUtil.
+        String format = instance.format(phoneNumber, PhoneNumberFormat.NATIONAL);
+        System.out.println(format);
+
+//        PhoneNumber p  =instance.
     }
 }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/oauth/dto/KakaoInformationResponse.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/outer/api/oauth/dto/KakaoInformationResponse.java
@@ -3,10 +3,6 @@ package band.gosrock.infrastructure.outer.api.oauth.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.google.i18n.phonenumbers.NumberParseException;
-import com.google.i18n.phonenumbers.PhoneNumberUtil;
-import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberFormat;
-import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -67,26 +63,5 @@ public class KakaoInformationResponse {
 
     public String getProfileUrl() {
         return kakaoAccount.getProfileImageUrl();
-    }
-
-    public static void main(String[] args) throws NumberParseException {
-        String s = "82 10-9476-8640";
-        PhoneNumberUtil instance = PhoneNumberUtil.getInstance();
-
-        PhoneNumber phoneNumber = instance.parseAndKeepRawInput(s,"KR");
-        System.out.println(instance.getExampleNumber("US"));
-
-        System.out.println(phoneNumber.getCountryCode());
-        System.out.println(phoneNumber.getNationalNumber());
-        System.out.println(phoneNumber.getCountryCodeSource());
-        System.out.println(phoneNumber.getExtension());
-        System.out.println(phoneNumber.getNumberOfLeadingZeros());
-        System.out.println(phoneNumber.getCountryCode());
-        System.out.println(phoneNumber.getPreferredDomesticCarrierCode());
-//        PhoneNumberUtil.
-        String format = instance.format(phoneNumber, PhoneNumberFormat.NATIONAL);
-        System.out.println(format);
-
-//        PhoneNumber p  =instance.
     }
 }


### PR DESCRIPTION
## 개요
- close #326 

## 작업사항
- 카카오톡에서 넘겨주는 전화번호 형식은 libphonenumber 패키지를 사용한 형식입니다
- 국제전화번호횽식
- 공식 문서에도 위 모듈 참고하라고 적혀있더라고요

- https://github.com/google/libphonenumber

PhoneNumberVo 만들었고
해당 vo로 리턴하면 JsonValue로 010-xxxx-xxxx 형식으로 내려줍니다.
```json
{
  "success": true,
  "status": 200,
  "data": {
    "userId": 24,
    "userName": "ddd",
    "email": "asdfasdf@naver.com",
    "phoneNumber": "010-xxxx-xxxx",
    "profileImage": "http://k.kakaocdn.net/dn/QPtC7/btqX09yP4mb/asdfasdf/img_640x640.jpg",
    "createdAt": "2023-02-09T02:42:19"
  },
  "timeStamp": "2023-02-09T02:42:37.442277"
}

```


## 변경로직
- 내용을 적어주세요.