### PR TITLE
fix  : order approve not delete user 

### DIFF
--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/validator/OrderValidator.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/validator/OrderValidator.java
@@ -9,6 +9,7 @@ import band.gosrock.domain.domains.issuedTicket.adaptor.IssuedTicketAdaptor;
 import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderLineItem;
 import band.gosrock.domain.domains.order.domain.OrderStatus;
+import band.gosrock.domain.domains.order.exception.CanNotApproveDeletedUserOrderException;
 import band.gosrock.domain.domains.order.exception.CanNotCancelOrderException;
 import band.gosrock.domain.domains.order.exception.CanNotRefundOrderException;
 import band.gosrock.domain.domains.order.exception.InvalidOrderException;
@@ -24,6 +25,8 @@ import band.gosrock.domain.domains.ticket_item.adaptor.OptionAdaptor;
 import band.gosrock.domain.domains.ticket_item.adaptor.TicketItemAdaptor;
 import band.gosrock.domain.domains.ticket_item.domain.Option;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
+import band.gosrock.domain.domains.user.domain.User;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +44,8 @@ public class OrderValidator {
 
     private final IssuedTicketAdaptor issuedTicketAdaptor;
     private final OptionAdaptor optionAdaptor;
+
+    private final UserAdaptor userAdaptor;
 
     /** 주문을 생성할 수 있는지에 대한검증 */
     public void validCanCreate(Order order) {
@@ -74,16 +79,22 @@ public class OrderValidator {
                 });
     }
 
-    public void validOptionNotChangeAfterDoneOrderEvent(Order order) {
-        TicketItem item = getItem(order);
-        validOptionNotChange(order, item);
-    }
 
     /** 승인 가능한 주문인지 검증합니다. */
     public void validCanApproveOrder(Order order) {
         validMethodIsCanApprove(order);
         validStatusCanApprove(getOrderStatus(order));
         validCanDone(order);
+        // 유저가 탈퇴를 안했는지 확인.
+        validUserNotDeleted(order);
+    }
+
+    /** 주문 승인 간에 유저가 탈퇴를 했는지 조회합니다. */
+    private void validUserNotDeleted(Order order) {
+        User user = userAdaptor.queryUser(order.getUserId());
+        if(user.isDeletedUser()){
+            throw CanNotApproveDeletedUserOrderException.EXCEPTION;
+        }
     }
 
     /** 결제 방식의 주문을 승인할수있는지 확인합니다. */

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/validator/OrderValidator.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/validator/OrderValidator.java
@@ -89,7 +89,7 @@ public class OrderValidator {
     }
 
     /** 주문 승인 간에 유저가 탈퇴를 했는지 조회합니다. */
