### PR TITLE
feat : 주문 완료 알림톡 버튼 추가

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/alimTalk/service/SendDoneOrderAlimTalkService.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/alimTalk/service/SendDoneOrderAlimTalkService.java
@@ -25,7 +25,7 @@ public class SendDoneOrderAlimTalkService {
                         userInfo.getUserName(), eventInfo.getHostName(), eventInfo.getEventName());
         String headerContent = OrderKakaoTalkAlarm.creationHeaderOf();
 
-        ncpHelper.sendItemNcpAlimTalk(
+        ncpHelper.sendDoneOrderAlimTalk(
                 userInfo.getPhoneNum(),
                 OrderKakaoTalkAlarm.creationTemplateCode(),
                 content,

--- a/DuDoong-Api/src/main/java/band/gosrock/api/alimTalk/service/SendWithdrawOrderAlimTalkService.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/alimTalk/service/SendWithdrawOrderAlimTalkService.java
@@ -25,7 +25,7 @@ public class SendWithdrawOrderAlimTalkService {
                         userInfo.getUserName(), eventInfo.getHostName(), eventInfo.getEventName());
         String headerContent = OrderKakaoTalkAlarm.deletionHeaderOf();
 
-        ncpHelper.sendItemButtonNcpAlimTalk(
+        ncpHelper.sendCancelOrderAlimTalk(
                 userInfo.getPhoneNum(),
                 OrderKakaoTalkAlarm.deletionTemplateCode(),
                 content,

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/common/alarm/OrderKakaoTalkAlarm.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/common/alarm/OrderKakaoTalkAlarm.java
@@ -25,7 +25,7 @@ public class OrderKakaoTalkAlarm {
     }
 
     public static String creationTemplateCode() {
-        return "doneorder";
+        return "doneorderv2";
     }
 
     public static String deletionOf(String userName, String hostName, String eventName) {

--- a/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/alilmTalk/NcpHelper.java
+++ b/DuDoong-Infrastructure/src/main/java/band/gosrock/infrastructure/config/alilmTalk/NcpHelper.java
@@ -45,7 +45,7 @@ public class NcpHelper {
     }
 
     // 주문 취소 알림톡 (아이템리스트+버튼)
-    public void sendItemButtonNcpAlimTalk(
+    public void sendCancelOrderAlimTalk(
             String to,
             String templateCode,
             String content,
@@ -64,7 +64,7 @@ public class NcpHelper {
                         ncpAccessKey, ncpSecretKey, alimTalkSignatureRequestUrl, timeStamp);
         // 바디 생성
         MessageDto.AlimTalkItemButtonBody alimTalkItemButtonBody =
-                makeItemButtonBody(templateCode, to, content, headerContent, orderInfo);
+                makeCancelOrderBody(templateCode, to, content, headerContent, orderInfo);
         ncpClient.sendItemButtonAlimTalk(
                 serviceID, ncpAccessKey, timeStamp, signature, alimTalkItemButtonBody);
     }
@@ -87,8 +87,8 @@ public class NcpHelper {
         ncpClient.sendButtonAlimTalk(serviceID, ncpAccessKey, timeStamp, signature, body);
     }
 
-    // 주문 성공 알림톡 (아이템리스트)
-    public void sendItemNcpAlimTalk(
+    // 주문 성공 알림톡 (아이템리스트+버튼)
+    public void sendDoneOrderAlimTalk(
             String to,
             String templateCode,
             String content,
@@ -106,9 +106,10 @@ public class NcpHelper {
                 makePostSignature(
                         ncpAccessKey, ncpSecretKey, alimTalkSignatureRequestUrl, timeStamp);
         // 바디 생성
-        MessageDto.AlimTalkItemBody alimTalkItemBody =
-                makeItemBody(templateCode, to, content, headerContent, orderInfo);
-        ncpClient.sendItemAlimTalk(serviceID, ncpAccessKey, timeStamp, signature, alimTalkItemBody);
+        MessageDto.AlimTalkItemButtonBody alimTalkItemButtonBody =
+                makeDoneOrderBody(templateCode, to, content, headerContent, orderInfo);
+        ncpClient.sendItemButtonAlimTalk(
+                serviceID, ncpAccessKey, timeStamp, signature, alimTalkItemButtonBody);
     }
 
     // 주문서 전송 알림톡 (아이템리스트)
@@ -136,14 +137,42 @@ public class NcpHelper {
         ncpClient.sendItemAlimTalk(serviceID, ncpAccessKey, timeStamp, signature, alimTalkItemBody);
     }
 
-    public MessageDto.AlimTalkItemButtonBody makeItemButtonBody(
+    public MessageDto.AlimTalkItemButtonBody makeDoneOrderBody(
             String templateCode,
             String to,
             String content,
             String headerContent,
             AlimTalkOrderInfo orderInfo) {
         MessageDto.AlimTalkItem alimTalkItem = makeOrderItem(orderInfo);
-        List<MessageDto.AlimTalkButton> alimTalkButtons = makeWithdrawButtons();
+        List<MessageDto.AlimTalkButton> alimTalkButtons = makeDoneOrderButtons();
+
+        MessageDto.AlimTalkItemButtonMessage alimTalkItemButtonMessage =
+                MessageDto.AlimTalkItemButtonMessage.builder()
+                        .to(to)
+                        .content(content)
+                        .headerContent(headerContent)
+                        .item(alimTalkItem)
+                        .buttons(alimTalkButtons)
+                        .build();
+
+        List<MessageDto.AlimTalkItemButtonMessage> alimTalkItemButtonMessages = new ArrayList<>();
+        alimTalkItemButtonMessages.add(alimTalkItemButtonMessage);
+
+        return MessageDto.AlimTalkItemButtonBody.builder()
+                .plusFriendId(plusFriendId)
+                .templateCode(templateCode)
+                .messages(alimTalkItemButtonMessages)
+                .build();
+    }
+
+    public MessageDto.AlimTalkItemButtonBody makeCancelOrderBody(
+            String templateCode,
+            String to,
+            String content,
+            String headerContent,
+            AlimTalkOrderInfo orderInfo) {
+        MessageDto.AlimTalkItem alimTalkItem = makeOrderItem(orderInfo);
+        List<MessageDto.AlimTalkButton> alimTalkButtons = makeCancelOrderButtons();
 
         MessageDto.AlimTalkItemButtonMessage alimTalkItemButtonMessage =
                 MessageDto.AlimTalkItemButtonMessage.builder()
@@ -282,6 +311,15 @@ public class NcpHelper {
         return MessageDto.AlimTalkButton.builder().type("AC").name("채널 추가").build();
     }
 
+    public MessageDto.AlimTalkButton makeMyPageButton() {
+        return MessageDto.AlimTalkButton.builder()
+                .type("WL")
+                .name("마이페이지 바로가기")
+                .linkMobile("https://dudoong.com/mypage")
+                .linkPc("https://dudoong.com/mypage")
+                .build();
+    }
+
     public List<MessageDto.AlimTalkButton> makeSignUpButtons() {
         MessageDto.AlimTalkButton alimTalkButton1 = makeAddChannelButton();
         MessageDto.AlimTalkButton alimTalkButton2 = makeHomePageButton();
@@ -291,7 +329,14 @@ public class NcpHelper {
         return alimTalkButtons;
     }
 
-    public List<MessageDto.AlimTalkButton> makeWithdrawButtons() {
+    public List<MessageDto.AlimTalkButton> makeDoneOrderButtons() {
+        MessageDto.AlimTalkButton alimTalkButton = makeMyPageButton();
+        List<MessageDto.AlimTalkButton> alimTalkButtons = new ArrayList<>();
+        alimTalkButtons.add(alimTalkButton);
+        return alimTalkButtons;
+    }
+
+    public List<MessageDto.AlimTalkButton> makeCancelOrderButtons() {
         MessageDto.AlimTalkButton alimTalkButton = makeHomePageButton();
         List<MessageDto.AlimTalkButton> alimTalkButtons = new ArrayList<>();
         alimTalkButtons.add(alimTalkButton);


### PR DESCRIPTION
## 개요
- close #541 

## 작업사항
- 주문 완료 알림톡에 마이페이지 이동 웹 버튼을 추가합니다.
https://dudoong.com/mypage
- 전송 예시
<img width="341" alt="image" src="https://user-images.githubusercontent.com/67696767/224614522-26b05f0b-5147-4bb8-8785-e766d8168e46.png">

오늘부터 예매 시작인 걸로 알아서 기능 먼저 올리고 리팩토링 새로운 이슈로 넣어서 작업할 예정입니다.

## 변경로직
- 내용을 적어주세요.