### PR TITLE
fix : 호스트 유저 초대 동시성 이슈 대응

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/model/mapper/HostMapper.java
@@ -16,7 +16,9 @@ import band.gosrock.domain.domains.host.domain.HostUser;
 import band.gosrock.domain.domains.host.exception.AlreadyJoinedHostException;
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
 import band.gosrock.domain.domains.user.domain.User;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -66,7 +68,6 @@ public class HostMapper {
 
     public UserProfileVo toHostInviteUserList(Long hostId, String email) {
         final Host host = hostAdaptor.findById(hostId);
-
         final User inviteUser = userAdaptor.queryUserByEmail(email);
         if (host.hasHostUserId(inviteUser.getId())) {
             throw AlreadyJoinedHostException.EXCEPTION;

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/InviteHostUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/InviteHostUseCase.java
@@ -16,7 +16,6 @@ import band.gosrock.domain.domains.host.service.HostService;
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
 import band.gosrock.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
@@ -27,15 +26,13 @@ public class InviteHostUseCase {
     private final HostAdaptor hostAdaptor;
     private final HostMapper hostMapper;
 
-    @Transactional
     @HostRolesAllowed(role = MANAGER, findHostFrom = HOST_ID)
     public HostDetailResponse execute(Long hostId, InviteHostRequest inviteHostRequest) {
-        // 초대할 유저
-        final User user = userAdaptor.queryUserByEmail(inviteHostRequest.getEmail());
-        final Long inviteUserId = user.getId();
         final Host host = hostAdaptor.findById(hostId);
+        final User invitedUser = userAdaptor.queryUserByEmail(inviteHostRequest.getEmail());
+        final Long invitedUserId = invitedUser.getId();
         final HostRole role = inviteHostRequest.getRole();
-        final HostUser hostUser = hostMapper.toHostUser(hostId, inviteUserId, role);
+        final HostUser hostUser = hostMapper.toHostUser(hostId, invitedUserId, role);
 
         return hostMapper.toHostDetailResponse(hostService.inviteHostUser(host, hostUser));
     }

--- a/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadInviteUsersUseCase.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/host/service/ReadInviteUsersUseCase.java
@@ -3,7 +3,6 @@ package band.gosrock.api.host.service;
 import static band.gosrock.api.common.aop.hostRole.FindHostFrom.HOST_ID;
 import static band.gosrock.api.common.aop.hostRole.HostQualification.GUEST;
 
-import band.gosrock.api.common.UserUtils;
 import band.gosrock.api.common.aop.hostRole.HostRolesAllowed;
 import band.gosrock.api.host.model.mapper.HostMapper;
 import band.gosrock.common.annotation.UseCase;
@@ -14,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 @UseCase
 @RequiredArgsConstructor
 public class ReadInviteUsersUseCase {
-    private final UserUtils userUtils;
     private final HostMapper hostMapper;
 
     @Transactional(readOnly = true)

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/host/service/HostService.java
@@ -2,6 +2,7 @@ package band.gosrock.domain.domains.host.service;
 
 
 import band.gosrock.common.annotation.DomainService;
+import band.gosrock.domain.common.aop.redissonLock.RedissonLock;
 import band.gosrock.domain.domains.host.adaptor.HostAdaptor;
 import band.gosrock.domain.domains.host.domain.Host;
 import band.gosrock.domain.domains.host.domain.HostProfile;
@@ -30,6 +31,7 @@ public class HostService {
         return hostRepository.save(host);
     }
 
+    @RedissonLock(LockName = "호스트유저초대", identifier = "id", paramClassType = Host.class)
     public Host inviteHostUser(Host host, HostUser hostUser) {
         host.inviteHostUsers(Set.of(hostUser));
         return hostRepository.save(host);

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/service/HostServiceConcurrencyFailureTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/service/HostServiceConcurrencyFailureTest.java
@@ -1,0 +1,59 @@
+package band.gosrock.domain.domains.host.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import band.gosrock.domain.CunCurrencyExecutorService;
+import band.gosrock.domain.DisableDomainEvent;
+import band.gosrock.domain.DisableRedissonLock;
+import band.gosrock.domain.DomainIntegrateSpringBootTest;
+import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.domain.HostUser;
+import band.gosrock.domain.domains.host.repository.HostRepository;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DomainIntegrateSpringBootTest
+@DisableDomainEvent
+@DisableRedissonLock
+@Slf4j
+public class HostServiceConcurrencyFailureTest {
+    @Autowired HostService hostService;
+
+    @Autowired RedissonClient redissonClient;
+
+    Host host;
+
+    @Mock HostUser hostUser;
+    @MockBean HostRepository hostRepository;
+
+    @BeforeEach
+    void setup() {
+        host = Host.builder().build();
+        ReflectionTestUtils.setField(host, "id", 1L);
+        given(hostUser.getUserId()).willReturn(9L);
+        given(hostRepository.save(any(Host.class))).willReturn(host);
+    }
+
+    @Test
+    @DisplayName("락 적용을 안하면 여러개의 초대가 승인될 수도 있다.")
+    public void 호스트유저_초대요청_동시성_실패() throws InterruptedException {
+        // given
+        // when
+        AtomicLong successCount = new AtomicLong();
+        CunCurrencyExecutorService.execute(
+                () -> hostService.inviteHostUser(host, hostUser), successCount);
+        // then
+        log.info(String.valueOf(successCount.get()));
+        assertThat(successCount.get()).isGreaterThanOrEqualTo(1L);
+    }
+}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/service/HostServiceConcurrencyTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/service/HostServiceConcurrencyTest.java
@@ -1,0 +1,56 @@
+package band.gosrock.domain.domains.host.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import band.gosrock.domain.CunCurrencyExecutorService;
+import band.gosrock.domain.DisableDomainEvent;
+import band.gosrock.domain.DomainIntegrateSpringBootTest;
+import band.gosrock.domain.domains.host.domain.Host;
+import band.gosrock.domain.domains.host.domain.HostUser;
+import band.gosrock.domain.domains.host.repository.HostRepository;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DomainIntegrateSpringBootTest
+@DisableDomainEvent
+@Slf4j
+public class HostServiceConcurrencyTest {
+    @Autowired HostService hostService;
+
+    @Autowired RedissonClient redissonClient;
+
+    Host host;
+
+    @Mock HostUser hostUser;
+    @MockBean HostRepository hostRepository;
+
+    @BeforeEach
+    void setup() {
+        host = Host.builder().build();
+        ReflectionTestUtils.setField(host, "id", 1L);
+        given(hostUser.getUserId()).willReturn(9L);
+        given(hostRepository.save(any(Host.class))).willReturn(host);
+    }
+
+    @Test
+    @DisplayName("동시에 초대 요청을 보내도 하나의 요청만 성공해야한다.")
+    public void 호스트유저_초대요청_동시성테스트() throws InterruptedException {
+        // given
+        // when
+        AtomicLong successCount = new AtomicLong();
+        CunCurrencyExecutorService.execute(
+                () -> hostService.inviteHostUser(host, hostUser), successCount);
+        // then
+        assertThat(successCount.get()).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
## 개요
- close #468 

## 작업사항
- 호스트 초대에 `@RedissonLock` 적용
- 동시성 이슈 테스트 코드 작성

## 변경로직
- `HostService` 의 `inviteHostUser` 에 `@RedissonLock` 적용
- identifier 는 HostId
- `HostService` 에서 `@RedissonLock` 적용 유무에 따른 테스트 코드 작성