### PR TITLE
feat : 발급 티켓 입장 처리 시 이메일 전송 로직 추가

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/email/dto/IssuedTicketMailDTO.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/email/dto/IssuedTicketMailDTO.java
@@ -1,0 +1,19 @@
+package band.gosrock.api.email.dto;
+
+
+import band.gosrock.infrastructure.config.mail.dto.EmailEventInfo;
+import band.gosrock.infrastructure.config.mail.dto.EmailIssuedTicketInfo;
+import band.gosrock.infrastructure.config.mail.dto.EmailUserInfo;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class IssuedTicketMailDTO {
+
+    private final EmailUserInfo userInfo;
+
+    private final EmailIssuedTicketInfo issuedTicketInfo;
+
+    private final EmailEventInfo eventInfo;
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/email/handler/EntranceIssuedTicketEventEmailHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/email/handler/EntranceIssuedTicketEventEmailHandler.java
@@ -1,0 +1,37 @@
+package band.gosrock.api.email.handler;
+
+
+import band.gosrock.api.email.dto.IssuedTicketMailDTO;
+import band.gosrock.api.email.service.EntranceIssuedTicketEmailService;
+import band.gosrock.api.email.service.IssuedTicketMailInfoHelper;
+import band.gosrock.domain.common.events.issuedTicket.EntranceIssuedTicketEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EntranceIssuedTicketEventEmailHandler {
+
+    private final IssuedTicketMailInfoHelper issuedTicketMailInfoHelper;
+
+    private final EntranceIssuedTicketEmailService entranceIssuedTicketEmailService;
+
+    @Async
+    @TransactionalEventListener(
+            classes = EntranceIssuedTicketEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
+    public void handleEntranceIssuedTicketEvent(
+            EntranceIssuedTicketEvent entranceIssuedTicketEvent) {
+        log.info(entranceIssuedTicketEvent.getIssuedTicketNo() + "번 티켓 입장 처리 이메일 전송");
+
+        IssuedTicketMailDTO issuedTicketMailDTO =
+                issuedTicketMailInfoHelper.execute(entranceIssuedTicketEvent.getIssuedTicketNo());
+        entranceIssuedTicketEmailService.execute(issuedTicketMailDTO);
+        log.info("이메일 전송 성공");
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/email/service/EntranceIssuedTicketEmailService.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/email/service/EntranceIssuedTicketEmailService.java
@@ -1,0 +1,29 @@
+package band.gosrock.api.email.service;
+
+
+import band.gosrock.api.email.dto.IssuedTicketMailDTO;
+import band.gosrock.infrastructure.config.mail.dto.EmailUserInfo;
+import band.gosrock.infrastructure.config.ses.AwsSesUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+
+@Service
+@RequiredArgsConstructor
+public class EntranceIssuedTicketEmailService {
+
+    private final AwsSesUtils awsSesUtils;
+
+    public void execute(IssuedTicketMailDTO issuedTicketMailDTO) {
+        String subject = "[두둥] 입장 확인 알림드립니다.";
+        Context context = new Context();
+        EmailUserInfo userInfo = issuedTicketMailDTO.getUserInfo();
+
+        context.setVariable("userInfo", userInfo);
+        context.setVariable("issuedTicketInfo", issuedTicketMailDTO.getIssuedTicketInfo());
+        context.setVariable("eventInfo", issuedTicketMailDTO.getEventInfo());
+
+        awsSesUtils.singleEmailRequest(
+                userInfo.getEmail(), subject, "entranceIssuedTicket", context);
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/email/service/IssuedTicketMailInfoHelper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/email/service/IssuedTicketMailInfoHelper.java
@@ -1,0 +1,45 @@
+package band.gosrock.api.email.service;
+
+
+import band.gosrock.api.email.dto.IssuedTicketMailDTO;
+import band.gosrock.common.annotation.Helper;
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
+import band.gosrock.domain.domains.event.domain.Event;
+import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
+import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
+import band.gosrock.domain.domains.user.domain.User;
+import band.gosrock.infrastructure.config.mail.dto.EmailEventInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@Helper
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class IssuedTicketMailInfoHelper {
+
+    private final UserAdaptor userAdaptor;
+
+    private final EventAdaptor eventAdaptor;
+
+    private final IssuedTicketAdaptor issuedTicketAdaptor;
+
+    private final HostAdaptor hostAdaptor;
+
+    public IssuedTicketMailDTO execute(String issuedTicketNo) {
+        IssuedTicket issuedTicket = issuedTicketAdaptor.queryByIssuedTicketNo(issuedTicketNo);
+        User user = userAdaptor.queryUser(issuedTicket.getUserInfo().getUserId());
+        Event event = eventAdaptor.findById(issuedTicket.getEventId());
+        Host host = hostAdaptor.findById(event.getHostId());
+        return new IssuedTicketMailDTO(
+                user.toEmailUserInfo(),
+                issuedTicket.toEmailIssuedTicketInfo(),
+                getEventInfo(event, host));
+    }
+
+    private EmailEventInfo getEventInfo(Event event, Host host) {
+        return new EmailEventInfo(host.getProfile().getName(), event.getEventBasic().getName());
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/service/EntranceIssuedTicketUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/issuedTicket/service/EntranceIssuedTicketUseCase.java
@@ -10,6 +10,7 @@ import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.common.vo.IssuedTicketInfoVo;
 import band.gosrock.domain.domains.issuedTicket.service.IssuedTicketDomainService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
@@ -21,6 +22,7 @@ public class EntranceIssuedTicketUseCase {
 
     private final UserUtils userUtils;
 
+    @Transactional
     @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID)
     public IssuedTicketInfoVo execute(Long eventId, Long issuedTicketId) {
         return issuedTicketDomainService.processingEntranceIssuedTicket(eventId, issuedTicketId);

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/issuedTicket/EntranceIssuedTicketEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/issuedTicket/EntranceIssuedTicketEvent.java
@@ -3,6 +3,7 @@ package band.gosrock.domain.common.events.issuedTicket;
 
 import band.gosrock.domain.common.aop.domainEvent.DomainEvent;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketUserInfoVo;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,14 +11,17 @@ import lombok.Getter;
 @Builder
 public class EntranceIssuedTicketEvent extends DomainEvent {
 
-    private final Long issuedTicketId;
+    private final String issuedTicketNo;
 
     private final Long eventId;
+
+    private final IssuedTicketUserInfoVo userInfo;
 
     public static EntranceIssuedTicketEvent from(IssuedTicket issuedTicket) {
         return EntranceIssuedTicketEvent.builder()
                 .eventId(issuedTicket.getEventId())
-                .issuedTicketId(issuedTicket.getId())
+                .issuedTicketNo(issuedTicket.getIssuedTicketNo())
+                .userInfo(issuedTicket.getUserInfo())
                 .build();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/issuedTicket/EntranceIssuedTicketEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/issuedTicket/EntranceIssuedTicketEvent.java
@@ -6,9 +6,11 @@ import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketUserInfoVo;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 public class EntranceIssuedTicketEvent extends DomainEvent {
 
     private final String issuedTicketNo;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptor.java
@@ -72,4 +72,10 @@ public class IssuedTicketAdaptor {
     public Long countPaidTicket(Long userId, Long itemId) {
         return issuedTicketRepository.countPaidTicket(userId, itemId);
     }
+
+    public IssuedTicket queryByIssuedTicketNo(String issuedTicketNo) {
+        return issuedTicketRepository
+                .findByIssuedTicketNo(issuedTicketNo)
+                .orElseThrow(() -> IssuedTicketNotFoundException.EXCEPTION);
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
@@ -87,7 +87,7 @@ public class IssuedTicket extends BaseTimeEntity {
     발급 티켓 상태
      */
     @Enumerated(EnumType.STRING)
-    private IssuedTicketStatus issuedTicketStatus;
+    private IssuedTicketStatus issuedTicketStatus = IssuedTicketStatus.ENTRANCE_INCOMPLETE;
 
     /*
     빌더를 통해 객체 생성 시 List는 큰 의미를 두지 않지만

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
@@ -11,6 +11,7 @@ import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelEntranceEx
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelException;
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotEntranceException;
 import band.gosrock.domain.domains.issuedTicket.exception.IssuedTicketAlreadyEntranceException;
+import band.gosrock.infrastructure.config.mail.dto.EmailIssuedTicketInfo;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -86,7 +87,7 @@ public class IssuedTicket extends BaseTimeEntity {
     발급 티켓 상태
      */
     @Enumerated(EnumType.STRING)
-    private IssuedTicketStatus issuedTicketStatus = IssuedTicketStatus.ENTRANCE_INCOMPLETE;
+    private IssuedTicketStatus issuedTicketStatus;
 
     /*
     빌더를 통해 객체 생성 시 List는 큰 의미를 두지 않지만
@@ -144,6 +145,15 @@ public class IssuedTicket extends BaseTimeEntity {
      */
     public IssuedTicketInfoVo toIssuedTicketInfoVo() {
         return IssuedTicketInfoVo.from(this);
+    }
+
+    public EmailIssuedTicketInfo toEmailIssuedTicketInfo() {
+        return new EmailIssuedTicketInfo(
+                this.getIssuedTicketNo(),
+                this.getItemInfo().getTicketName(),
+                this.getCreatedAt(),
+                this.getIssuedTicketStatus().getKr(),
+                this.getPrice().toString());
     }
 
     /** ---------------------------- 상태 변환 관련 메서드 ---------------------------------- */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/repository/IssuedTicketRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/repository/IssuedTicketRepository.java
@@ -3,6 +3,7 @@ package band.gosrock.domain.domains.issuedTicket.repository;
 
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface IssuedTicketRepository
@@ -10,4 +11,6 @@ public interface IssuedTicketRepository
     List<IssuedTicket> findAllByOrderLineId(Long orderLineId);
 
     List<IssuedTicket> findAllByOrderUuid(String orderId);
+
+    Optional<IssuedTicket> findByIssuedTicketNo(String issuedTicketNo);
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -55,7 +55,6 @@ public class IssuedTicketDomainService {
     /*
     발급 티켓 입장 처리 로직
      */
-    @Transactional
     public IssuedTicketInfoVo processingEntranceIssuedTicket(Long eventId, Long issuedTicketId) {
         IssuedTicket issuedTicket = issuedTicketAdaptor.queryIssuedTicket(issuedTicketId);
         issuedTicketValidator.validIssuedTicketEventIdEqualEvent(issuedTicket, eventId);

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/mail/dto/EmailIssuedTicketInfo.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/mail/dto/EmailIssuedTicketInfo.java
@@ -1,0 +1,21 @@
+package band.gosrock.infrastructure.config.mail.dto;
+
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class EmailIssuedTicketInfo {
+
+    private final String issuedTicketNo;
+
+    private final String ticketName;
+
+    private final LocalDateTime createdAt;
+
+    private final String issuedTicketStatus;
+
+    private final String money;
+}

--- a/DuDoong-Infrastructure/src/main/resources/templates/entranceIssuedTicket.html
+++ b/DuDoong-Infrastructure/src/main/resources/templates/entranceIssuedTicket.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html
+    xmlns:th="http://www.thymeleaf.org"
+    xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+    xmlns="http://www.w3.org/1999/xhtml"
+    layout:decorate="~{layouts/mailFormat}"
+>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title></title>
+  <style>
+    * {
+      line-height: 150%;
+      font-family: Pretendard ,AppleSDGothic, apple sd gothic neo, noto sans korean,
+      noto sans korean regular, noto sans cjk kr, noto sans cjk,
+      nanum gothic, malgun gothic, dotum, arial, helvetica, MS Gothic,
+      sans-serif !important;
+      mso-line-height-rule: exactly;
+      line-height: 1.8;
+      -ms-text-size-adjust: 100%;
+      -webkit-text-size-adjust: 100%;
+      word-break: break-word;
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0">
+<div layout:fragment="content">
+  <div th:replace="fragments/title :: title(title='티켓 입장 확인 안내')">divider</div>
+
+    <div >
+      <span >안녕하세요</span>
+      <span  th:text="${userInfo.name}" >이름</span>
+      <span >님</span>
+      <br />
+      <span th:text="${userInfo.name}" >이름</span>
+      <span>님이 발급하신 </span>
+    </div>
+  <div th:replace="fragments/subTilte :: hostAndEventAndIssuedTicket(eventInfo=${eventInfo}, issuedTicketInfo=${issuedTicketInfo}, text=' 티켓이 입장 처리 되었습니다.')">
+    이벤트 및 발급 티켓 정보
+  </div>
+  <div th:replace="fragments/issuedTicketInfo :: issuedTicketInfo(issuedTicketInfo=${issuedTicketInfo})">
+    발급 티켓 정보
+  </div>
+  <span>즐거운 관람 되세요!</span>
+
+  <div align="right">
+    <img width="163" style="" src="https://asset.dudoong.com/common/duduongs.png"/>
+  </div>
+
+  <div th:replace="fragments/button :: button(href='https://dudoong.com' , text='두둥 바로가기')">
+    button
+  </div>
+</div>
+</body>
+</html>

--- a/DuDoong-Infrastructure/src/main/resources/templates/fragments/issuedTicketInfo.html
+++ b/DuDoong-Infrastructure/src/main/resources/templates/fragments/issuedTicketInfo.html
@@ -1,0 +1,48 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+  <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+  <title></title>
+  <style>
+    * {
+      line-height: 150%;
+    }
+  </style>
+</head>
+<div th:fragment="issuedTicketInfo(issuedTicketInfo)"
+     style="
+      overflow: hidden;
+      padding: 0px;
+      margin-top: 20px;
+      border: 0;
+      font-weight: bold;
+      font-size: 14px;
+      font-family: Pretendard , AppleSDGothic, apple sd gothic neo, noto sans korean,
+        noto sans korean regular, noto sans cjk kr, noto sans cjk, nanum gothic,
+        malgun gothic, dotum, arial, helvetica, MS Gothic, sans-serif !important;
+    "
+>
+  <div style="font-weight: bold; background: #F8F8FA; padding: 10px ; margin-top: 10px;margin-bottom: 10px">
+    <div >
+      <span  >티켓 번호 : </span>
+      <span  th:text="${issuedTicketInfo.issuedTicketNo}" >티켓 번호</span>
+    </div>
+    <div >
+      <span  >티켓명 : </span>
+      <span  th:text="${issuedTicketInfo.ticketName}" >티켓명</span>
+    </div>
+    <div >
+      <span  >발급 일시 : </span>
+      <span  th:text="${#temporals.format(issuedTicketInfo.createdAt, 'yyyy-MM-dd HH:mm')}" >발급 일시</span>
+    </div>
+    <div >
+      <span  >티켓 상태 : </span>
+      <span  th:text="${issuedTicketInfo.issuedTicketStatus}" >티켓 상태</span>
+    </div>
+    <div>
+      <span>가격 : </span>
+      <span th:text="${issuedTicketInfo.money}">가격</span>
+    </div>
+  </div>
+</div>
+</html>

--- a/DuDoong-Infrastructure/src/main/resources/templates/fragments/subTilte.html
+++ b/DuDoong-Infrastructure/src/main/resources/templates/fragments/subTilte.html
@@ -47,4 +47,18 @@
     <br />
   </div>
 </div>
+
+<div th:fragment="hostAndEventAndIssuedTicket(eventInfo, issuedTicketInfo, text)"
+     style="..."
+>
+  <div>
+    <span th:text="${eventInfo.hostName}" >호스트이름</span>
+    <span th:text="${eventInfo.eventName}">이벤트 이름</span>
+    <span>의</span>
+    <span th:text="${issuedTicketInfo.issuedTicketNo}">발급 티켓 번호</span>
+    <span th:text="${text}"> 텍스트 </span>
+    <br />
+  </div>
+</div>
+
 </html>


### PR DESCRIPTION
## 개요
- close #317 

## 작업사항
- 발급 티켓 입장 시 EntranceIssuedTicketEvent 이벤트 발행
- 해당 이벤트 핸들러를 통해 커밋이 일어난 후 이메일 전송 로직 추가
- 이메일 템플릿 추가
![스크린샷 2023-02-11 오전 1 24 47](https://user-images.githubusercontent.com/59060780/218143292-af885b02-fd9e-4884-b9e7-90aad93d9c1a.png)
- 이메일 문구 피드백 받습니다


## 변경로직
- 내용을 적어주세요.