### PR TITLE
test : 발급 티켓 관련 vo들 테스트 코드 추가 및 발급티켓 응답값에 티켓 payType 추가

### DIFF
--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/IssuedTicketInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/vo/IssuedTicketInfoVo.java
@@ -4,7 +4,7 @@ package band.gosrock.domain.common.vo;
 import band.gosrock.common.annotation.DateFormat;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
 import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketStatus;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketUserInfoVo;
+import band.gosrock.domain.domains.ticket_item.domain.TicketPayType;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,6 +34,11 @@ public class IssuedTicketInfoVo {
     private final String ticketName;
 
     /*
+    발급 티켓 지불 방식
+     */
+    private final TicketPayType payType;
+
+    /*
     발급 티켓 가격
      */
     private final Money ticketPrice;
@@ -55,19 +60,17 @@ public class IssuedTicketInfoVo {
      */
     private final Money optionPrice;
 
-    private final IssuedTicketUserInfoVo userInfo;
-
     public static IssuedTicketInfoVo from(IssuedTicket issuedTicket) {
         return IssuedTicketInfoVo.builder()
                 .issuedTicketId(issuedTicket.getId())
                 .issuedTicketNo(issuedTicket.getIssuedTicketNo())
                 .uuid(issuedTicket.getUuid())
                 .ticketName(issuedTicket.getItemInfo().getTicketName())
+                .payType(issuedTicket.getItemInfo().getPayType())
                 .ticketPrice(issuedTicket.getItemInfo().getPrice())
                 .createdAt(issuedTicket.getCreatedAt())
                 .issuedTicketStatus(issuedTicket.getIssuedTicketStatus())
                 .optionPrice(issuedTicket.sumOptionPrice())
-                .userInfo(issuedTicket.getUserInfo())
                 .enteredAt(issuedTicket.getEnteredAt())
                 .build();
     }

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketItemInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketItemInfoVo.java
@@ -3,6 +3,7 @@ package band.gosrock.domain.domains.issuedTicket.domain;
 
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.ticket_item.domain.TicketPayType;
 import band.gosrock.domain.domains.ticket_item.domain.TicketType;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
@@ -21,15 +22,23 @@ public class IssuedTicketItemInfoVo {
     @Enumerated(EnumType.STRING)
     private TicketType ticketType;
 
+    @Enumerated(EnumType.STRING)
+    private TicketPayType payType;
+
     private String ticketName;
 
     private Money price;
 
     @Builder
     public IssuedTicketItemInfoVo(
-            Long ticketItemId, TicketType ticketType, String ticketName, Money price) {
+            Long ticketItemId,
+            TicketType ticketType,
+            TicketPayType payType,
+            String ticketName,
+            Money price) {
         this.ticketItemId = ticketItemId;
         this.ticketType = ticketType;
+        this.payType = payType;
         this.ticketName = ticketName;
         this.price = price;
     }
@@ -38,6 +47,7 @@ public class IssuedTicketItemInfoVo {
         return IssuedTicketItemInfoVo.builder()
                 .ticketItemId(item.getId())
                 .ticketType(item.getType())
+                .payType(item.getPayType())
                 .ticketName(item.getName())
                 .price(item.getPrice())
                 .build();

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketUserInfoVo.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketUserInfoVo.java
@@ -19,10 +19,14 @@ public class IssuedTicketUserInfoVo {
 
     private PhoneNumberVo phoneNumber;
 
+    private String email;
+
     @Builder
-    public IssuedTicketUserInfoVo(Long userId, String userName, PhoneNumberVo phoneNumber) {
+    public IssuedTicketUserInfoVo(
+            Long userId, String userName, String email, PhoneNumberVo phoneNumber) {
         this.userId = userId;
         this.userName = userName;
+        this.email = email;
         this.phoneNumber = phoneNumber;
     }
 
@@ -31,6 +35,7 @@ public class IssuedTicketUserInfoVo {
                 .userId(user.getId())
                 .userName(user.getProfile().getName())
                 .phoneNumber(user.getProfile().getPhoneNumberVo())
+                .email(user.getProfile().getEmail())
                 .build();
     }
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptorTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/adaptor/IssuedTicketAdaptorTest.java
@@ -1,0 +1,8 @@
+package band.gosrock.domain.domains.issuedTicket.adaptor;
+
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class IssuedTicketAdaptorTest {}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketItemInfoVoTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketItemInfoVoTest.java
@@ -20,6 +20,8 @@ public class IssuedTicketItemInfoVoTest {
 
     private final TicketType ticketType = TicketType.FIRST_COME_FIRST_SERVED;
 
+    private final TicketPayType payType = TicketPayType.DUDOONG_TICKET;
+
     private final Money w3000 = Money.wons(3000L);
 
     private final LocalDateTime startAt = LocalDateTime.now();
@@ -32,6 +34,7 @@ public class IssuedTicketItemInfoVoTest {
                 IssuedTicketItemInfoVo.builder()
                         .ticketItemId(1L)
                         .ticketType(ticketType)
+                        .payType(payType)
                         .ticketName("testTicket")
                         .price(w3000)
                         .build();
@@ -67,6 +70,7 @@ public class IssuedTicketItemInfoVoTest {
         assertAll(
                 () -> assertEquals(itemInfoVo.getPrice(), itemInfoVoForTest.getPrice()),
                 () -> assertEquals(itemInfoVo.getTicketName(), itemInfoVoForTest.getTicketName()),
-                () -> assertEquals(itemInfoVo.getTicketType(), itemInfoVoForTest.getTicketType()));
+                () -> assertEquals(itemInfoVo.getTicketType(), itemInfoVoForTest.getTicketType()),
+                () -> assertEquals(itemInfoVo.getPayType(), itemInfoVoForTest.getPayType()));
     }
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketItemInfoVoTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketItemInfoVoTest.java
@@ -1,0 +1,72 @@
+package band.gosrock.domain.domains.issuedTicket.domain;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import band.gosrock.domain.common.vo.Money;
+import band.gosrock.domain.domains.ticket_item.domain.TicketItem;
+import band.gosrock.domain.domains.ticket_item.domain.TicketPayType;
+import band.gosrock.domain.domains.ticket_item.domain.TicketType;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class IssuedTicketItemInfoVoTest {
+
+    IssuedTicketItemInfoVo itemInfoVo;
+
+    private final TicketType ticketType = TicketType.FIRST_COME_FIRST_SERVED;
+
+    private final Money w3000 = Money.wons(3000L);
+
+    private final LocalDateTime startAt = LocalDateTime.now();
+
+    private final LocalDateTime endAt = startAt.plusDays(1L);
+
+    @BeforeEach
+    void setUp() {
+        itemInfoVo =
+                IssuedTicketItemInfoVo.builder()
+                        .ticketItemId(1L)
+                        .ticketType(ticketType)
+                        .ticketName("testTicket")
+                        .price(w3000)
+                        .build();
+    }
+
+    @Test
+    public void 티켓_아이템_정보를_발급티켓_아이템_인포로_정상적으로_변환_테스트() {
+        // given
+        TicketItem newTicketItem =
+                TicketItem.builder()
+                        .payType(TicketPayType.DUDOONG_TICKET)
+                        .name("testTicket")
+                        .description("test")
+                        .price(w3000)
+                        .quantity(1L)
+                        .supplyCount(1L)
+                        .purchaseLimit(1L)
+                        .type(ticketType)
+                        .bankName("test")
+                        .accountHolder("test")
+                        .accountNumber("test")
+                        .isQuantityPublic(true)
+                        .isSellable(true)
+                        .saleStartAt(startAt)
+                        .saleEndAt(endAt)
+                        .eventId(1L)
+                        .build();
+
+        // when
+        IssuedTicketItemInfoVo itemInfoVoForTest = IssuedTicketItemInfoVo.from(newTicketItem);
+
+        // then
+        assertAll(
+                () -> assertEquals(itemInfoVo.getPrice(), itemInfoVoForTest.getPrice()),
+                () -> assertEquals(itemInfoVo.getTicketName(), itemInfoVoForTest.getTicketName()),
+                () -> assertEquals(itemInfoVo.getTicketType(), itemInfoVoForTest.getTicketType()));
+    }
+}

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketOptionAnswerTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketOptionAnswerTest.java
@@ -1,11 +1,10 @@
-package band.gosrock.domain.domains.issuedTicket;
+package band.gosrock.domain.domains.issuedTicket.domain;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 
 import band.gosrock.domain.common.vo.Money;
 import band.gosrock.domain.common.vo.OptionAnswerVo;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketOptionAnswer;
 import band.gosrock.domain.domains.ticket_item.domain.Option;
 import band.gosrock.domain.domains.ticket_item.domain.OptionGroupType;
 import org.junit.jupiter.api.BeforeEach;

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketTest.java
@@ -1,15 +1,10 @@
-package band.gosrock.domain.domains.issuedTicket;
+package band.gosrock.domain.domains.issuedTicket.domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
 import band.gosrock.domain.common.vo.Money;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketItemInfoVo;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketOptionAnswer;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketStatus;
-import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketUserInfoVo;
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelEntranceException;
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelException;
 import band.gosrock.domain.domains.issuedTicket.exception.CanNotEntranceException;

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketUserInfoVoTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketUserInfoVoTest.java
@@ -31,6 +31,7 @@ public class IssuedTicketUserInfoVoTest {
                         .userId(1L)
                         .userName("test")
                         .phoneNumber(phoneNumberVo)
+                        .email("test@test.com")
                         .build();
         profile =
                 Profile.builder()
@@ -55,6 +56,7 @@ public class IssuedTicketUserInfoVoTest {
                 () ->
                         assertEquals(
                                 userInfoVo.getPhoneNumber().getPhoneNumber(),
-                                userInfoVoForTest.getPhoneNumber().getPhoneNumber()));
+                                userInfoVoForTest.getPhoneNumber().getPhoneNumber()),
+                () -> assertEquals(userInfoVo.getEmail(), userInfoVoForTest.getEmail()));
     }
 }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketUserInfoVoTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketUserInfoVoTest.java
@@ -1,0 +1,60 @@
+package band.gosrock.domain.domains.issuedTicket.domain;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+
+import band.gosrock.domain.common.vo.PhoneNumberVo;
+import band.gosrock.domain.domains.user.domain.Profile;
+import band.gosrock.domain.domains.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class IssuedTicketUserInfoVoTest {
+
+    @Mock User user;
+
+    IssuedTicketUserInfoVo userInfoVo;
+
+    Profile profile;
+
+    private final PhoneNumberVo phoneNumberVo = PhoneNumberVo.valueOf("010-1234-5678");
+
+    @BeforeEach
+    void setUp() {
+        userInfoVo =
+                IssuedTicketUserInfoVo.builder()
+                        .userId(1L)
+                        .userName("test")
+                        .phoneNumber(phoneNumberVo)
+                        .build();
+        profile =
+                Profile.builder()
+                        .profileImage("test")
+                        .phoneNumber("010-1234-5678")
+                        .name("test")
+                        .email("test@test.com")
+                        .build();
+    }
+
+    @Test
+    public void 유저_정보를_발급티켓_유저_인포로_변환_테스트() {
+        // given
+        given(user.getProfile()).willReturn(profile);
+
+        // when
+        IssuedTicketUserInfoVo userInfoVoForTest = IssuedTicketUserInfoVo.from(user);
+
+        // then
+        assertAll(
+                () -> assertEquals(userInfoVo.getUserName(), userInfoVoForTest.getUserName()),
+                () ->
+                        assertEquals(
+                                userInfoVo.getPhoneNumber().getPhoneNumber(),
+                                userInfoVoForTest.getPhoneNumber().getPhoneNumber()));
+    }
+}


### PR DESCRIPTION
## 개요
- close #360 

## 작업사항
- 발급 티켓 관련 vo들 테스트 코드를 간단하게 추가 해 보았습니다.
- 또, 발급 티켓 응답값에 티켓 payType을 추가했습니다.

 `테스트 커버리지 1% 상승 `
## 변경로직
- 내용을 적어주세요.