### PR TITLE
feat : 주문 관련 호스트 슬랙 알림

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/order/DudoongTicketRefundOrderEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/order/DudoongTicketRefundOrderEventHandler.java
@@ -1,0 +1,46 @@
+package band.gosrock.api.slack.handler.order;
+
+
+import band.gosrock.domain.common.alarm.HostSlackAlarm;
+import band.gosrock.domain.common.events.order.WithDrawOrderEvent;
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
+import band.gosrock.domain.domains.event.domain.Event;
+import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
+import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
+import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.infrastructure.config.slack.SlackMessageProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DudoongTicketRefundOrderEventHandler {
+    private final EventAdaptor eventAdaptor;
+
+    private final HostAdaptor hostAdaptor;
+    private final OrderAdaptor orderAdaptor;
+    private final SlackMessageProvider slackMessageProvider;
+
+    @Async
+    @TransactionalEventListener(
+            classes = WithDrawOrderEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(readOnly = true)
+    public void handle(WithDrawOrderEvent withDrawOrderEvent) {
+        log.info("두둥 티켓 환불시 전송되는 알림");
+        if (!withDrawOrderEvent.getIsDudoongTicketOrder()) return;
+        if (!withDrawOrderEvent.getIsRefund()) return;
+        Order order = orderAdaptor.findByOrderUuid(withDrawOrderEvent.getOrderUuid());
+        Event event = eventAdaptor.findById(order.getEventId());
+        Host host = hostAdaptor.findById(event.getHostId());
+        String message = HostSlackAlarm.dudoongOrderRefund(event, order);
+        slackMessageProvider.sendMessage(host.getSlackUrl(), message);
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/order/NewApproveOrderAlarmEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/order/NewApproveOrderAlarmEventHandler.java
@@ -1,0 +1,37 @@
+package band.gosrock.api.slack.handler.order;
+
+
+import band.gosrock.api.email.service.HostUserInvitationEmailService;
+import band.gosrock.domain.common.events.host.HostUserInvitationEvent;
+import band.gosrock.domain.domains.host.domain.HostRole;
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
+import band.gosrock.domain.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NewApproveOrderAlarmEventHandler {
+    private final UserAdaptor userAdaptor;
+    private final HostUserInvitationEmailService invitationEmailService;
+
+    @Async
+    @TransactionalEventListener(
+            classes = HostUserInvitationEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(readOnly = true)
+    public void handle(HostUserInvitationEvent hostUserInvitationEvent) {
+        final Long userId = hostUserInvitationEvent.getUserId();
+        final User user = userAdaptor.queryUser(userId);
+        final HostRole role = hostUserInvitationEvent.getRole();
+        final String hostName = hostUserInvitationEvent.getHostProfileVo().getName();
+
+        invitationEmailService.execute(user.toEmailUserInfo(), hostName, role);
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/order/NewConfirmOrderAlarmEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/order/NewConfirmOrderAlarmEventHandler.java
@@ -1,0 +1,49 @@
+package band.gosrock.api.slack.handler.order;
+
+
+import band.gosrock.domain.common.alarm.HostSlackAlarm;
+import band.gosrock.domain.common.events.order.DoneOrderEvent;
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
+import band.gosrock.domain.domains.event.domain.Event;
+import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
+import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
+import band.gosrock.domain.domains.order.domain.Order;
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
+import band.gosrock.infrastructure.config.slack.SlackMessageProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NewConfirmOrderAlarmEventHandler {
+    private final UserAdaptor userAdaptor;
+
+    private final EventAdaptor eventAdaptor;
+
+    private final HostAdaptor hostAdaptor;
+    private final OrderAdaptor orderAdaptor;
+    private final SlackMessageProvider slackMessageProvider;
+
+    @Async
+    @TransactionalEventListener(
+            classes = DoneOrderEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(readOnly = true)
+    public void handle(DoneOrderEvent doneOrderEvent) {
+        // 선착순 방식의 결제만 알림 발송 대상.
+        if (!doneOrderEvent.getOrderMethod().isPayment()) return;
+        log.info("선착순 방식의 결제만 알림 발송 대상 알림 전송");
+        Order order = orderAdaptor.findByOrderUuid(doneOrderEvent.getOrderUuid());
+        Event event = eventAdaptor.findById(order.getEventId());
+        Host host = hostAdaptor.findById(event.getHostId());
+        String message = HostSlackAlarm.newConfirmOrder(event, order);
+        slackMessageProvider.sendMessage(host.getSlackUrl(), message);
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/order/NewConfirmOrderAlarmEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/order/NewConfirmOrderAlarmEventHandler.java
@@ -9,7 +9,6 @@ import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
-import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
 import band.gosrock.infrastructure.config.slack.SlackMessageProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,8 +22,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 @Slf4j
 public class NewConfirmOrderAlarmEventHandler {
-    private final UserAdaptor userAdaptor;
-
     private final EventAdaptor eventAdaptor;
 
     private final HostAdaptor hostAdaptor;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/order/OrderApprovedAlarmEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/order/OrderApprovedAlarmEventHandler.java
@@ -1,0 +1,37 @@
+package band.gosrock.api.slack.handler.order;
+
+
+import band.gosrock.api.email.service.HostUserInvitationEmailService;
+import band.gosrock.domain.common.events.host.HostUserInvitationEvent;
+import band.gosrock.domain.domains.host.domain.HostRole;
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
+import band.gosrock.domain.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OrderApprovedAlarmEventHandler {
+    private final UserAdaptor userAdaptor;
+    private final HostUserInvitationEmailService invitationEmailService;
+
+    @Async
+    @TransactionalEventListener(
+            classes = HostUserInvitationEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(readOnly = true)
+    public void handle(HostUserInvitationEvent hostUserInvitationEvent) {
+        final Long userId = hostUserInvitationEvent.getUserId();
+        final User user = userAdaptor.queryUser(userId);
+        final HostRole role = hostUserInvitationEvent.getRole();
+        final String hostName = hostUserInvitationEvent.getHostProfileVo().getName();
+
+        invitationEmailService.execute(user.toEmailUserInfo(), hostName, role);
+    }
+}

--- a/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/order/WithDrawOrderEventHandler.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/slack/handler/order/WithDrawOrderEventHandler.java
@@ -2,7 +2,7 @@ package band.gosrock.api.slack.handler.order;
 
 
 import band.gosrock.domain.common.alarm.HostSlackAlarm;
-import band.gosrock.domain.common.events.order.DoneOrderEvent;
+import band.gosrock.domain.common.events.order.WithDrawOrderEvent;
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor;
 import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
@@ -21,7 +21,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class OrderApprovedAlarmEventHandler {
+public class WithDrawOrderEventHandler {
     private final EventAdaptor eventAdaptor;
 
     private final HostAdaptor hostAdaptor;
@@ -30,16 +30,17 @@ public class OrderApprovedAlarmEventHandler {
 
     @Async
     @TransactionalEventListener(
-            classes = DoneOrderEvent.class,
+            classes = WithDrawOrderEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(readOnly = true)
-    public void handle(DoneOrderEvent doneOrderEvent) {
-        if (doneOrderEvent.getOrderMethod().isPayment()) return;
-        log.info("승인 방식 완료 시에 알림 전송");
-        Order order = orderAdaptor.findByOrderUuid(doneOrderEvent.getOrderUuid());
+    public void handle(WithDrawOrderEvent withDrawOrderEvent) {
+        log.info("선착순 유료,무료  승인 무료 시에 전송되는 알람");
+        if (withDrawOrderEvent.getIsDudoongTicketOrder()) return;
+
+        Order order = orderAdaptor.findByOrderUuid(withDrawOrderEvent.getOrderUuid());
         Event event = eventAdaptor.findById(order.getEventId());
         Host host = hostAdaptor.findById(event.getHostId());
-        String message = HostSlackAlarm.approvedOrder(event, order);
+        String message = HostSlackAlarm.withDrawOrder(event, order);
         slackMessageProvider.sendMessage(host.getSlackUrl(), message);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/alarm/HostSlackAlarm.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/alarm/HostSlackAlarm.java
@@ -7,7 +7,6 @@ import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.jetbrains.annotations.NotNull;
 
 @Getter
 @AllArgsConstructor
@@ -47,16 +46,11 @@ public class HostSlackAlarm {
                 + getOrderNameAndAmount(order);
     }
 
-    public static String ApprovedOrder(Event event, Order order) {
+    public static String approvedOrder(Event event, Order order) {
         return getEventOrderTitle(event)
                 + getOrderNo(order)
                 + " 주문이 승인 되었습니다.\n"
                 + getOrderNameAndAmount(order);
-    }
-
-    @NotNull
-    private static String getOrderNo(Order order) {
-        return "주문번호 : " + order.getOrderNo();
     }
 
     public static String withDrawOrder(Event event, Order order) {
@@ -71,6 +65,10 @@ public class HostSlackAlarm {
                 + getOrderNo(order)
                 + " 두둥티켓 주문이 구매자에의해 환불 처리 되었습니다. 구매자에게 연락해서 환불을 진행해 주세요.\n"
                 + getOrderNameAndAmount(order);
+    }
+
+    private static String getOrderNo(Order order) {
+        return "주문번호 : " + order.getOrderNo();
     }
 
     private static String getOrderNameAndAmount(Order order) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/alarm/HostSlackAlarm.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/alarm/HostSlackAlarm.java
@@ -1,10 +1,13 @@
 package band.gosrock.domain.common.alarm;
 
 
+import band.gosrock.domain.domains.event.domain.Event;
 import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 
 @Getter
 @AllArgsConstructor
@@ -24,6 +27,54 @@ public class HostSlackAlarm {
 
     public static String disabledOf(User user) {
         return nameOf(user) + "님이 호스트에서 추방당했습니다.";
+    }
+
+    private static String getEventOrderTitle(Event event) {
+        return event.getEventBasic().getName() + " 이벤트 주문관련 알림\n";
+    }
+
+    public static String newConfirmOrder(Event event, Order order) {
+        return getEventOrderTitle(event)
+                + getOrderNo(order)
+                + " 주문이 결제되었습니다.\n"
+                + getOrderNameAndAmount(order);
+    }
+
+    public static String newApproveOrder(Event event, Order order) {
+        return getEventOrderTitle(event)
+                + getOrderNo(order)
+                + " 주문 승인이 요청 되었습니다.\n"
+                + getOrderNameAndAmount(order);
+    }
+
+    public static String ApprovedOrder(Event event, Order order) {
+        return getEventOrderTitle(event)
+                + getOrderNo(order)
+                + " 주문이 승인 되었습니다.\n"
+                + getOrderNameAndAmount(order);
+    }
+
+    @NotNull
+    private static String getOrderNo(Order order) {
+        return "주문번호 : " + order.getOrderNo();
+    }
+
+    public static String withDrawOrder(Event event, Order order) {
+        return getEventOrderTitle(event)
+                + getOrderNo(order)
+                + " 주문이 철회 되었습니다.\n"
+                + getOrderNameAndAmount(order);
+    }
+
+    public static String refundRequestOrder(Event event, Order order) {
+        return getEventOrderTitle(event)
+                + getOrderNo(order)
+                + " 두둥티켓 주문이 구매자에의해 환불 처리 되었습니다. 구매자에게 연락해서 환불을 진행해 주세요.\n"
+                + getOrderNameAndAmount(order);
+    }
+
+    private static String getOrderNameAndAmount(Order order) {
+        return "주문이름 :" + order.getOrderName() + " | 주문 금액 : " + order.getTotalPaymentPrice();
     }
 
     private static String nameOf(Host host) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/alarm/HostSlackAlarm.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/alarm/HostSlackAlarm.java
@@ -60,10 +60,17 @@ public class HostSlackAlarm {
                 + getOrderNameAndAmount(order);
     }
 
-    public static String refundRequestOrder(Event event, Order order) {
+    public static String dudoongOrderRefund(Event event, Order order) {
         return getEventOrderTitle(event)
                 + getOrderNo(order)
                 + " 두둥티켓 주문이 구매자에의해 환불 처리 되었습니다. 구매자에게 연락해서 환불을 진행해 주세요.\n"
+                + getOrderNameAndAmount(order);
+    }
+
+    public static String dudoongOrderCancel(Event event, Order order) {
+        return getEventOrderTitle(event)
+                + getOrderNo(order)
+                + " 두둥티켓 주문이 관리자에의해 환불 처리 되었습니다. 구매자에게 연락해서 환불을 진행해 주세요.\n"
                 + getOrderNameAndAmount(order);
     }
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
@@ -20,6 +20,8 @@ public class WithDrawOrderEvent extends DomainEvent {
     private final OrderMethod orderMethod;
     private final OrderStatus orderStatus;
 
+    private final Boolean isDudoongTicketOrder;
+
     @Nullable private final String paymentKey;
     private final Long itemId;
 
@@ -36,6 +38,7 @@ public class WithDrawOrderEvent extends DomainEvent {
                 .itemId(order.getItemId())
                 .isUsingCoupon(order.hasCoupon())
                 .issuedCouponId(order.getOrderCouponVo().getCouponId())
+                .isDudoongTicketOrder(order.isDudoongTicketOrder())
                 .build();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/events/order/WithDrawOrderEvent.java
@@ -21,6 +21,7 @@ public class WithDrawOrderEvent extends DomainEvent {
     private final OrderStatus orderStatus;
 
     private final Boolean isDudoongTicketOrder;
+    private final Boolean isRefund;
 
     @Nullable private final String paymentKey;
     private final Long itemId;
@@ -39,6 +40,7 @@ public class WithDrawOrderEvent extends DomainEvent {
                 .isUsingCoupon(order.hasCoupon())
                 .issuedCouponId(order.getOrderCouponVo().getCouponId())
                 .isDudoongTicketOrder(order.isDudoongTicketOrder())
+                .isRefund(order.getOrderStatus() == OrderStatus.REFUND)
                 .build();
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/Order.java
@@ -332,6 +332,11 @@ public class Order extends BaseTimeEntity {
         return isNeedPaid();
     }
 
+    public Boolean isDudoongTicketOrder() {
+        return getTotalPaymentPrice().isGreaterThan(Money.ZERO)
+                && orderMethod == OrderMethod.APPROVAL;
+    }
+
     public List<Long> getDistinctItemIds() {
         return this.orderLineItems.stream().map(OrderLineItem::getItemId).distinct().toList();
     }

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/slack/SlackErrorNotificationProvider.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/slack/SlackErrorNotificationProvider.java
@@ -1,7 +1,6 @@
 package band.gosrock.infrastructure.config.slack;
 
 
-import com.slack.api.methods.MethodsClient;
 import com.slack.api.model.block.LayoutBlock;
 import java.util.Arrays;
 import java.util.List;
@@ -22,8 +21,6 @@ public class SlackErrorNotificationProvider {
 
     @Value("${slack.webhook.id}")
     private String CHANNEL_ID;
-
-    private final MethodsClient methodsClient;
 
     public String getErrorStack(Throwable throwable) {
         String exceptionAsString = Arrays.toString(throwable.getStackTrace());

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/slack/SlackHelper.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/slack/SlackHelper.java
@@ -19,7 +19,7 @@ import org.springframework.util.CollectionUtils;
 @Slf4j
 public class SlackHelper {
     private final Environment env;
-    private final List<String> sendAlarmProfiles = List.of("staging", "prod", "dev");
+    private final List<String> sendAlarmProfiles = List.of("staging", "prod");
 
     private final MethodsClient methodsClient;
 

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/slack/SlackMessageProvider.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/slack/SlackMessageProvider.java
@@ -5,11 +5,11 @@ import com.slack.api.Slack;
 import com.slack.api.webhook.Payload;
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,8 +23,10 @@ public class SlackMessageProvider {
     @Value("${slack.webhook.icon-url}")
     private String iconUrl;
 
-    @Async
+    /** 이벤트 핸들러 자체에서 비동기로 실행하기 때문에 @Async 어노테이션 지움 */
     public void sendMessage(String url, String text) {
+        // 슬랙 url 이 null 일경우 안보냄.
+        if (Objects.isNull(url)) return;
         try {
             doSend(url, text);
         } catch (Exception ignored) {


### PR DESCRIPTION
## 개요
- close #338 

## 작업사항
- 주문 관련 호스트 슬랙 알림을 추가했습니다.
- 주문 결제시 알림
- 주문 승인 시 알림
- 주문 승인 요청시 알림
- 주문 철회 알림
- 두둥 티켓 주문 취소
- 두둥 티켓 주문 환불

## 변경로직
- 호스트의 url 이 없을때 그냥 리턴해줬습니다.
- 슬랙 메시지 프로바이더에서 send할때
- async 어노테이션 없앴습니다.이벤트핸들러에서 이미 쓰레드 받아서 한번더하면 쓰레드 중복 생성입다!