### PR TITLE
bug : toAlimTalkUserInfo null 오류 해결

### DIFF
--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
@@ -104,8 +104,7 @@ public class User extends BaseTimeEntity {
     }
 
     public AlimTalkUserInfo toAlimTalkUserInfo() throws NumberParseException {
-        if (profile.getPhoneNumberVo().getPhoneNumber() == null
-                || profile.getPhoneNumberVo().getPhoneNumber().isEmpty()) {
+        if (profile.getPhoneNumberVo() == null) {
             throw EmptyPhoneNumException.EXCEPTION;
         }
         return new AlimTalkUserInfo(


### PR DESCRIPTION
## 개요
- close #453 

## 작업사항
- profile.getPhoneNumberVo().getPhoneNumber() == null에서 전화번호 없을 때 vo 자체가 null이어서 getPhoneNumber 호출시 null 에러 발생했었음
- profile.getPhoneNumberVo() == null로 해결
## 변경로직
- 내용을 적어주세요.