### PR TITLE
feat : 두둥 티켓 적용

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostCallTransactionFactory.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostCallTransactionFactory.java
@@ -1,20 +1,38 @@
 package band.gosrock.api.common.aop.hostRole;
 
 
-import lombok.RequiredArgsConstructor;
+import band.gosrock.api.common.UserUtils;
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
+import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import org.springframework.stereotype.Component;
 
-@RequiredArgsConstructor
 @Component
 class HostCallTransactionFactory {
 
     private final HostRoleEventTransaction hostRoleEventTransaction;
-    private final HostRoleHostTransaction hostRoleHostTransaction;
+    private final HostRoleEventTransaction hostRoleEventWithoutTransaction;
 
-    public HostRoleCallTransaction getCallTransaction(FindHostFrom findHostFrom) {
+    public HostCallTransactionFactory(
+            UserUtils userUtils,
+            HostAdaptor hostAdaptor,
+            EventAdaptor eventAdaptor,
+            HostRoleEventTransaction hostRoleEventTransaction,
+            HostRoleHostTransaction hostRoleHostTransaction) {
+        this.hostRoleEventTransaction = hostRoleEventTransaction;
+        this.hostRoleEventWithoutTransaction =
+                new HostRoleEventTransaction(userUtils, eventAdaptor, hostAdaptor);
+        this.hostRoleHostTransaction = hostRoleHostTransaction;
+        this.hostRoleHostWithoutTransaction = new HostRoleHostTransaction(userUtils, hostAdaptor);
+    }
+
+    private final HostRoleHostTransaction hostRoleHostTransaction;
+    private final HostRoleHostTransaction hostRoleHostWithoutTransaction;
+
+    public HostRoleCallTransaction getCallTransaction(
+            FindHostFrom findHostFrom, Boolean applyTransaction) {
         if (findHostFrom == FindHostFrom.HOST_ID) {
-            return hostRoleHostTransaction;
+            return applyTransaction ? hostRoleHostTransaction : hostRoleHostWithoutTransaction;
         }
-        return hostRoleEventTransaction;
+        return applyTransaction ? hostRoleEventTransaction : hostRoleEventWithoutTransaction;
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleAop.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleAop.java
@@ -44,7 +44,7 @@ class HostRoleAop {
         Long id = getId(parameterNames, args, identifier);
 
         return hostCallTransactionFactory
-                .getCallTransaction(findHostFrom)
+                .getCallTransaction(findHostFrom, annotation.applyTransaction())
                 .proceed(id, hostQualification, joinPoint);
     }
 

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleCallTransaction.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleCallTransaction.java
@@ -4,6 +4,6 @@ package band.gosrock.api.common.aop.hostRole;
 import org.aspectj.lang.ProceedingJoinPoint;
 
 interface HostRoleCallTransaction {
-    Object proceed(Long id, HostQualification role, final ProceedingJoinPoint joinPoint)
+    Object proceed(Long eventId, HostQualification role, final ProceedingJoinPoint joinPoint)
             throws Throwable;
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleCallTransaction.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleCallTransaction.java
@@ -4,6 +4,6 @@ package band.gosrock.api.common.aop.hostRole;
 import org.aspectj.lang.ProceedingJoinPoint;
 
 interface HostRoleCallTransaction {
-    Object proceed(Long eventId, HostQualification role, final ProceedingJoinPoint joinPoint)
+    Object proceed(Long id, HostQualification role, final ProceedingJoinPoint joinPoint)
             throws Throwable;
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleEventTransaction.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleEventTransaction.java
@@ -25,10 +25,14 @@ class HostRoleEventTransaction implements HostRoleCallTransaction {
     @Transactional(readOnly = true)
     public Object proceed(Long eventId, HostQualification role, final ProceedingJoinPoint joinPoint)
             throws Throwable {
+        validRole(eventId, role);
+        return joinPoint.proceed();
+    }
+
+    private void validRole(Long eventId, HostQualification role) {
         Long currentUserId = userUtils.getCurrentUserId();
         Event event = eventAdaptor.findById(eventId);
         Host host = hostAdaptor.findById(event.getHostId());
         role.validQualification(currentUserId, host);
-        return joinPoint.proceed();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleHostTransaction.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRoleHostTransaction.java
@@ -22,9 +22,13 @@ class HostRoleHostTransaction implements HostRoleCallTransaction {
     @Transactional(readOnly = true)
     public Object proceed(Long hostId, HostQualification role, final ProceedingJoinPoint joinPoint)
             throws Throwable {
+        validRole(hostId, role);
+        return joinPoint.proceed();
+    }
+
+    private void validRole(Long hostId, HostQualification role) {
         Long currentUserId = userUtils.getCurrentUserId();
         Host host = hostAdaptor.findById(hostId);
         role.validQualification(currentUserId, host);
-        return joinPoint.proceed();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRolesAllowed.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/common/aop/hostRole/HostRolesAllowed.java
@@ -18,4 +18,6 @@ public @interface HostRolesAllowed {
     HostQualification role();
 
     FindHostFrom findHostFrom();
+
+    boolean applyTransaction() default true;
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/CreateOrderResponse.java
@@ -5,6 +5,7 @@ import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderMethod;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.ticket_item.domain.TicketPayType;
 import band.gosrock.domain.domains.ticket_item.domain.TicketType;
 import band.gosrock.domain.domains.user.domain.Profile;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -38,6 +39,12 @@ public class CreateOrderResponse {
     @Schema(description = "티켓의 타입. 승인 , 선착순 두가지입니다.")
     private final TicketType ticketType;
 
+    @Schema(description = "티켓의 지불 타입. 두둥티켓, 무료 , 유료 세가지입니다.")
+    private final TicketPayType ticketPayType;
+
+    @Schema(description = "계좌정보", nullable = true)
+    private final String accountNumber;
+
     public static CreateOrderResponse from(Order order, TicketItem item, Profile profile) {
         return CreateOrderResponse.builder()
                 .customerEmail(profile.getEmail())
@@ -48,6 +55,8 @@ public class CreateOrderResponse {
                 .orderMethod(order.getOrderMethod())
                 .isNeedPayment(order.isNeedPaid())
                 .ticketType(item.getType())
+                .ticketPayType(item.getPayType())
+                .accountNumber(item.getAccountNumber())
                 .build();
     }
 }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ApproveOrderUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/service/ApproveOrderUseCase.java
@@ -18,7 +18,7 @@ public class ApproveOrderUseCase {
 
     private final OrderMapper orderMapper;
 
-    @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID)
+    @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID, applyTransaction = false)
     public OrderResponse execute(Long eventId, String orderUuid) {
         String confirmOrderUuid = orderApproveService.execute(orderUuid);
         return orderMapper.toOrderResponse(confirmOrderUuid);

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -142,9 +142,6 @@ public class Order extends BaseTimeEntity {
     /** 승인 결제인 주문을 생성합니다. */
     public static Order createApproveOrder(
             Long userId, Cart cart, TicketItem item, OrderValidator orderValidator) {
-        if (cart.isNeedPaid()) {
-            throw InvalidOrderException.EXCEPTION;
-        }
         Order order =
                 Order.builder()
                         .userId(userId)
@@ -155,6 +152,7 @@ public class Order extends BaseTimeEntity {
                         .eventId(item.getEventId())
                         .build();
         orderValidator.validCanCreate(order);
+        order.calculatePaymentInfo();
         return order;
     }
 
@@ -310,7 +308,7 @@ public class Order extends BaseTimeEntity {
     /** 결제가 필요한 오더인지 반환합니다. */
     public Boolean isNeedPaid() {
         // 결제 여부는 총 결제금액으로 정함
-        return Money.ZERO.isLessThan(getTotalPaymentPrice());
+        return Money.ZERO.isLessThan(getTotalPaymentPrice()) && orderMethod.isPayment();
     }
 
     /** 결제 수단 정보를 가져옵니다. */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderCouponVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/OrderCouponVo.java
@@ -6,6 +6,7 @@ import static band.gosrock.common.consts.DuDoongStatic.ZERO;
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.coupon.domain.IssuedCoupon;
 import band.gosrock.domain.domains.order.exception.LessThanMinmumPaymentOrderException;
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +16,10 @@ import lombok.NoArgsConstructor;
 @Embeddable
 @NoArgsConstructor
 public class OrderCouponVo {
+
+    @Column(name = "coupon_name")
     private String name = "사용하지 않음";
+
     private Money discountAmount = Money.ZERO;
     private Long couponId = ZERO;
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderFactory.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/OrderFactory.java
@@ -10,6 +10,7 @@ import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.validator.OrderValidator;
 import band.gosrock.domain.domains.ticket_item.adaptor.TicketItemAdaptor;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.ticket_item.domain.TicketPayType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,12 +30,23 @@ public class OrderFactory {
     public Order createNormalOrder(Long cartId, Long userId) {
         Cart cart = cartAdaptor.queryCart(cartId, userId);
         TicketItem ticketItem = itemAdaptor.queryTicketItem(cart.getItemId());
-        // 결제 주문 생성
-        if (ticketItem.isFCFS()) {
-            return Order.createPaymentOrder(userId, cart, ticketItem, orderValidator);
+        TicketPayType payType = ticketItem.getPayType();
+        // 두둥티켓
+        if (payType == TicketPayType.DUDOONG_TICKET) {
+            return Order.createApproveOrder(userId, cart, ticketItem, orderValidator);
         }
-        // 승인 주문 생성
-        return Order.createApproveOrder(userId, cart, ticketItem, orderValidator);
+        // 무료 티켓
+        if (payType == TicketPayType.FREE_TICKET) {
+            // 선착순 티켓
+            if (ticketItem.isFCFS()) {
+                return Order.createPaymentOrder(userId, cart, ticketItem, orderValidator);
+            }
+            // 승인 티켓
+            return Order.createApproveOrder(userId, cart, ticketItem, orderValidator);
+        }
+        // 유료 티켓
+        // 결제 주문 생성
+        return Order.createPaymentOrder(userId, cart, ticketItem, orderValidator);
     }
 
     public Order createCouponOrder(Long cartId, Long userId, Long couponId) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/handler/ConfirmOrderFailHandler.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/service/handler/ConfirmOrderFailHandler.java
@@ -7,6 +7,7 @@ import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
 import band.gosrock.domain.domains.issuedTicket.service.IssuedTicketDomainService;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.domain.domains.order.domain.OrderStatus;
 import band.gosrock.domain.domains.order.service.WithdrawPaymentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +38,10 @@ public class ConfirmOrderFailHandler {
         log.info(doneOrderEvent.getOrderUuid() + "주문 실패 처리 핸들러");
 
         Order order = orderAdaptor.findByOrderUuid(doneOrderEvent.getOrderUuid());
+        if (order.getOrderStatus() == OrderStatus.FAILED) {
+            return;
+        }
+
         order.fail();
 
         if (order.hasCoupon()) { // 쿠폰 사용했을 시 쿠폰 복구
@@ -47,7 +52,7 @@ public class ConfirmOrderFailHandler {
         issuedTicketDomainService.doneOrderEventAfterRollBackWithdrawIssuedTickets(
                 doneOrderEvent.getItemId(), doneOrderEvent.getOrderUuid());
 
-        if (order.isPaid()) {
+        if (order.isNeedPaid()) {
             log.info(
                     doneOrderEvent.getOrderUuid()
                             + ":"


### PR DESCRIPTION
## 개요
- close #340 

## 작업사항
- 주문쪽은 뭐 크게 변한거없이 적용했습니다.
- 승인/선착순 두개 타입으로 그대로 적용했으며
- 아이템의 타입에 따라서 승인 주문을 생성할지 , 선착순을 생성할지 시도했습니다.

## 변경로직
- HostRollAllowed 어노테이션에 트랜잭션 끌지 켤지 옵션넣어줬습니다 @kim-wonjin 
- 디폴트는 true이므로 기존껀 건드실 필요없지만 
- 트랜잭션을 분리해야할 경우 적용하시길 바랍니다. ( 락을 잡고 새로운 트랜잭션에서 수행할경우 )
