### PR TITLE
feat : 밸리데이션 정리 및 밸리데이션 테스트 코드 작성

### DIFF
--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
@@ -9,6 +9,7 @@ import band.gosrock.domain.common.vo.IssuedTicketInfoVo;
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelEntranceException;
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelException;
+import band.gosrock.domain.domains.issuedTicket.exception.CanNotEntranceException;
 import band.gosrock.domain.domains.issuedTicket.exception.IssuedTicketAlreadyEntranceException;
 import band.gosrock.infrastructure.config.mail.dto.EmailIssuedTicketInfo;
 import java.util.ArrayList;
@@ -175,7 +176,7 @@ public class IssuedTicket extends BaseTimeEntity {
      */
     public void entrance() {
         if (this.issuedTicketStatus.isCanceled()) {
-            throw CanNotCancelException.EXCEPTION;
+            throw CanNotEntranceException.EXCEPTION;
         }
         if (this.issuedTicketStatus.isAfterEntrance()) {
             throw IssuedTicketAlreadyEntranceException.EXCEPTION;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
@@ -9,7 +9,6 @@ import band.gosrock.domain.common.vo.IssuedTicketInfoVo;
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelEntranceException;
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelException;
-import band.gosrock.domain.domains.issuedTicket.exception.CanNotEntranceException;
 import band.gosrock.domain.domains.issuedTicket.exception.IssuedTicketAlreadyEntranceException;
 import band.gosrock.infrastructure.config.mail.dto.EmailIssuedTicketInfo;
 import java.util.ArrayList;
@@ -163,7 +162,7 @@ public class IssuedTicket extends BaseTimeEntity {
     티켓이 입장 미완료 상태가 아니면 취소 할 수 없음
      */
     public void cancel() {
-        if (this.issuedTicketStatus != IssuedTicketStatus.ENTRANCE_INCOMPLETE) {
+        if (!this.issuedTicketStatus.isBeforeEntrance()) {
             throw CanNotCancelException.EXCEPTION;
         }
         this.issuedTicketStatus = IssuedTicketStatus.CANCELED;
@@ -175,10 +174,10 @@ public class IssuedTicket extends BaseTimeEntity {
     (입장 처리 도메인 이벤트 발행)
      */
     public void entrance() {
-        if (this.issuedTicketStatus == IssuedTicketStatus.CANCELED) {
-            throw CanNotEntranceException.EXCEPTION;
+        if (this.issuedTicketStatus.isCanceled()) {
+            throw CanNotCancelException.EXCEPTION;
         }
-        if (this.issuedTicketStatus == IssuedTicketStatus.ENTRANCE_COMPLETED) {
+        if (this.issuedTicketStatus.isAfterEntrance()) {
             throw IssuedTicketAlreadyEntranceException.EXCEPTION;
         }
         this.issuedTicketStatus = IssuedTicketStatus.ENTRANCE_COMPLETED;
@@ -190,7 +189,7 @@ public class IssuedTicket extends BaseTimeEntity {
     티켓이 입장 완료 상태가 아니면 입장 취소 할 수 없음
      */
     public void entranceCancel() {
-        if (this.issuedTicketStatus != IssuedTicketStatus.ENTRANCE_COMPLETED) {
+        if (!this.issuedTicketStatus.isAfterEntrance()) {
             throw CanNotCancelEntranceException.EXCEPTION;
         }
         this.issuedTicketStatus = IssuedTicketStatus.ENTRANCE_INCOMPLETE;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketStatus.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketStatus.java
@@ -30,4 +30,8 @@ public enum IssuedTicketStatus {
     public Boolean isAfterEntrance() {
         return this == IssuedTicketStatus.ENTRANCE_COMPLETED;
     }
+
+    public Boolean is(IssuedTicket issuedTicket) {
+        return issuedTicket.getIssuedTicketStatus() == IssuedTicketStatus.ENTRANCE_INCOMPLETE;
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/validator/IssuedTicketValidator.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/validator/IssuedTicketValidator.java
@@ -3,9 +3,7 @@ package band.gosrock.domain.domains.issuedTicket.validator;
 
 import band.gosrock.common.annotation.Validator;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
-import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
-import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.exception.IssuedTicketNotMatchedEventException;
 import java.util.Objects;
@@ -17,12 +15,13 @@ public class IssuedTicketValidator {
 
     private final EventAdaptor eventAdaptor;
     private final HostAdaptor hostAdaptor;
-
-    public void validCanModifyIssuedTicketUser(IssuedTicket issuedTicket, Long currentUserId) {
-        Event event = eventAdaptor.findById(issuedTicket.getEventId());
-        Host host = hostAdaptor.findById(event.getHostId());
-        host.validateHostUser(currentUserId);
-    }
+    //
+    //    public void validCanModifyIssuedTicketUser(IssuedTicket issuedTicket, Long currentUserId)
+    // {
+    //        Event event = eventAdaptor.findById(issuedTicket.getEventId());
+    //        Host host = hostAdaptor.findById(event.getHostId());
+    //        host.validateHostUser(currentUserId);
+    //    }
 
     public void validIssuedTicketEventIdEqualEvent(IssuedTicket issuedTicket, Long eventId) {
         if (!Objects.equals(issuedTicket.getEventId(), eventId)) {

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/validator/IssuedTicketValidatorTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/validator/IssuedTicketValidatorTest.java
@@ -1,0 +1,51 @@
+package band.gosrock.domain.domains.issuedTicket.domain.validator;
+
+import static org.mockito.BDDMockito.given;
+
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
+import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
+import band.gosrock.domain.domains.issuedTicket.exception.IssuedTicketNotMatchedEventException;
+import band.gosrock.domain.domains.issuedTicket.validator.IssuedTicketValidator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class IssuedTicketValidatorTest {
+
+    @Mock IssuedTicket issuedTicket;
+
+    @Mock EventAdaptor eventAdaptor;
+
+    @Mock HostAdaptor hostAdaptor;
+
+    IssuedTicketValidator issuedTicketValidator;
+
+    @BeforeEach
+    public void setUp() {
+        issuedTicketValidator = new IssuedTicketValidator(eventAdaptor, hostAdaptor);
+    }
+
+    @Test
+    public void 발급티켓_이벤트_검증_성공() {
+        // given
+        given(issuedTicket.getEventId()).willReturn(1L);
+        // when
+        issuedTicketValidator.validIssuedTicketEventIdEqualEvent(issuedTicket, 1L);
+    }
+
+    @Test
+    public void 발급티켓_이벤트_검증_실패() {
+        // given
+        given(issuedTicket.getEventId()).willReturn(2L);
+        // when
+        // then
+        Assertions.assertThrows(
+                IssuedTicketNotMatchedEventException.class,
+                () -> issuedTicketValidator.validIssuedTicketEventIdEqualEvent(issuedTicket, 1L));
+    }
+}


### PR DESCRIPTION
## 개요
- close #342 

## 작업사항
- 발급 티켓 입장 처리 및 취소 로직에서 상태 검증 밸리데이션을 ENUM 클래스에 있는 메서드로 바꿨습니다.
- IssuedTicketValidator에 있는 로직의 테스트 코드를 작성했습니다.
- 이제 IssuedTicketDomainService의 테스트코드를 작성할 예정입니다.

## 변경로직
- 내용을 적어주세요.