-    private void validUserNotDeleted(Order order) {
+    public void validUserNotDeleted(Order order) {
         User user = userAdaptor.queryUser(order.getUserId());
         if (user.isDeletedUser()) {
             throw CanNotApproveDeletedUserOrderException.EXCEPTION;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/validator/OrderValidator.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/domain/validator/OrderValidator.java
@@ -79,7 +79,6 @@ public class OrderValidator {
                 });
     }
 
-
     /** 승인 가능한 주문인지 검증합니다. */
     public void validCanApproveOrder(Order order) {
         validMethodIsCanApprove(order);
@@ -92,7 +91,7 @@ public class OrderValidator {
     /** 주문 승인 간에 유저가 탈퇴를 했는지 조회합니다. */
     private void validUserNotDeleted(Order order) {
         User user = userAdaptor.queryUser(order.getUserId());
-        if(user.isDeletedUser()){
+        if (user.isDeletedUser()) {
             throw CanNotApproveDeletedUserOrderException.EXCEPTION;
         }
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/CanNotApproveDeletedUserOrderException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/CanNotApproveDeletedUserOrderException.java
@@ -1,0 +1,13 @@
+package band.gosrock.domain.domains.order.exception;
+
+
+import band.gosrock.common.exception.DuDoongCodeException;
+
+public class CanNotApproveDeletedUserOrderException extends DuDoongCodeException {
+
+    public static final DuDoongCodeException EXCEPTION = new CanNotApproveDeletedUserOrderException();
+
+    private CanNotApproveDeletedUserOrderException() {
+        super(OrderErrorCode.CAN_NOT_DELETED_USER_APPROVE);
+    }
+}

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/CanNotApproveDeletedUserOrderException.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/CanNotApproveDeletedUserOrderException.java
@@ -5,7 +5,8 @@ import band.gosrock.common.exception.DuDoongCodeException;
 
 public class CanNotApproveDeletedUserOrderException extends DuDoongCodeException {
 
-    public static final DuDoongCodeException EXCEPTION = new CanNotApproveDeletedUserOrderException();
+    public static final DuDoongCodeException EXCEPTION =
+            new CanNotApproveDeletedUserOrderException();
 
     private CanNotApproveDeletedUserOrderException() {
         super(OrderErrorCode.CAN_NOT_DELETED_USER_APPROVE);

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/OrderErrorCode.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/exception/OrderErrorCode.java
@@ -34,7 +34,8 @@ public enum OrderErrorCode implements BaseErrorCode {
     ORDER_LESS_THAN_MINIMUM(BAD_REQUEST, "Order_400_11", "최소 결제금액인 1000원보다 낮은 주문입니다."),
     @ExplainError("한 장바구니엔 관련된 한 아이템만 올수 있음")
     ORDER_INVALID_ITEM_KIND_POLICY(BAD_REQUEST, "Order_400_12", "장바구니에 아이템을 담는 정책을 위반하였습니다."),
-    ORDER_OPTION_CHANGED(BAD_REQUEST, "Order_400_13", "주문 과정중 아이템의 옵션이 변화했습니다.");
+    ORDER_OPTION_CHANGED(BAD_REQUEST, "Order_400_13", "주문 과정중 아이템의 옵션이 변화했습니다."),
+    CAN_NOT_DELETED_USER_APPROVE(BAD_REQUEST, "Order_400_14", "유저가 탈퇴를 했습니다.");
 
     private Integer status;
     private String code;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/repository/OrderCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/repository/OrderCustomRepositoryImpl.java
@@ -10,6 +10,7 @@ import band.gosrock.domain.domains.order.domain.Order;
 import band.gosrock.domain.domains.order.domain.OrderStatus;
 import band.gosrock.domain.domains.order.repository.condition.FindEventOrdersCondition;
 import band.gosrock.domain.domains.order.repository.condition.FindMyPageOrderCondition;
+import band.gosrock.domain.domains.user.domain.AccountState;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.DateTemplate;
 import com.querydsl.core.types.dsl.Expressions;
@@ -73,6 +74,8 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
                         .join(user)
                         .on(user.id.eq(order.userId))
                         .where(
+                                // 주문 승인 요청 보여질 때만 지워진 유저를 보이게 하지 않습니다.
+                                condition.showDeleteUserExpression(),
                                 eqEventId(condition.getEventId()),
                                 condition.getOrderStatusFilter(),
                                 condition.getSearchStringFilter())
@@ -88,6 +91,7 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
                         .join(user)
                         .on(user.id.eq(order.userId))
                         .where(
+                                condition.showDeleteUserExpression(),
                                 eqEventId(condition.getEventId()),
                                 condition.getOrderStatusFilter(),
                                 condition.getSearchStringFilter());
@@ -130,5 +134,9 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
         return isShowing == Boolean.TRUE
                 ? eventEndAtTemplate.after(now)
                 : eventEndAtTemplate.before(now);
+    }
+
+    private BooleanExpression notDeletedUser() {
+        return user.accountState.ne(AccountState.DELETED);
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/repository/condition/AdminTableOrderFilterType.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/repository/condition/AdminTableOrderFilterType.java
@@ -6,21 +6,32 @@ import static band.gosrock.domain.domains.order.domain.OrderStatus.CONFIRM;
 import static band.gosrock.domain.domains.order.domain.OrderStatus.PENDING_APPROVE;
 import static band.gosrock.domain.domains.order.domain.OrderStatus.REFUND;
 import static band.gosrock.domain.domains.order.domain.QOrder.order;
+import static band.gosrock.domain.domains.user.domain.QUser.user;
 
+import band.gosrock.domain.domains.user.domain.AccountState;
 import com.querydsl.core.types.dsl.BooleanExpression;
 
 /** 어드민 테이블의 주문 상태 검색 조건 지정을 위함. */
 public enum AdminTableOrderFilterType {
-    APPROVE_WAITING(order.orderStatus.eq(PENDING_APPROVE)),
-    CONFIRMED(order.orderStatus.in(CONFIRM, APPROVED, CANCELED, REFUND));
+    APPROVE_WAITING(
+            order.orderStatus.eq(PENDING_APPROVE), user.accountState.ne(AccountState.DELETED)),
+    // 완료된 주문을 가져오는건 지워진 유저도 불러와야한다.
+    CONFIRMED(order.orderStatus.in(CONFIRM, APPROVED, CANCELED, REFUND), null);
 
     private final BooleanExpression expression;
+    private final BooleanExpression showDeleteUserExpression;
 
-    AdminTableOrderFilterType(BooleanExpression expression) {
+    AdminTableOrderFilterType(
+            BooleanExpression expression, BooleanExpression showDeleteUserExpression) {
         this.expression = expression;
+        this.showDeleteUserExpression = showDeleteUserExpression;
     }
 
     public BooleanExpression getFilter() {
         return expression;
+    }
+
+    public BooleanExpression showDeleteUserExpression() {
+        return showDeleteUserExpression;
     }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/repository/condition/FindEventOrdersCondition.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/order/repository/condition/FindEventOrdersCondition.java
@@ -31,6 +31,10 @@ public class FindEventOrdersCondition {
         return filterType.getFilter();
     }
 
+    public BooleanExpression showDeleteUserExpression() {
+        return filterType.showDeleteUserExpression();
+    }
+
     public BooleanExpression getSearchStringFilter() {
         if (searchType == null) return null;
         return searchType.getContains(searchString);

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
@@ -126,4 +126,8 @@ public class User extends BaseTimeEntity {
     public void toggleMarketingAgree() {
         marketingAgree = !marketingAgree;
     }
+
+    public Boolean isDeletedUser(){
+        return accountState == AccountState.DELETED;
+    }
 }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/user/domain/User.java
@@ -127,7 +127,7 @@ public class User extends BaseTimeEntity {
         marketingAgree = !marketingAgree;
     }
 
-    public Boolean isDeletedUser(){
+    public Boolean isDeletedUser() {
         return accountState == AccountState.DELETED;
     }
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/validator/OrderValidatorTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/validator/OrderValidatorTest.java
@@ -34,6 +34,7 @@ import band.gosrock.domain.domains.ticket_item.domain.Option;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
 import band.gosrock.domain.domains.ticket_item.exception.TicketItemQuantityLackException;
 import band.gosrock.domain.domains.ticket_item.exception.TicketPurchaseLimitException;
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,6 +56,7 @@ class OrderValidatorTest {
     @Mock TicketItemAdaptor ticketItemAdaptor;
     @Mock IssuedTicketAdaptor issuedTicketAdaptor;
     @Mock OptionAdaptor optionAdaptor;
+    @Mock UserAdaptor userAdaptor;
     @Mock Option optionOfGroup1;
     @Mock Option optionOfGroup2;
     @Mock OrderLineItem orderLineItem;
@@ -67,7 +69,11 @@ class OrderValidatorTest {
     void setUp() {
         orderValidator =
                 new OrderValidator(
-                        eventAdaptor, ticketItemAdaptor, issuedTicketAdaptor, optionAdaptor);
+                        eventAdaptor,
+                        ticketItemAdaptor,
+                        issuedTicketAdaptor,
+                        optionAdaptor,
+                        userAdaptor);
     }
 
     @Test

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyFailTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyFailTest.java
@@ -52,6 +52,7 @@ class OrderApproveServiceConcurrencyFailTest {
                         .build();
         order.addUUID();
         willDoNothing().given(orderValidator).validCanDone(any());
+        willDoNothing().given(orderValidator).validUserNotDeleted(any());
         willCallRealMethod().given(orderValidator).validCanApproveOrder(any());
         willCallRealMethod().given(orderValidator).validStatusCanApprove(any());
         given(orderAdaptor.findByOrderUuid(any())).willReturn(order);

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
@@ -53,6 +53,7 @@ class OrderApproveServiceConcurrencyTest {
                         .build();
         order.addUUID();
         willDoNothing().given(orderValidator).validCanDone(any());
+        willDoNothing().given(orderValidator).validUserNotDeleted(any());
         willCallRealMethod().given(orderValidator).validCanApproveOrder(any());
         willCallRealMethod().given(orderValidator).validStatusCanApprove(any());
         given(orderAdaptor.findByOrderUuid(any())).willReturn(order);


### PR DESCRIPTION
## 개요
- close #470 

## 작업사항
- 어드민 주문 승인 테이블에서는 탈퇴한 유저가 조회안되게,
- 주문 승인시 ( 누가 강제로 api 호출할경우 ) 탈퇴한 유저면 주문 취소되게

## 변경로직
- 내용을 적어주세요.