### PR TITLE
test : 호스트 유저 테스트 코드 작성

### DIFF
--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostInfoVo.java
@@ -20,7 +20,7 @@ public class HostInfoVo {
 
     private final String contactNumber;
 
-    private final boolean partner;
+    private final Boolean partner;
 
     public static HostInfoVo from(Host host) {
         return HostInfoVo.builder()

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostInfoVo.java
@@ -3,9 +3,11 @@ package band.gosrock.domain.common.vo;
 
 import band.gosrock.domain.domains.host.domain.Host;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode
 @Builder
 public class HostInfoVo {
     private final Long hostId;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostProfileVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/HostProfileVo.java
@@ -3,9 +3,11 @@ package band.gosrock.domain.common.vo;
 
 import band.gosrock.domain.domains.host.domain.Host;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode
 @Builder
 public class HostProfileVo {
     private final Long hostId;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
@@ -1,5 +1,7 @@
 package band.gosrock.domain.domains.host.domain;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 
 import band.gosrock.domain.common.aop.domainEvent.Events;
 import band.gosrock.domain.common.events.host.HostRegisterSlackEvent;
@@ -33,7 +35,7 @@ public class Host extends BaseTimeEntity {
 
     // 파트너 여부
     // 정책상 초기값 false 로 고정입니다
-    private final Boolean partner = false;
+    private final Boolean partner = FALSE;
 
     // 슬랙 웹훅 url
     private String slackUrl;
@@ -68,11 +70,6 @@ public class Host extends BaseTimeEntity {
                 .orElseThrow(() -> HostUserNotFoundException.EXCEPTION);
     }
 
-    public String getSlackToken() {
-        if (this.slackUrl == null) return null;
-        return this.slackUrl.substring(this.slackUrl.indexOf("https://hooks.slack.com/services/"));
-    }
-
     public void updateProfile(HostProfile hostProfile) {
         this.profile.updateProfile(hostProfile);
     }
@@ -100,9 +97,8 @@ public class Host extends BaseTimeEntity {
 
     public void setHostUserRole(Long userId, HostRole role) {
         // 마스터의 역할은 수정할 수 없음
-        if (this.getMasterUserId().equals(userId)) {
+        if (this.getMasterUserId().equals(userId))
             throw CannotModifyMasterHostRoleException.EXCEPTION;
-        }
         this.hostUsers.stream()
                 .filter(hostUser -> hostUser.getUserId().equals(userId))
                 .findFirst()
@@ -125,17 +121,13 @@ public class Host extends BaseTimeEntity {
 
     /** 해당 유저가 호스트에 속하는지 확인하는 검증 로직입니다 */
     public void validateHostUser(Long userId) {
-        if (!this.hasHostUserId(userId)) {
-            throw ForbiddenHostException.EXCEPTION;
-        }
+        if (!this.hasHostUserId(userId)) throw ForbiddenHostException.EXCEPTION;
     }
 
     /** 해당 유저가 호스트에 속하며 가입 승인을 완료했는지 (활성상태) 확인하는 검증 로직입니다 */
     public void validateActiveHostUser(Long userId) {
         this.validateHostUser(userId);
-        if (!this.isActiveHostUserId(userId)) {
-            throw NotAcceptedHostException.EXCEPTION;
-        }
+        if (!this.isActiveHostUserId(userId)) throw NotAcceptedHostException.EXCEPTION;
     }
 
     /** 해당 유저가 매니저 이상인지 확인하는 검증 로직입니다 */
@@ -149,16 +141,12 @@ public class Host extends BaseTimeEntity {
     /** 해당 유저가 호스트의 마스터(담당자, 방장)인지 확인하는 검증 로직입니다 */
     public void validateMasterHostUser(Long userId) {
         this.validateActiveHostUser(userId);
-        if (!this.getMasterUserId().equals(userId)) {
-            throw NotMasterHostException.EXCEPTION;
-        }
+        if (!this.getMasterUserId().equals(userId)) throw NotMasterHostException.EXCEPTION;
     }
 
     /** 해당 호스트가 파트너 인지 검증합니다. */
     public void validatePartnerHost() {
-        if (!partner) {
-            throw NotPartnerHostException.EXCEPTION;
-        }
+        if (partner != TRUE) throw NotPartnerHostException.EXCEPTION;
     }
 
     public HostInfoVo toHostInfoVo() {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostUser.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostUser.java
@@ -1,5 +1,7 @@
 package band.gosrock.domain.domains.host.domain;
 
+import static band.gosrock.domain.domains.host.domain.HostRole.GUEST;
+import static java.lang.Boolean.FALSE;
 
 import band.gosrock.domain.common.aop.domainEvent.Events;
 import band.gosrock.domain.common.events.host.HostUserJoinEvent;
@@ -32,11 +34,11 @@ public class HostUser extends BaseTimeEntity {
     private Long userId;
 
     // 초대 승락 여부
-    private Boolean active = false;
+    private Boolean active = FALSE;
 
     // 유저의 권한
     @Enumerated(EnumType.STRING)
-    private HostRole role = HostRole.GUEST;
+    private HostRole role = GUEST;
 
     public void setHostRole(HostRole role) {
         this.role = role;

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostProfileTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostProfileTest.java
@@ -1,0 +1,42 @@
+package band.gosrock.domain.domains.host.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class HostProfileTest {
+
+    @Mock Host host;
+
+    HostProfile hostProfile;
+
+    @BeforeEach
+    void setup() {
+        hostProfile = HostProfile.builder().build();
+    }
+
+    @Test
+    void 호스트_프로필_업데이트_테스트() {
+        // given
+        final HostProfile newHostProfile =
+                HostProfile.builder()
+                        .name("테스트")
+                        .contactEmail("22@cc.com")
+                        .contactNumber("010-0000-0000")
+                        .introduce("123")
+                        .profileImageKey("key")
+                        .build();
+        // when
+        hostProfile.updateProfile(newHostProfile);
+        // then
+        assertEquals(hostProfile.getProfileImage(), newHostProfile.getProfileImage());
+        assertEquals(hostProfile.getContactEmail(), newHostProfile.getContactEmail());
+        assertEquals(hostProfile.getContactNumber(), newHostProfile.getContactNumber());
+        assertEquals(hostProfile.getIntroduce(), newHostProfile.getIntroduce());
+    }
+}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostRoleTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostRoleTest.java
@@ -1,0 +1,24 @@
+package band.gosrock.domain.domains.host.domain;
+
+import static band.gosrock.domain.domains.host.domain.HostRole.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class HostRoleTest {
+
+    @Test
+    void ENUM_값에_해당하지_않으면_NULL_반환해야한다() {
+        // given
+        // when
+        // then
+        assertEquals(HostRole.fromHostRole("MASTER"), MASTER);
+        assertEquals(HostRole.fromHostRole("MANAGER"), MANAGER);
+        assertEquals(HostRole.fromHostRole("GUEST"), GUEST);
+        assertNull(HostRole.fromHostRole("NOT_PROVIDED"));
+    }
+}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostTest.java
@@ -311,6 +311,7 @@ public class HostTest {
     public void 호스트_vo_변환_테스트() {
         // given
         // when
+        HostInfoVo hostInfoVo1 = host.toHostInfoVo();
         // then
         assertEquals(host.toHostInfoVo().getClass(), HostInfoVo.class);
         assertEquals(host.toHostProfileVo().getClass(), HostProfileVo.class);

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostTest.java
@@ -311,9 +311,8 @@ public class HostTest {
     public void 호스트_vo_변환_테스트() {
         // given
         // when
-        HostInfoVo hostInfoVo1 = host.toHostInfoVo();
         // then
-        assertEquals(host.toHostInfoVo().getClass(), HostInfoVo.class);
-        assertEquals(host.toHostProfileVo().getClass(), HostProfileVo.class);
+        assertEquals(host.toHostInfoVo(), HostInfoVo.from(host));
+        assertEquals(host.toHostProfileVo(), HostProfileVo.from(host));
     }
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import band.gosrock.domain.common.vo.HostInfoVo;
+import band.gosrock.domain.common.vo.HostProfileVo;
 import band.gosrock.domain.domains.host.exception.*;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +21,8 @@ public class HostTest {
     @Mock HostUser managerHostUser;
     @Mock HostUser guestHostUser;
     @Mock HostProfile hostProfile;
+    @Mock HostInfoVo hostInfoVo;
+    @Mock HostProfileVo hostProfileVo;
 
     Host host;
     final Long masterUserId = 1L;
@@ -301,5 +305,14 @@ public class HostTest {
         // then
         assertThrows(NotPartnerHostException.class, () -> host.validatePartnerHost());
         assertDoesNotThrow(partnerHost::validatePartnerHost);
+    }
+
+    @Test
+    public void 호스트_vo_변환_테스트() {
+        // given
+        // when
+        // then
+        assertEquals(host.toHostInfoVo().getClass(), HostInfoVo.class);
+        assertEquals(host.toHostProfileVo().getClass(), HostProfileVo.class);
     }
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostUserTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostUserTest.java
@@ -1,0 +1,54 @@
+package band.gosrock.domain.domains.host.domain;
+
+import static band.gosrock.domain.domains.host.domain.HostRole.MANAGER;
+import static band.gosrock.domain.domains.host.domain.HostRole.MASTER;
+import static java.lang.Boolean.TRUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import band.gosrock.domain.domains.host.exception.AlreadyJoinedHostException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class HostUserTest {
+
+    @Mock Host host;
+    HostUser hostUser;
+
+    @BeforeEach
+    void setup() {
+        hostUser = HostUser.builder().host(host).role(MASTER).build();
+    }
+
+    @Test
+    void 호스트유저_권한변경_테스트() {
+        // given
+        final HostRole role = MANAGER;
+        // when
+        hostUser.setHostRole(role);
+        // then
+        assertEquals(hostUser.getRole(), role);
+    }
+
+    @Test
+    void 호스트유저_초대수락으로_활성화_테스트() {
+        // given
+        // when
+        hostUser.activate();
+        // then
+        assertEquals(hostUser.getActive(), TRUE);
+    }
+
+    @Test
+    void 호스트유저_초대_중복수락은_불가능하다() {
+        // given
+        // when
+        hostUser.activate();
+        // then
+        assertThrows(AlreadyJoinedHostException.class, () -> hostUser.activate());
+    }
+}


### PR DESCRIPTION
## 개요
- close #355 

## 작업사항
- 호스트 유저 테스트 코드 작성
- 호스트 프로필 테스트 코드 작성
- 호스트 불필요 로직 삭제
- 호스트 VO 테스트 코드 작성
<img width="527" alt="image" src="https://user-images.githubusercontent.com/72291860/218937618-21ddff39-7ff8-4731-92c8-2d493fadfbec.png">

- Boolean 타입 주입 및 비교 시 `Boolean.TRUE` 같은 static method 이용해서 주입
- Boolean 타입 같은 경우 `!partner` 이런식으로 비교하면 NPE 발생 가능성이 있대서
`partner != Boolean.TRUE` 이런 식으로 비교하는 것이 바람직 하다네요

## 변경로직
- 위와 같음