### PR TITLE
fix : 호스트 이벤트 접근 권한 설정

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/event/model/mapper/EventMapper.java
@@ -80,7 +80,7 @@ public class EventMapper {
     }
 
     public Slice<EventProfileResponse> toEventProfileResponseSlice(Long userId, Pageable pageable) {
-        List<Host> hosts = hostAdaptor.findAllByHostUsers_UserId(userId);
+        List<Host> hosts = hostAdaptor.querySliceHostsByActiveUserId(userId);
         List<Long> hostIds = hosts.stream().map(Host::getId).toList();
         Slice<Event> events = eventAdaptor.querySliceEventsByHostIdIn(hostIds, pageable);
         return events.map(event -> this.toEventProfileResponse(hosts, event));

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
@@ -95,7 +95,6 @@ public class HostController {
         return updateHostUserRoleUseCase.execute(hostId, updateHostUserRoleRequest);
     }
 
-    // todo :: 슈퍼 호스트 이상으로?
     @Operation(summary = "호스트 정보를 변경합니다. 매니저 이상만 가능합니다.")
     @PatchMapping("/{hostId}/profile")
     public HostDetailResponse patchHostById(

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/controller/HostController.java
@@ -39,6 +39,7 @@ public class HostController {
     private final UpdateHostUserRoleUseCase updateHostUserRoleUseCase;
     private final InviteHostUseCase inviteHostUseCase;
     private final JoinHostUseCase joinHostUseCase;
+    private final RejectHostUseCase rejectHostUseCase;
 
     @Operation(summary = "내가 속한 호스트 리스트를 가져옵니다.")
     @GetMapping
@@ -78,6 +79,12 @@ public class HostController {
     @PostMapping("/{hostId}/join")
     public HostDetailResponse joinHost(@PathVariable Long hostId) {
         return joinHostUseCase.execute(hostId);
+    }
+
+    @Operation(summary = "호스트 초대를 거절합니다.")
+    @PostMapping("/{hostId}/reject")
+    public HostDetailResponse rejectHost(@PathVariable Long hostId) {
+        return rejectHostUseCase.execute(hostId);
     }
 
     @Operation(summary = "다른 유저를 호스트 유저로 초대합니다.")

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostEventsUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadHostEventsUseCase.java
@@ -1,6 +1,9 @@
 package band.gosrock.api.host.service;
 
+import static band.gosrock.api.common.aop.hostRole.FindHostFrom.HOST_ID;
+import static band.gosrock.api.common.aop.hostRole.HostQualification.GUEST;
 
+import band.gosrock.api.common.aop.hostRole.HostRolesAllowed;
 import band.gosrock.api.common.page.PageResponse;
 import band.gosrock.api.host.model.dto.response.HostEventProfileResponse;
 import band.gosrock.common.annotation.UseCase;
@@ -18,6 +21,7 @@ public class ReadHostEventsUseCase {
     private final HostAdaptor hostAdaptor;
     private final EventAdaptor eventAdaptor;
 
+    @HostRolesAllowed(role = GUEST, findHostFrom = HOST_ID)
     public PageResponse<HostEventProfileResponse> execute(Long hostId, Pageable pageable) {
         Host host = hostAdaptor.findById(hostId);
         return PageResponse.of(

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/RejectHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/RejectHostUseCase.java
@@ -1,0 +1,30 @@
+package band.gosrock.api.host.service;
+
+
+import band.gosrock.api.common.UserUtils;
+import band.gosrock.api.host.model.dto.response.HostDetailResponse;
+import band.gosrock.api.host.model.mapper.HostMapper;
+import band.gosrock.common.annotation.UseCase;
+import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
+import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.service.HostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class RejectHostUseCase {
+
+    private final UserUtils userUtils;
+    private final HostService hostService;
+    private final HostAdaptor hostAdaptor;
+    private final HostMapper hostMapper;
+
+    @Transactional
+    public HostDetailResponse execute(Long hostId) {
+        final Long userId = userUtils.getCurrentUserId();
+        final Host host = hostAdaptor.findById(hostId);
+
+        return hostMapper.toHostDetailResponse(hostService.removeHostUser(host, userId));
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/adaptor/HostAdaptor.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/adaptor/HostAdaptor.java
@@ -38,4 +38,13 @@ public class HostAdaptor {
     public List<Host> findAllByHostUsers_UserId(Long userId) {
         return hostRepository.findAllByHostUsers_UserId(userId);
     }
+
+    /** 자신이 속해있는 호스트 리스트 중 초대 수락한 호스트만 가져오는 쿼리 요청 */
+    public List<Host> querySliceHostsByActiveUserId(Long userId) {
+        return hostRepository.queryHostsByActiveUserId(userId);
+    }
+
+    public Slice<Host> querySliceHostsByActiveUserId(Long userId, Pageable pageable) {
+        return hostRepository.querySliceHostsByActiveUserId(userId, pageable);
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/Host.java
@@ -43,7 +43,11 @@ public class Host extends BaseTimeEntity {
     private String slackUrl;
 
     // 단방향 oneToMany 매핑
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OneToMany(
+            mappedBy = "host",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.EAGER)
     @OrderBy("createdAt DESC")
     private final Set<HostUser> hostUsers = new HashSet<>();
 
@@ -113,6 +117,11 @@ public class Host extends BaseTimeEntity {
                 .setHostRole(role);
     }
 
+    public void removeHostUser(Long userId) {
+        if (this.isActiveHostUserId(userId)) throw AlreadyJoinedHostException.EXCEPTION;
+        this.hostUsers.remove(this.getHostUserByUserId(userId));
+    }
+
     /** 해당 유저가 호스트에 이미 속하는지 확인하는 검증 로직입니다 */
     public void validateHostUserIdExistence(Long userId) {
         if (this.hasHostUserId(userId)) {
@@ -123,8 +132,6 @@ public class Host extends BaseTimeEntity {
     public void validateHostUserExistence(HostUser hostUser) {
         validateHostUserIdExistence(hostUser.getUserId());
     }
-
-    // todo :: 여기서부터 테스트 진행
 
     /** 해당 유저가 호스트에 속하는지 확인하는 검증 로직입니다 */
     public void validateHostUser(Long userId) {

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostUser.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/domain/HostUser.java
@@ -25,7 +25,7 @@ public class HostUser extends BaseTimeEntity {
     private Long id;
 
     // 소속 호스트 아이디
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "host_id")
     private Host host;
 

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepository.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/repository/HostCustomRepository.java
@@ -2,9 +2,14 @@ package band.gosrock.domain.domains.host.repository;
 
 
 import band.gosrock.domain.domains.host.domain.Host;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface HostCustomRepository {
     Slice<Host> querySliceHostsByUserId(Long id, Pageable pageable);
+
+    List<Host> queryHostsByActiveUserId(Long id);
+
+    Slice<Host> querySliceHostsByActiveUserId(Long id, Pageable pageable);
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
@@ -55,6 +55,11 @@ public class HostService {
         return hostRepository.save(host);
     }
 
+    public Host removeHostUser(Host host, Long userId) {
+        host.removeHostUser(userId);
+        return hostRepository.save(host);
+    }
+
     public void validateDuplicatedSlackUrl(Host host, String url) {
         if (StringUtils.equals(host.getSlackUrl(), url)) {
             throw InvalidSlackUrlException.EXCEPTION;


### PR DESCRIPTION
## 개요
- close #458 

## 작업사항
- 호스트가 관리중인 이벤트 목록 조회 시 초대 수락하지 않은 유저도 접근 가능했던 것 수정
- 호스트 초대 거절 추가

## 변경로직
- 호스트가 관리 중인 이벤트 목록 권한 설정
- 자신이 관리중인 호스트 이벤트 목록에서 초대 받지 않은 호스트의 이벤트는 쿼리에 포함시키지 않도록
- 호스트 초대 거절 로직
- 호스트 <-> 호스트 유저 엔티티 변경