### PR TITLE
refactor : 티켓 재고 숨기기 기능 추가

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/controller/TicketItemController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/controller/TicketItemController.java
@@ -56,6 +56,12 @@ public class TicketItemController {
         return getEventTicketItemsUseCase.execute(eventId);
     }
 
+    @Operation(summary = "해당 이벤트의 티켓상품을 모두 조회합니다. (어드민용)", description = "재고 정보가 무조건 공개됩니다.")
+    @GetMapping("/admin")
+    public GetEventTicketItemsResponse getEventTicketItemsForAdmin(@PathVariable Long eventId) {
+        return getEventTicketItemsUseCase.executeForAdmin(eventId);
+    }
+
     @Operation(summary = "해당 티켓상품의 옵션을 모두 조회합니다.")
     @GetMapping("/{ticketItemId}/options")
     public GetTicketItemOptionsResponse getTicketItemOptions(

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/dto/response/TicketItemResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/dto/response/TicketItemResponse.java
@@ -42,7 +42,7 @@ public class TicketItemResponse {
     @Schema(description = "재고공개 여부")
     private final Boolean isQuantityPublic;
 
-    public static TicketItemResponse from(TicketItem ticketItem) {
+    public static TicketItemResponse from(TicketItem ticketItem, Boolean isAdmin) {
 
         return TicketItemResponse.builder()
                 .ticketItemId(ticketItem.getId())
@@ -53,7 +53,10 @@ public class TicketItemResponse {
                 .approveType(ticketItem.getType())
                 .purchaseLimit(ticketItem.getPurchaseLimit())
                 .supplyCount(ticketItem.getSupplyCount())
-                .quantity(ticketItem.getQuantity())
+                .quantity(
+                        isAdmin || ticketItem.getIsQuantityPublic()
+                                ? ticketItem.getQuantity()
+                                : null)
                 .isQuantityPublic(ticketItem.getIsQuantityPublic())
                 .build();
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/mapper/TicketItemMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/mapper/TicketItemMapper.java
@@ -41,12 +41,15 @@ public class TicketItemMapper {
     }
 
     @Transactional(readOnly = true)
-    public GetEventTicketItemsResponse toGetEventTicketItemsResponse(Long eventId) {
+    public GetEventTicketItemsResponse toGetEventTicketItemsResponse(
+            Long eventId, Boolean isAdmin) {
 
         Event event = eventAdaptor.findById(eventId);
         List<TicketItem> ticketItems = ticketItemAdaptor.findAllByEventId(event.getId());
         return GetEventTicketItemsResponse.from(
-                ticketItems.stream().map(TicketItemResponse::from).toList());
+                ticketItems.stream()
+                        .map(ticketItem -> TicketItemResponse.from(ticketItem, isAdmin))
+                        .toList());
     }
 
     @Transactional(readOnly = true)

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/CreateTicketItemUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/CreateTicketItemUseCase.java
@@ -42,6 +42,6 @@ public class CreateTicketItemUseCase {
                 ticketItemService.createTicketItem(
                         ticketItemMapper.toTicketItem(createTicketItemRequest, event), isPartner);
 
-        return TicketItemResponse.from(ticketItem);
+        return TicketItemResponse.from(ticketItem, true);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/DeleteTicketItemUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/DeleteTicketItemUseCase.java
@@ -34,6 +34,6 @@ public class DeleteTicketItemUseCase {
 
         ticketItemService.softDeleteTicketItem(eventId, ticketItemId);
 
-        return ticketItemMapper.toGetEventTicketItemsResponse(eventId);
+        return ticketItemMapper.toGetEventTicketItemsResponse(eventId, true);
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/GetEventTicketItemsUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/ticketItem/service/GetEventTicketItemsUseCase.java
@@ -1,6 +1,9 @@
 package band.gosrock.api.ticketItem.service;
 
+import static band.gosrock.api.common.aop.hostRole.FindHostFrom.EVENT_ID;
+import static band.gosrock.api.common.aop.hostRole.HostQualification.GUEST;
 
+import band.gosrock.api.common.aop.hostRole.HostRolesAllowed;
 import band.gosrock.api.ticketItem.dto.response.GetEventTicketItemsResponse;
 import band.gosrock.api.ticketItem.mapper.TicketItemMapper;
 import band.gosrock.common.annotation.UseCase;
@@ -14,6 +17,12 @@ public class GetEventTicketItemsUseCase {
 
     public GetEventTicketItemsResponse execute(Long eventId) {
 
-        return ticketItemMapper.toGetEventTicketItemsResponse(eventId);
+        return ticketItemMapper.toGetEventTicketItemsResponse(eventId, false);
+    }
+
+    @HostRolesAllowed(role = GUEST, findHostFrom = EVENT_ID)
+    public GetEventTicketItemsResponse executeForAdmin(Long eventId) {
+
+        return ticketItemMapper.toGetEventTicketItemsResponse(eventId, true);
     }
 }


### PR DESCRIPTION
## 개요
- close #298 

## 작업사항
- 티켓 재고 숨김 여부에 따라 조회시 보이지 않도록 처리
- 어드민 접근의 경우에도 어드민 페이지와 예매 페이지에서 다르게 보여야 함으로 API 분리

## 변경로직