### PR TITLE
fix : 호스트 이벤트 버그 수정 및 슬랙 URL 검증 추가

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/service/ReadEventDetailUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/service/ReadEventDetailUseCase.java
@@ -27,7 +27,7 @@ public class ReadEventDetailUseCase {
         final Host host = hostAdaptor.findById(event.getHostId());
         final Long userId = userUtils.getCurrentUserId();
         // 호스트 유저가 아닐 경우 준비 상태일 때 조회할 수 없음
-        if (event.isPreparing() && !host.hasHostUserId(userId)) {
+        if (event.isPreparing() && !host.isActiveHostUserId(userId)) {
             throw EventNotOpenException.EXCEPTION;
         }
         return eventMapper.toEventDetailResponse(host, event);

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostSlackRequest.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/dto/request/UpdateHostSlackRequest.java
@@ -2,6 +2,7 @@ package band.gosrock.api.host.model.dto.request;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,7 @@ import org.hibernate.validator.constraints.URL;
 @AllArgsConstructor
 public class UpdateHostSlackRequest {
     @Schema(defaultValue = "https://slack.dd.com", description = "슬랙 웹훅 URL")
+    @NotBlank(message = "올바른 슬랙 URL 을 입력해주세요")
     @URL(message = "올바른 슬랙 URL 을 입력해주세요")
     private String slackUrl;
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
@@ -31,6 +31,7 @@ public class UpdateHostSlackUrlUseCase {
     public HostDetailResponse execute(Long hostId, UpdateHostSlackRequest updateHostSlackRequest) {
         final Host host = hostAdaptor.findById(hostId);
         final String slackUrl = updateHostSlackRequest.getSlackUrl();
+        hostService.validateDuplicatedSlackUrl(host, slackUrl);
 
         try {
             slackMessageProvider.register(slackUrl);

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/UpdateHostSlackUrlUseCase.java
@@ -10,7 +10,10 @@ import band.gosrock.api.host.model.mapper.HostMapper;
 import band.gosrock.common.annotation.UseCase;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.exception.InvalidSlackUrlException;
 import band.gosrock.domain.domains.host.service.HostService;
+import band.gosrock.infrastructure.config.slack.SlackMessageProvider;
+import java.net.UnknownHostException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,11 +24,19 @@ public class UpdateHostSlackUrlUseCase {
     private final HostAdaptor hostAdaptor;
     private final HostMapper hostMapper;
 
+    private final SlackMessageProvider slackMessageProvider;
+
     @Transactional
     @HostRolesAllowed(role = MANAGER, findHostFrom = HOST_ID)
     public HostDetailResponse execute(Long hostId, UpdateHostSlackRequest updateHostSlackRequest) {
         final Host host = hostAdaptor.findById(hostId);
         final String slackUrl = updateHostSlackRequest.getSlackUrl();
-        return hostMapper.toHostDetailResponse(hostService.updateHostSlackUrl(host, slackUrl));
+
+        try {
+            slackMessageProvider.register(slackUrl);
+            return hostMapper.toHostDetailResponse(hostService.updateHostSlackUrl(host, slackUrl));
+        } catch (UnknownHostException e) {
+            throw InvalidSlackUrlException.EXCEPTION;
+        }
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/event/EventContentChangeEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/event/EventContentChangeEventHandler.java
@@ -1,8 +1,8 @@
-package band.gosrock.api.event.handler;
+package band.gosrock.api.slack.handler.event;
 
 
 import band.gosrock.domain.common.alarm.EventSlackAlarm;
-import band.gosrock.domain.common.events.event.EventDeletionEvent;
+import band.gosrock.domain.common.events.event.EventContentChangeEvent;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
@@ -18,19 +18,19 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class EventDeletionEventHandler {
+public class EventContentChangeEventHandler {
     private final HostAdaptor hostAdaptor;
     private final EventAdaptor eventAdaptor;
     private final SlackMessageProvider slackMessageProvider;
 
     @Async
     @TransactionalEventListener(
-            classes = EventDeletionEvent.class,
+            classes = EventContentChangeEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(EventDeletionEvent eventDeletionEvent) {
-        final Host host = hostAdaptor.findById(eventDeletionEvent.getHostId());
-        final Event event = eventAdaptor.findById(eventDeletionEvent.getEventId());
-        final String message = EventSlackAlarm.deletionOf(event);
+    public void handle(EventContentChangeEvent eventContentChangeEvent) {
+        final Host host = hostAdaptor.findById(eventContentChangeEvent.getHostId());
+        final Event event = eventAdaptor.findById(eventContentChangeEvent.getEventId());
+        final String message = EventSlackAlarm.changeContentOf(event);
 
         slackMessageProvider.sendMessage(host.getSlackUrl(), message);
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/event/EventCreationEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/event/EventCreationEventHandler.java
@@ -1,10 +1,9 @@
-package band.gosrock.api.event.handler;
+package band.gosrock.api.slack.handler.event;
 
 
 import band.gosrock.domain.common.alarm.EventSlackAlarm;
-import band.gosrock.domain.common.events.event.EventContentChangeEvent;
+import band.gosrock.domain.common.events.event.EventCreationEvent;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
-import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.infrastructure.config.slack.SlackMessageProvider;
@@ -18,19 +17,18 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class EventContentChangeEventHandler {
+public class EventCreationEventHandler {
     private final HostAdaptor hostAdaptor;
     private final EventAdaptor eventAdaptor;
     private final SlackMessageProvider slackMessageProvider;
 
     @Async
     @TransactionalEventListener(
-            classes = EventContentChangeEvent.class,
+            classes = EventCreationEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(EventContentChangeEvent eventContentChangeEvent) {
-        final Host host = hostAdaptor.findById(eventContentChangeEvent.getHostId());
-        final Event event = eventAdaptor.findById(eventContentChangeEvent.getEventId());
-        final String message = EventSlackAlarm.changeContentOf(event);
+    public void handle(EventCreationEvent eventCreationEvent) {
+        final Host host = hostAdaptor.findById(eventCreationEvent.getHostId());
+        final String message = EventSlackAlarm.creationOf(eventCreationEvent.getEventName());
 
         slackMessageProvider.sendMessage(host.getSlackUrl(), message);
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/event/EventDeletionEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/event/EventDeletionEventHandler.java
@@ -1,8 +1,8 @@
-package band.gosrock.api.event.handler;
+package band.gosrock.api.slack.handler.event;
 
 
 import band.gosrock.domain.common.alarm.EventSlackAlarm;
-import band.gosrock.domain.common.events.event.EventStatusChangeEvent;
+import band.gosrock.domain.common.events.event.EventDeletionEvent;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
@@ -18,19 +18,19 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class EventStatusChangeEventHandler {
+public class EventDeletionEventHandler {
     private final HostAdaptor hostAdaptor;
     private final EventAdaptor eventAdaptor;
     private final SlackMessageProvider slackMessageProvider;
 
     @Async
     @TransactionalEventListener(
-            classes = EventStatusChangeEvent.class,
+            classes = EventDeletionEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(EventStatusChangeEvent eventStatusChangeEvent) {
-        final Host host = hostAdaptor.findById(eventStatusChangeEvent.getHostId());
-        final Event event = eventAdaptor.findById(eventStatusChangeEvent.getEventId());
-        final String message = EventSlackAlarm.changeStatusOf(event);
+    public void handle(EventDeletionEvent eventDeletionEvent) {
+        final Host host = hostAdaptor.findById(eventDeletionEvent.getHostId());
+        final Event event = eventAdaptor.findById(eventDeletionEvent.getEventId());
+        final String message = EventSlackAlarm.deletionOf(event);
 
         slackMessageProvider.sendMessage(host.getSlackUrl(), message);
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/event/EventStatusChangeEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/event/EventStatusChangeEventHandler.java
@@ -1,9 +1,10 @@
-package band.gosrock.api.event.handler;
+package band.gosrock.api.slack.handler.event;
 
 
 import band.gosrock.domain.common.alarm.EventSlackAlarm;
-import band.gosrock.domain.common.events.event.EventCreationEvent;
+import band.gosrock.domain.common.events.event.EventStatusChangeEvent;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
+import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.infrastructure.config.slack.SlackMessageProvider;
@@ -17,18 +18,19 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class EventCreationEventHandler {
+public class EventStatusChangeEventHandler {
     private final HostAdaptor hostAdaptor;
     private final EventAdaptor eventAdaptor;
     private final SlackMessageProvider slackMessageProvider;
 
     @Async
     @TransactionalEventListener(
-            classes = EventCreationEvent.class,
+            classes = EventStatusChangeEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(EventCreationEvent eventCreationEvent) {
-        final Host host = hostAdaptor.findById(eventCreationEvent.getHostId());
-        final String message = EventSlackAlarm.creationOf(eventCreationEvent.getEventName());
+    public void handle(EventStatusChangeEvent eventStatusChangeEvent) {
+        final Host host = hostAdaptor.findById(eventStatusChangeEvent.getHostId());
+        final Event event = eventAdaptor.findById(eventStatusChangeEvent.getEventId());
+        final String message = EventSlackAlarm.changeStatusOf(event);
 
         slackMessageProvider.sendMessage(host.getSlackUrl(), message);
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/host/HostRegisterSlackEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/host/HostRegisterSlackEventHandler.java
@@ -1,4 +1,4 @@
-package band.gosrock.api.host.handler;
+package band.gosrock.api.slack.handler.host;
 
 
 import band.gosrock.domain.common.alarm.HostSlackAlarm;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/host/HostUserDisabledEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/host/HostUserDisabledEventHandler.java
@@ -1,4 +1,4 @@
-package band.gosrock.api.host.handler;
+package band.gosrock.api.slack.handler.host;
 
 
 import band.gosrock.api.email.service.HostUserDisabledEmailService;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/host/HostUserInvitationEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/host/HostUserInvitationEventHandler.java
@@ -1,4 +1,4 @@
-package band.gosrock.api.host.handler;
+package band.gosrock.api.slack.handler.host;
 
 
 import band.gosrock.api.email.service.HostUserInvitationEmailService;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/host/HostUserJoinEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/host/HostUserJoinEventHandler.java
@@ -1,4 +1,4 @@
-package band.gosrock.api.host.handler;
+package band.gosrock.api.slack.handler.host;
 
 
 import band.gosrock.domain.common.alarm.HostSlackAlarm;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/host/HostUserRoleChangeEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/host/HostUserRoleChangeEventHandler.java
@@ -1,4 +1,4 @@
-package band.gosrock.api.host.handler;
+package band.gosrock.api.slack.handler.host;
 
 
 import band.gosrock.api.email.service.HostMasterChangeEmailService;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostInfoVo.java
@@ -30,6 +30,7 @@ public class HostInfoVo {
                 .profileImage(host.getProfile().getProfileImage())
                 .contactEmail(host.getProfile().getContactEmail())
                 .contactNumber(host.getProfile().getContactNumber())
+                .partner(host.getPartner())
                 .build();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
@@ -15,6 +15,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.commons.codec.binary.StringUtils;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -77,7 +78,7 @@ public class Host extends BaseTimeEntity {
     }
 
     public void setSlackUrl(String slackUrl) {
-        if (this.slackUrl != null && this.slackUrl.equals(slackUrl)) {
+        if (StringUtils.equals(this.slackUrl, slackUrl)) {
             throw DuplicateSlackUrlException.EXCEPTION;
         }
         Events.raise(HostRegisterSlackEvent.of(this));

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
@@ -77,7 +77,7 @@ public class Host extends BaseTimeEntity {
     }
 
     public void setSlackUrl(String slackUrl) {
-        if (this.slackUrl.equals(slackUrl)) {
+        if (this.slackUrl != null && this.slackUrl.equals(slackUrl)) {
             throw DuplicateSlackUrlException.EXCEPTION;
         }
         Events.raise(HostRegisterSlackEvent.of(this));

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/HostErrorCode.java
@@ -22,6 +22,7 @@ public enum HostErrorCode implements BaseErrorCode {
     NOT_ACCEPTED_HOST(BAD_REQUEST, "HOST_400_6", "아직 초대를 수락하지 않은 유저입니다."),
     NOT_PARTNER_HOST(BAD_REQUEST, "HOST_400_7", "파트너 호스트만 사용할 수 있는 기능입니다. 제휴 신청을 해주세요."),
     DUPLICATED_SLACK_URL(BAD_REQUEST, "HOST_400_8", "기존과 동일한 슬랙 url 입니다."),
+    INVALID_SLACK_URL(BAD_REQUEST, "HOST_400_9", "유효하지 않은 않은 슬랙 url 입니다."),
     HOST_NOT_FOUND(NOT_FOUND, "Host_404_1", "해당 호스트를 찾을 수 없습니다."),
     HOST_USER_NOT_FOUND(NOT_FOUND, "HOST_404_2", "가입된 호스트 유저가 아닙니다.");
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/InvalidSlackUrlException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/exception/InvalidSlackUrlException.java
@@ -1,0 +1,12 @@
+package band.gosrock.domain.domains.host.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class InvalidSlackUrlException extends DuDoongCodeException {
+    public static final DuDoongCodeException EXCEPTION = new InvalidSlackUrlException();
+
+    private InvalidSlackUrlException() {
+        super(HostErrorCode.INVALID_SLACK_URL);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
@@ -7,9 +7,11 @@ import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.host.domain.HostProfile;
 import band.gosrock.domain.domains.host.domain.HostRole;
 import band.gosrock.domain.domains.host.domain.HostUser;
+import band.gosrock.domain.domains.host.exception.InvalidSlackUrlException;
 import band.gosrock.domain.domains.host.repository.HostRepository;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.codec.binary.StringUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 @DomainService
@@ -51,6 +53,12 @@ public class HostService {
     public Host activateHostUser(Host host, Long userId) {
         host.getHostUserByUserId(userId).activate();
         return hostRepository.save(host);
+    }
+
+    public void validateDuplicatedSlackUrl(Host host, String url) {
+        if (StringUtils.equals(host.getSlackUrl(), url)) {
+            throw InvalidSlackUrlException.EXCEPTION;
+        }
     }
 
     /** 해당 유저가 호스트에 속하는지 확인하는 검증 로직입니다 */

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/slack/SlackMessageProvider.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/slack/SlackMessageProvider.java
@@ -23,6 +23,7 @@ public class SlackMessageProvider {
 
     @Async
     public void sendMessage(String url, String text) {
+        if (url == null || url.isBlank()) return;
         Slack slack = Slack.getInstance();
         Payload payload = Payload.builder().text(text).username(username).iconUrl(iconUrl).build();
 

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/slack/SlackMessageProvider.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/slack/SlackMessageProvider.java
@@ -4,8 +4,10 @@ package band.gosrock.infrastructure.config.slack;
 import com.slack.api.Slack;
 import com.slack.api.webhook.Payload;
 import java.io.IOException;
+import java.net.UnknownHostException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -23,12 +25,30 @@ public class SlackMessageProvider {
 
     @Async
     public void sendMessage(String url, String text) {
-        if (url == null || url.isBlank()) return;
-        Slack slack = Slack.getInstance();
-        Payload payload = Payload.builder().text(text).username(username).iconUrl(iconUrl).build();
-
         try {
-            slack.send(url, payload);
+            doSend(url, text);
+        } catch (Exception ignored) {
+        }
+    }
+
+    /** 호스트가 존재하는 지 확인하기 위해 동기로 처리 */
+    public void register(String url) throws UnknownHostException {
+        final String text = "두둥 슬랙 알림이 성공적으로 등록되었습니다!";
+        doSend(url, text);
+    }
+
+    private void doSend(String url, String text) throws UnknownHostException {
+        final Slack slack = Slack.getInstance();
+        final Payload payload =
+                Payload.builder().text(text).username(username).iconUrl(iconUrl).build();
+        try {
+            String responseBody = slack.send(url, payload).getBody();
+            if (!StringUtils.equals(responseBody, "ok")) {
+                throw new UnknownHostException("올바른 슬랙 URL이 아닙니다.");
+            }
+        } catch (UnknownHostException error) {
+            // 호스트가 존재하지 않을 경우 abort
+            throw error;
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new RuntimeException(e);


### PR DESCRIPTION
## 개요
- close #337 

## 작업사항
- 이벤트 준비중일 때 열람 권한을 속한 유저 -> 초대 수락한 유저로 변경
- HostInfoVo 에서 누락된 partner 필드 추가
- 슬랙 메세지 이벤트 핸들러 디렉토리 이동
- `SlackURL` 필드 NULL CHECK
- 호스트의 슬랙 URL 등록 시 ack 가 올바르게 오지 않을 경우 등록 취소시키는 기능 추가

![image](https://user-images.githubusercontent.com/72291860/218259864-82cbf400-7ed3-40d0-83b1-69ca7392bef2.png)

- 호스트 슬랙 url 과 변경하려는 url 의 중복 검사를 먼저 하기 위해 validation 로직을 usecase 로 올렸습니다

![image](https://user-images.githubusercontent.com/72291860/218259887-1f678bdd-c9a7-47f8-8e39-c6bc171508e6.png)

- 슬랙 url 등록과 메세지 전송을 분리시켰습니다
- 슬랙 url 이 존재했다가 없어질 경우 로그에 에러 메세지가 계속 뜰텐데, 이를 생각해서 일단 임시로 메세지 전송에서는 임시로 예외를 무시하도록 했습니다.
- url 등록은 1회성이니 동기로 처리해서 메세지 성공 시 받을 응답을 대기하도록 했습니다.


## 변경로직
- 위와 같음