### PR TITLE
test : issuedTicketDomainService 테스트 코드 작성

### DIFF
--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/IssuedTicketInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/IssuedTicketInfoVo.java
@@ -61,7 +61,7 @@ public class IssuedTicketInfoVo {
                 .issuedTicketNo(issuedTicket.getIssuedTicketNo())
                 .uuid(issuedTicket.getUuid())
                 .ticketName(issuedTicket.getItemInfo().getTicketName())
-                .ticketPrice(issuedTicket.getPrice())
+                .ticketPrice(issuedTicket.getItemInfo().getPrice())
                 .createdAt(issuedTicket.getCreatedAt())
                 .issuedTicketStatus(issuedTicket.getIssuedTicketStatus())
                 .optionPrice(issuedTicket.sumOptionPrice())

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.java
@@ -11,10 +11,16 @@ import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelEntranceEx
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelException;
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotEntranceException;
 import band.gosrock.domain.domains.issuedTicket.exception.IssuedTicketAlreadyEntranceException;
+import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.domain.domains.order.domain.OrderLineItem;
+import band.gosrock.domain.domains.order.domain.OrderOptionAnswer;
+import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.user.domain.User;
 import band.gosrock.infrastructure.config.mail.dto.EmailIssuedTicketInfo;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.LongStream;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -79,11 +85,6 @@ public class IssuedTicket extends BaseTimeEntity {
     private String uuid;
 
     /*
-    발급 티켓 가격
-     */
-    @Embedded private Money price;
-
-    /*
     발급 티켓 상태
      */
     @Enumerated(EnumType.STRING)
@@ -100,7 +101,6 @@ public class IssuedTicket extends BaseTimeEntity {
             String orderUuid,
             Long orderLineId,
             IssuedTicketItemInfoVo itemInfo,
-            Money price,
             IssuedTicketStatus issuedTicketStatus,
             List<IssuedTicketOptionAnswer> issuedTicketOptionAnswers) {
         this.eventId = eventId;
@@ -108,7 +108,6 @@ public class IssuedTicket extends BaseTimeEntity {
         this.itemInfo = itemInfo;
         this.orderUuid = orderUuid;
         this.orderLineId = orderLineId;
-        this.price = price;
         this.issuedTicketStatus = issuedTicketStatus;
         this.issuedTicketOptionAnswers.addAll(issuedTicketOptionAnswers);
     }
@@ -147,13 +146,47 @@ public class IssuedTicket extends BaseTimeEntity {
         return IssuedTicketInfoVo.from(this);
     }
 
+    public static IssuedTicket create(
+            TicketItem ticketItem,
+            User user,
+            Order order,
+            Long eventId,
+            OrderLineItem orderLineItem) {
+        List<OrderOptionAnswer> orderOptionAnswers = orderLineItem.getOrderOptionAnswers();
+        return IssuedTicket.builder()
+                .issuedTicketOptionAnswers(
+                        orderOptionAnswers.stream().map(IssuedTicketOptionAnswer::from).toList())
+                .itemInfo(IssuedTicketItemInfoVo.from(ticketItem))
+                .orderLineId(orderLineItem.getId())
+                .orderUuid(order.getUuid())
+                .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
+                .userInfo(IssuedTicketUserInfoVo.from(user))
+                .eventId(eventId)
+                .build();
+    }
+
+    public static List<IssuedTicket> orderLineToIssuedTicket(
+            TicketItem ticketItem,
+            User user,
+            Order order,
+            Long eventId,
+            OrderLineItem orderLineItem) {
+        Long quantity = orderLineItem.getQuantity();
+        return LongStream.range(0, quantity)
+                .mapToObj(i -> IssuedTicket.create(ticketItem, user, order, eventId, orderLineItem))
+                .toList();
+    }
+
+    /*
+    발급 티켓을 이메일 형식 Dto로 매핑하는 메서드
+     */
     public EmailIssuedTicketInfo toEmailIssuedTicketInfo() {
         return new EmailIssuedTicketInfo(
                 this.getIssuedTicketNo(),
                 this.getItemInfo().getTicketName(),
                 this.getCreatedAt(),
                 this.getIssuedTicketStatus().getKr(),
-                this.getPrice().toString());
+                this.getItemInfo().getPrice().toString());
     }
 
     /** ---------------------------- 상태 변환 관련 메서드 ---------------------------------- */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketItemInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketItemInfoVo.java
@@ -1,6 +1,7 @@
 package band.gosrock.domain.domains.issuedTicket.domain;
 
 
+import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
 import band.gosrock.domain.domains.ticket_item.domain.TicketType;
 import javax.persistence.Embeddable;
@@ -22,11 +23,15 @@ public class IssuedTicketItemInfoVo {
 
     private String ticketName;
 
+    private Money price;
+
     @Builder
-    public IssuedTicketItemInfoVo(Long ticketItemId, TicketType ticketType, String ticketName) {
+    public IssuedTicketItemInfoVo(
+            Long ticketItemId, TicketType ticketType, String ticketName, Money price) {
         this.ticketItemId = ticketItemId;
         this.ticketType = ticketType;
         this.ticketName = ticketName;
+        this.price = price;
     }
 
     public static IssuedTicketItemInfoVo from(TicketItem item) {
@@ -34,6 +39,7 @@ public class IssuedTicketItemInfoVo {
                 .ticketItemId(item.getId())
                 .ticketType(item.getType())
                 .ticketName(item.getName())
+                .price(item.getPrice())
                 .build();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -83,16 +83,17 @@ public class IssuedTicketDomainService {
         List<IssuedTicket> issuedTickets =
                 orderLineItems.stream()
                         .map(
-                                orderLineItem ->
-                                        IssuedTicket.orderLineToIssuedTicket(
-                                                ticketItem,
-                                                user,
-                                                order,
-                                                order.getEventId(),
-                                                orderLineItem))
+                                orderLineItem -> {
+                                    ticketItem.reduceQuantity(orderLineItem.getQuantity());
+                                    return IssuedTicket.orderLineToIssuedTicket(
+                                            ticketItem,
+                                            user,
+                                            order,
+                                            order.getEventId(),
+                                            orderLineItem);
+                                })
                         .flatMap(Collection::stream)
                         .toList();
         issuedTicketAdaptor.saveAll(issuedTickets);
-        ticketItem.reduceQuantity((long) issuedTickets.size());
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -83,17 +83,17 @@ public class IssuedTicketDomainService {
         List<IssuedTicket> issuedTickets =
                 orderLineItems.stream()
                         .map(
-                                orderLineItem -> {
-                                    ticketItem.reduceQuantity(1L);
-                                    return IssuedTicket.orderLineToIssuedTicket(
+                                orderLineItem ->
+                                     IssuedTicket.orderLineToIssuedTicket(
                                             ticketItem,
                                             user,
                                             order,
                                             order.getEventId(),
-                                            orderLineItem);
-                                })
+                                            orderLineItem)
+                                )
                         .flatMap(Collection::stream)
                         .toList();
         issuedTicketAdaptor.saveAll(issuedTickets);
+        ticketItem.reduceQuantity((long) issuedTickets.size());
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -84,13 +84,12 @@ public class IssuedTicketDomainService {
                 orderLineItems.stream()
                         .map(
                                 orderLineItem ->
-                                     IssuedTicket.orderLineToIssuedTicket(
-                                            ticketItem,
-                                            user,
-                                            order,
-                                            order.getEventId(),
-                                            orderLineItem)
-                                )
+                                        IssuedTicket.orderLineToIssuedTicket(
+                                                ticketItem,
+                                                user,
+                                                order,
+                                                order.getEventId(),
+                                                orderLineItem))
                         .flatMap(Collection::stream)
                         .toList();
         issuedTicketAdaptor.saveAll(issuedTickets);

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -30,8 +30,6 @@ public class IssuedTicketDomainService {
 
     private final IssuedTicketValidator issuedTicketValidator;
 
-    private final OrderToIssuedTicketService orderToIssuedTicketService;
-
     /*
     티켓 철회 로직
      */
@@ -85,16 +83,17 @@ public class IssuedTicketDomainService {
         List<IssuedTicket> issuedTickets =
                 orderLineItems.stream()
                         .map(
-                                orderLineItem ->
-                                        IssuedTicket.orderLineToIssuedTicket(
-                                                ticketItem,
-                                                user,
-                                                order,
-                                                order.getEventId(),
-                                                orderLineItem))
+                                orderLineItem -> {
+                                    ticketItem.reduceQuantity(1L);
+                                    return IssuedTicket.orderLineToIssuedTicket(
+                                            ticketItem,
+                                            user,
+                                            order,
+                                            order.getEventId(),
+                                            orderLineItem);
+                                })
                         .flatMap(Collection::stream)
                         .toList();
         issuedTicketAdaptor.saveAll(issuedTickets);
-        ticketItem.reduceQuantity((long) issuedTickets.size());
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainService.java
@@ -7,8 +7,14 @@ import band.gosrock.domain.common.vo.IssuedTicketInfoVo;
 import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.validator.IssuedTicketValidator;
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
+import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.domain.domains.order.domain.OrderLineItem;
 import band.gosrock.domain.domains.ticket_item.adaptor.TicketItemAdaptor;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
+import band.gosrock.domain.domains.user.domain.User;
+import java.util.Collection;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,11 +25,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class IssuedTicketDomainService {
     private final IssuedTicketAdaptor issuedTicketAdaptor;
     private final TicketItemAdaptor ticketItemAdaptor;
+    private final UserAdaptor userAdaptor;
+    private final OrderAdaptor orderAdaptor;
 
     private final IssuedTicketValidator issuedTicketValidator;
 
     private final OrderToIssuedTicketService orderToIssuedTicketService;
 
+    /*
+    티켓 철회 로직
+     */
     @RedissonLock(LockName = "티켓관리", identifier = "itemId")
     public void withdrawIssuedTicket(Long itemId, List<IssuedTicket> issuedTickets) {
         // itemId로 티켓 아이템 찾아서 (해당 락에선 ticketItem이 하나로 정해지기 때문에)
@@ -62,11 +73,27 @@ public class IssuedTicketDomainService {
         return issuedTicket.toIssuedTicketInfoVo();
     }
 
+    /*
+    티켓 발급 로직
+     */
     @RedissonLock(LockName = "티켓관리", identifier = "itemId")
     public void createIssuedTicket(Long itemId, String orderUuid, Long userId) {
         TicketItem ticketItem = ticketItemAdaptor.queryTicketItem(itemId);
+        User user = userAdaptor.queryUser(userId);
+        Order order = orderAdaptor.findByOrderUuid(orderUuid);
+        List<OrderLineItem> orderLineItems = order.getOrderLineItems();
         List<IssuedTicket> issuedTickets =
-                orderToIssuedTicketService.execute(ticketItem, orderUuid, userId);
+                orderLineItems.stream()
+                        .map(
+                                orderLineItem ->
+                                        IssuedTicket.orderLineToIssuedTicket(
+                                                ticketItem,
+                                                user,
+                                                order,
+                                                order.getEventId(),
+                                                orderLineItem))
+                        .flatMap(Collection::stream)
+                        .toList();
         issuedTicketAdaptor.saveAll(issuedTickets);
         ticketItem.reduceQuantity((long) issuedTickets.size());
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/OrderToIssuedTicketService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/OrderToIssuedTicketService.java
@@ -3,14 +3,9 @@ package band.gosrock.domain.domains.issuedTicket.service;
 
 import band.gosrock.common.annotation.DomainService;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketItemInfoVo;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketOptionAnswer;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketStatus;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketUserInfoVo;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderLineItem;
-import band.gosrock.domain.domains.order.domain.OrderOptionAnswer;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
 import band.gosrock.domain.domains.user.domain.User;
@@ -48,49 +43,7 @@ public class OrderToIssuedTicketService {
             OrderLineItem orderLineItem) {
         Long quantity = orderLineItem.getQuantity();
         return LongStream.range(0, quantity)
-                .mapToObj(i -> createIssuedTicket(ticketItem, user, order, eventId, orderLineItem))
+                .mapToObj(i -> IssuedTicket.create(ticketItem, user, order, eventId, orderLineItem))
                 .toList();
     }
-
-    private IssuedTicket createIssuedTicket(
-            TicketItem ticketItem,
-            User user,
-            Order order,
-            Long eventId,
-            OrderLineItem orderLineItem) {
-        return IssuedTicket.builder()
-                .issuedTicketOptionAnswers(getIssuedTicketOptionAnswers(orderLineItem))
-                .itemInfo(IssuedTicketItemInfoVo.from(ticketItem))
-                .price(ticketItem.getPrice())
-                .orderLineId(orderLineItem.getId())
-                .orderUuid(order.getUuid())
-                .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
-                .userInfo(IssuedTicketUserInfoVo.from(user))
-                .eventId(eventId)
-                .build();
-    }
-
-    //    private static List<Long> getOptionIds(List<OrderOptionAnswer> orderOptionAnswers) {
-    //        return orderOptionAnswers.stream().map(OrderOptionAnswer::getOptionId).toList();
-    //    }
-
-    private List<IssuedTicketOptionAnswer> getIssuedTicketOptionAnswers(
-            OrderLineItem orderLineItem) {
-        List<OrderOptionAnswer> orderOptionAnswers = orderLineItem.getOrderOptionAnswers();
-        //        List<Option> options = getOptionsFromOptionAnswers(orderOptionAnswers);
-
-        return orderOptionAnswers.stream().map(IssuedTicketOptionAnswer::from).toList();
-    }
-
-    //    private List<Option> getOptionsFromOptionAnswers(List<OrderOptionAnswer>
-    // orderOptionAnswers) {
-    //        return optionAdaptor.findAllByIds(getOptionIds(orderOptionAnswers));
-    //    }
-    //
-    //    private Option findOptionFromAnswers(List<Option> options, Long optionId) {
-    //        return options.stream()
-    //                .filter(option -> option.getId().equals(optionId))
-    //                .findFirst()
-    //                .orElseThrow();
-    //    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithdrawOrderEventHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithdrawOrderEventHandler.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class WithDrawOrderEventHandler {
+public class WithdrawOrderEventHandler {
 
     private final IssuedTicketDomainService issuedTicketDomainService;
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/validator/IssuedTicketValidator.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/validator/IssuedTicketValidator.java
@@ -2,8 +2,6 @@ package band.gosrock.domain.domains.issuedTicket.validator;
 
 
 import band.gosrock.common.annotation.Validator;
-import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
-import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.exception.IssuedTicketNotMatchedEventException;
 import java.util.Objects;
@@ -12,16 +10,6 @@ import lombok.RequiredArgsConstructor;
 @Validator
 @RequiredArgsConstructor
 public class IssuedTicketValidator {
-
-    private final EventAdaptor eventAdaptor;
-    private final HostAdaptor hostAdaptor;
-    //
-    //    public void validCanModifyIssuedTicketUser(IssuedTicket issuedTicket, Long currentUserId)
-    // {
-    //        Event event = eventAdaptor.findById(issuedTicket.getEventId());
-    //        Host host = hostAdaptor.findById(event.getHostId());
-    //        host.validateHostUser(currentUserId);
-    //    }
 
     public void validIssuedTicketEventIdEqualEvent(IssuedTicket issuedTicket, Long eventId) {
         if (!Objects.equals(issuedTicket.getEventId(), eventId)) {

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/IssuedTicketTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/IssuedTicketTest.java
@@ -54,7 +54,6 @@ public class IssuedTicketTest {
                         .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
                         .orderLineId(1L)
                         .orderUuid(orderUuid)
-                        .price(W3000)
                         .build();
 
         canceledIssuedTicket =
@@ -67,7 +66,6 @@ public class IssuedTicketTest {
                         .issuedTicketStatus(IssuedTicketStatus.CANCELED)
                         .orderLineId(1L)
                         .orderUuid(orderUuid)
-                        .price(W3000)
                         .build();
 
         entranceIssuedTicket =
@@ -80,7 +78,6 @@ public class IssuedTicketTest {
                         .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_COMPLETED)
                         .orderLineId(1L)
                         .orderUuid(orderUuid)
-                        .price(W3000)
                         .build();
     }
 

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/IssuedTicketTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/IssuedTicketTest.java
@@ -161,4 +161,5 @@ public class IssuedTicketTest {
                 CanNotCancelEntranceException.class, () -> canceledIssuedTicket.entranceCancel());
         assertThrows(CanNotCancelEntranceException.class, () -> issuedTicket.entranceCancel());
     }
+
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/IssuedTicketTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/IssuedTicketTest.java
@@ -161,5 +161,4 @@ public class IssuedTicketTest {
                 CanNotCancelEntranceException.class, () -> canceledIssuedTicket.entranceCancel());
         assertThrows(CanNotCancelEntranceException.class, () -> issuedTicket.entranceCancel());
     }
-
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/validator/IssuedTicketValidatorTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/validator/IssuedTicketValidatorTest.java
@@ -2,8 +2,6 @@ package band.gosrock.domain.domains.issuedTicket.domain.validator;
 
 import static org.mockito.BDDMockito.given;
 
-import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
-import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.exception.IssuedTicketNotMatchedEventException;
 import band.gosrock.domain.domains.issuedTicket.validator.IssuedTicketValidator;
@@ -19,15 +17,11 @@ public class IssuedTicketValidatorTest {
 
     @Mock IssuedTicket issuedTicket;
 
-    @Mock EventAdaptor eventAdaptor;
-
-    @Mock HostAdaptor hostAdaptor;
-
     IssuedTicketValidator issuedTicketValidator;
 
     @BeforeEach
     public void setUp() {
-        issuedTicketValidator = new IssuedTicketValidator(eventAdaptor, hostAdaptor);
+        issuedTicketValidator = new IssuedTicketValidator();
     }
 
     @Test

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainServiceTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainServiceTest.java
@@ -1,28 +1,237 @@
 package band.gosrock.domain.domains.issuedTicket.service;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.*;
 
+import band.gosrock.domain.DisableDomainEvent;
+import band.gosrock.domain.DomainIntegrateSpringBootTest;
+import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketItemInfoVo;
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketOptionAnswer;
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketStatus;
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketUserInfoVo;
 import band.gosrock.domain.domains.issuedTicket.validator.IssuedTicketValidator;
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
+import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.domain.domains.order.domain.OrderLineItem;
+import band.gosrock.domain.domains.order.domain.OrderOptionAnswer;
 import band.gosrock.domain.domains.ticket_item.adaptor.TicketItemAdaptor;
+import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
+import band.gosrock.domain.domains.user.domain.User;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
-@ExtendWith(MockitoExtension.class)
+@DomainIntegrateSpringBootTest
+@DisableDomainEvent
 public class IssuedTicketDomainServiceTest {
+
+    @Autowired IssuedTicketDomainService issuedTicketDomainService;
+
+    @MockBean UserAdaptor userAdaptor;
+
+    @MockBean TicketItemAdaptor ticketItemAdaptor;
+
+    @MockBean OrderAdaptor orderAdaptor;
+
+    @MockBean IssuedTicketAdaptor issuedTicketAdaptor;
 
     @Mock IssuedTicket issuedTicket;
 
-    @Mock IssuedTicketAdaptor issuedTicketAdaptor;
+    @Mock IssuedTicket issuedTicket1;
 
-    @Mock TicketItemAdaptor ticketItemAdaptor;
+    @Mock IssuedTicket issuedTicket2;
+
+    @Mock IssuedTicketOptionAnswer issuedTicketOptionAnswer;
+
+    @Mock IssuedTicketOptionAnswer issuedTicketOptionAnswer1;
+
+    @Mock TicketItem ticketItem;
+
+    @Mock OrderLineItem orderLineItem;
+
+    @Mock OrderLineItem orderLineItem1;
+
+    @Mock OrderOptionAnswer orderOptionAnswer;
+
+    @Mock User user;
+
+    @Mock Order order;
+
+    @Mock IssuedTicketItemInfoVo itemInfoVo;
+
+    @Mock IssuedTicketItemInfoVo itemInfoVo1;
+
+    @Mock IssuedTicketUserInfoVo userInfoVo;
 
     @Mock IssuedTicketValidator issuedTicketValidator;
 
-    @Mock OrderToIssuedTicketService orderToIssuedTicketService;
+    private final String orderUuid = "orderUuid";
+
+    private final List<IssuedTicket> issuedTickets = new ArrayList<>();
+
+    private final List<OrderLineItem> orderLineItems = new ArrayList<>();
+
+    private final Money w3000 = Money.wons(3000L);
 
     @BeforeEach
-    void setUp() {}
+    void setUp() {
+        // Todo: orderLineItem 생성
+
+        issuedTicket =
+                IssuedTicket.builder()
+                        .issuedTicketOptionAnswers(
+                                List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1))
+                        .itemInfo(itemInfoVo)
+                        .userInfo(userInfoVo)
+                        .eventId(1L)
+                        .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
+                        .orderLineId(1L)
+                        .orderUuid(orderUuid)
+                        .build();
+
+        issuedTicket.createUUID();
+        issuedTickets.add(issuedTicket);
+
+        issuedTicket1 =
+                IssuedTicket.builder()
+                        .issuedTicketOptionAnswers(
+                                List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1))
+                        .itemInfo(itemInfoVo)
+                        .userInfo(userInfoVo)
+                        .eventId(1L)
+                        .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
+                        .orderLineId(1L)
+                        .orderUuid(orderUuid)
+                        .build();
+
+        issuedTicket1.createUUID();
+        issuedTickets.add(issuedTicket1);
+
+        issuedTicket2 =
+                IssuedTicket.builder()
+                        .issuedTicketOptionAnswers(
+                                List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1))
+                        .itemInfo(itemInfoVo1)
+                        .userInfo(userInfoVo)
+                        .eventId(1L)
+                        .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
+                        .orderLineId(1L)
+                        .orderUuid(orderUuid)
+                        .build();
+
+        issuedTicket2.createUUID();
+
+        IssuedTicketDomainService issuedTicketDomainService =
+                new IssuedTicketDomainService(
+                        issuedTicketAdaptor,
+                        ticketItemAdaptor,
+                        userAdaptor,
+                        orderAdaptor,
+                        issuedTicketValidator);
+
+        orderLineItems.add(orderLineItem);
+        orderLineItems.add(orderLineItem1);
+    }
+
+    @Test
+    public void 티켓_취소_로직_정상_작동_테스트() {
+        IssuedTicketDomainService issuedTicketDomainService =
+                new IssuedTicketDomainService(
+                        issuedTicketAdaptor,
+                        ticketItemAdaptor,
+                        userAdaptor,
+                        orderAdaptor,
+                        issuedTicketValidator);
+
+        // given
+        given(ticketItemAdaptor.queryTicketItem(any())).willReturn(ticketItem);
+
+        // when
+        issuedTicketDomainService.withdrawIssuedTicket(1L, issuedTickets);
+
+        // then
+        then(ticketItem).should(times(2)).increaseQuantity(1L);
+        assertAll(
+                () ->
+                        assertEquals(
+                                issuedTicket.getIssuedTicketStatus(), IssuedTicketStatus.CANCELED),
+                () ->
+                        assertEquals(
+                                issuedTicket1.getIssuedTicketStatus(), IssuedTicketStatus.CANCELED),
+                () ->
+                        assertEquals(
+                                issuedTicket2.getIssuedTicketStatus(),
+                                IssuedTicketStatus.ENTRANCE_INCOMPLETE));
+    }
+
+    @Test
+    public void 주문중_티켓_취소_로직_정상_작동_테스트() {
+        IssuedTicketDomainService issuedTicketDomainService =
+                new IssuedTicketDomainService(
+                        issuedTicketAdaptor,
+                        ticketItemAdaptor,
+                        userAdaptor,
+                        orderAdaptor,
+                        issuedTicketValidator);
+
+        // given
+        given(issuedTicketAdaptor.findAllByOrderUuid(orderUuid)).willReturn(issuedTickets);
+        given(ticketItemAdaptor.queryTicketItem(any())).willReturn(ticketItem);
+
+        // when
+        issuedTicketDomainService.doneOrderEventAfterRollBackWithdrawIssuedTickets(1L, orderUuid);
+
+        // then
+        then(ticketItem).should(times(2)).increaseQuantity(1L);
+        assertAll(
+                () ->
+                        assertEquals(
+                                issuedTicket.getIssuedTicketStatus(), IssuedTicketStatus.CANCELED),
+                () ->
+                        assertEquals(
+                                issuedTicket1.getIssuedTicketStatus(), IssuedTicketStatus.CANCELED),
+                () ->
+                        assertEquals(
+                                issuedTicket2.getIssuedTicketStatus(),
+                                IssuedTicketStatus.ENTRANCE_INCOMPLETE));
+    }
+
+    @Test
+    public void 발급_티켓_입장_처리_로직_정상_작동_테스트() {
+        // given
+        given(issuedTicketAdaptor.queryIssuedTicket(any())).willReturn(issuedTicket1);
+        given(issuedTicketOptionAnswer.getAdditionalPrice()).willReturn(w3000);
+        given(issuedTicketOptionAnswer1.getAdditionalPrice()).willReturn(w3000);
+
+        // when
+        issuedTicketDomainService.processingEntranceIssuedTicket(1L, 1L);
+
+        // then
+        assertEquals(issuedTicket1.getIssuedTicketStatus(), IssuedTicketStatus.ENTRANCE_COMPLETED);
+    }
+
+    @Test
+    public void 티켓_발급_로직_정상_작동_테스트() {
+        // given
+        given(ticketItemAdaptor.queryTicketItem(any())).willReturn(ticketItem);
+        given(userAdaptor.queryUser(any())).willReturn(user);
+        given(orderAdaptor.findByOrderUuid(any())).willReturn(order);
+        given(order.getOrderLineItems()).willReturn(orderLineItems);
+
+        // when
+        issuedTicketDomainService.createIssuedTicket(1L, orderUuid, 1L);
+
+        // then
+        then(ticketItem).should(times(orderLineItems.size())).reduceQuantity(any());
+
+    }
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainServiceTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainServiceTest.java
@@ -232,6 +232,5 @@ public class IssuedTicketDomainServiceTest {
 
         // then
         then(ticketItem).should(times(orderLineItems.size())).reduceQuantity(any());
-
     }
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainServiceTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainServiceTest.java
@@ -1,0 +1,5 @@
+package band.gosrock.domain.domains.issuedTicket.service;
+
+public class IssuedTicketDomainServiceTest {
+
+}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainServiceTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainServiceTest.java
@@ -1,5 +1,28 @@
 package band.gosrock.domain.domains.issuedTicket.service;
 
+
+import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
+import band.gosrock.domain.domains.issuedTicket.validator.IssuedTicketValidator;
+import band.gosrock.domain.domains.ticket_item.adaptor.TicketItemAdaptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 public class IssuedTicketDomainServiceTest {
 
+    @Mock IssuedTicket issuedTicket;
+
+    @Mock IssuedTicketAdaptor issuedTicketAdaptor;
+
+    @Mock TicketItemAdaptor ticketItemAdaptor;
+
+    @Mock IssuedTicketValidator issuedTicketValidator;
+
+    @Mock OrderToIssuedTicketService orderToIssuedTicketService;
+
+    @BeforeEach
+    void setUp() {}
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/OrderToIssuedTicketServiceTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/OrderToIssuedTicketServiceTest.java
@@ -1,0 +1,10 @@
+package band.gosrock.domain.domains.issuedTicket.service;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class OrderToIssuedTicketServiceTest {
+
+}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/OrderToIssuedTicketServiceTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/OrderToIssuedTicketServiceTest.java
@@ -1,8 +1,0 @@
-package band.gosrock.domain.domains.issuedTicket.service;
-
-
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-@ExtendWith(MockitoExtension.class)
-public class OrderToIssuedTicketServiceTest {}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/OrderToIssuedTicketServiceTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/OrderToIssuedTicketServiceTest.java
@@ -1,10 +1,8 @@
 package band.gosrock.domain.domains.issuedTicket.service;
 
+
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class OrderToIssuedTicketServiceTest {
-
-}
+public class OrderToIssuedTicketServiceTest {}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandlerTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandlerTest.java
@@ -1,0 +1,49 @@
+package band.gosrock.domain.domains.issuedTicket.service.handlers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import band.gosrock.domain.common.events.order.DoneOrderEvent;
+import band.gosrock.domain.domains.issuedTicket.service.IssuedTicketDomainService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class OrderEventHandlerTest {
+
+    @Mock
+    IssuedTicketDomainService issuedTicketDomainService;
+
+    @Mock
+    DoneOrderEvent doneOrderEvent;
+
+    @Mock
+    DoneOrderEvent doneOrderEvent1;
+
+    @Mock
+    DoneOrderEvent doneOrderEvent2;
+
+    @Test
+    public void 주문이_정상_처리되었으면_티켓발급_서비스를_실행하는지_테스트() {
+        OrderEventHandler orderEventHandler = new OrderEventHandler(issuedTicketDomainService);
+        //when
+        orderEventHandler.handleDoneOrderEvent(doneOrderEvent);
+
+        then(issuedTicketDomainService).should(times(1)).createIssuedTicket(any(), any(), any());
+    }
+
+    @Test
+    public void 주문이_여러번_정상_처리되었으면_그만큼_티켓발급_서비스를_실행하는지_테스트() {
+        OrderEventHandler orderEventHandler = new OrderEventHandler(issuedTicketDomainService);
+        //when
+        orderEventHandler.handleDoneOrderEvent(doneOrderEvent);
+        orderEventHandler.handleDoneOrderEvent(doneOrderEvent1);
+        orderEventHandler.handleDoneOrderEvent(doneOrderEvent2);
+
+        then(issuedTicketDomainService).should(times(3)).createIssuedTicket(any(), any(), any());
+    }
+}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandlerTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/handlers/OrderEventHandlerTest.java
@@ -8,29 +8,24 @@ import band.gosrock.domain.common.events.order.DoneOrderEvent;
 import band.gosrock.domain.domains.issuedTicket.service.IssuedTicketDomainService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class OrderEventHandlerTest {
 
-    @Mock
-    IssuedTicketDomainService issuedTicketDomainService;
+    @Mock IssuedTicketDomainService issuedTicketDomainService;
 
-    @Mock
-    DoneOrderEvent doneOrderEvent;
+    @Mock DoneOrderEvent doneOrderEvent;
 
-    @Mock
-    DoneOrderEvent doneOrderEvent1;
+    @Mock DoneOrderEvent doneOrderEvent1;
 
-    @Mock
-    DoneOrderEvent doneOrderEvent2;
+    @Mock DoneOrderEvent doneOrderEvent2;
 
     @Test
     public void 주문이_정상_처리되었으면_티켓발급_서비스를_실행하는지_테스트() {
         OrderEventHandler orderEventHandler = new OrderEventHandler(issuedTicketDomainService);
-        //when
+        // when
         orderEventHandler.handleDoneOrderEvent(doneOrderEvent);
 
         then(issuedTicketDomainService).should(times(1)).createIssuedTicket(any(), any(), any());
@@ -39,7 +34,7 @@ public class OrderEventHandlerTest {
     @Test
     public void 주문이_여러번_정상_처리되었으면_그만큼_티켓발급_서비스를_실행하는지_테스트() {
         OrderEventHandler orderEventHandler = new OrderEventHandler(issuedTicketDomainService);
-        //when
+        // when
         orderEventHandler.handleDoneOrderEvent(doneOrderEvent);
         orderEventHandler.handleDoneOrderEvent(doneOrderEvent1);
         orderEventHandler.handleDoneOrderEvent(doneOrderEvent2);

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithdrawOrderEventHandlerTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithdrawOrderEventHandlerTest.java
@@ -1,5 +1,59 @@
 package band.gosrock.domain.domains.issuedTicket.service.handlers;
 
+import static org.mockito.BDDMockito.*;
+
+import band.gosrock.domain.common.events.order.WithDrawOrderEvent;
+import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
+import band.gosrock.domain.domains.issuedTicket.service.IssuedTicketDomainService;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 public class WithdrawOrderEventHandlerTest {
 
+    @Mock
+    IssuedTicketDomainService issuedTicketDomainService;
+
+    @Mock
+    IssuedTicketAdaptor issuedTicketAdaptor;
+
+    @Mock
+    IssuedTicket issuedTicket;
+
+    @Mock
+    IssuedTicket issuedTicket1;
+
+    @Mock
+    WithDrawOrderEvent withDrawOrderEvent;
+
+    List<IssuedTicket> issuedTickets = new ArrayList<>();
+
+    private String orderUuid = "ORDERUUID";
+
+    @BeforeEach
+    void setUp() {
+        issuedTickets.add(issuedTicket);
+        issuedTickets.add(issuedTicket1);
+    }
+
+    @Test
+    public void 주문이_취소되었으면_티켓발급_취소_로직_실행_테스트() {
+        WithdrawOrderEventHandler withDrawOrderEventHandler = new WithdrawOrderEventHandler(
+            issuedTicketDomainService, issuedTicketAdaptor);
+        //given
+        given(withDrawOrderEvent.getOrderUuid()).willReturn(orderUuid);
+        given(issuedTicketAdaptor.findAllByOrderUuid(orderUuid)).willReturn(issuedTickets);
+
+        //when
+        withDrawOrderEventHandler.handleWithdrawOrderEvent(withDrawOrderEvent);
+
+        //then
+        then(issuedTicketDomainService).should(times(1)).withdrawIssuedTicket(any(), any());
+    }
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithdrawOrderEventHandlerTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithdrawOrderEventHandlerTest.java
@@ -17,20 +17,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class WithdrawOrderEventHandlerTest {
 
-    @Mock
-    IssuedTicketDomainService issuedTicketDomainService;
+    @Mock IssuedTicketDomainService issuedTicketDomainService;
 
-    @Mock
-    IssuedTicketAdaptor issuedTicketAdaptor;
+    @Mock IssuedTicketAdaptor issuedTicketAdaptor;
 
-    @Mock
-    IssuedTicket issuedTicket;
+    @Mock IssuedTicket issuedTicket;
 
-    @Mock
-    IssuedTicket issuedTicket1;
+    @Mock IssuedTicket issuedTicket1;
 
-    @Mock
-    WithDrawOrderEvent withDrawOrderEvent;
+    @Mock WithDrawOrderEvent withDrawOrderEvent;
 
     List<IssuedTicket> issuedTickets = new ArrayList<>();
 
@@ -44,16 +39,16 @@ public class WithdrawOrderEventHandlerTest {
 
     @Test
     public void 주문이_취소되었으면_티켓발급_취소_로직_실행_테스트() {
-        WithdrawOrderEventHandler withDrawOrderEventHandler = new WithdrawOrderEventHandler(
-            issuedTicketDomainService, issuedTicketAdaptor);
-        //given
+        WithdrawOrderEventHandler withDrawOrderEventHandler =
+                new WithdrawOrderEventHandler(issuedTicketDomainService, issuedTicketAdaptor);
+        // given
         given(withDrawOrderEvent.getOrderUuid()).willReturn(orderUuid);
         given(issuedTicketAdaptor.findAllByOrderUuid(orderUuid)).willReturn(issuedTickets);
 
-        //when
+        // when
         withDrawOrderEventHandler.handleWithdrawOrderEvent(withDrawOrderEvent);
 
-        //then
+        // then
         then(issuedTicketDomainService).should(times(1)).withdrawIssuedTicket(any(), any());
     }
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithdrawOrderEventHandlerTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/handlers/WithdrawOrderEventHandlerTest.java
@@ -1,0 +1,5 @@
+package band.gosrock.domain.domains.issuedTicket.service.handlers;
+
+public class WithdrawOrderEventHandlerTest {
+
+}


### PR DESCRIPTION
## 개요
- close #316

## 작업사항
- 발급 티켓 관련 서비스들에 관한 테스트 코드를 작성했습니다.
- 아직 동시성 테스트에 관한 코드는 작성하지 못했습니다.
- 따로 이슈 파서 작업하도록 하겠습니다.
- 다음 이슈에서 발급 티켓 쪽 커버리지 100%를 노려보겠습니다.

## 변경로직
- 발급 티켓 생성하는 코드 부분이 뎁스를 한 번 더 들어가는 것이 불필요하고 테스트 코드 짜는데에 있어서 불편해서 orderToIssuedTicket에서 담당하는 코드를 조금씩 분산해서 리팩토링 했습니다.