### PR TITLE
refactor : 티켓 스태이지 지난 공연 상태 처리

### DIFF
--- a/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderBriefElement.java
+++ b/DuDoong-Api/src/main/java/band/gosrock/api/order/model/dto/response/OrderBriefElement.java
@@ -42,7 +42,7 @@ public class OrderBriefElement {
     public static OrderBriefElement of(Order order, Event event, IssuedTickets issuedTickets) {
         return OrderBriefElement.builder()
                 .refundInfo(event.toRefundInfoVoWithOrderStatus(order.getOrderStatus()))
-                .stage(issuedTickets.getIssuedTicketsStage())
+                .stage(issuedTickets.getIssuedTicketsStage(event))
                 .orderUuid(order.getUuid())
                 .orderNo(order.getOrderNo())
                 .orderStatus(order.getOrderStatus())

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/Event.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/domain/Event.java
@@ -69,6 +69,10 @@ public class Event extends BaseTimeEntity {
         return this.status == PREPARING;
     }
 
+    public Boolean isClosed() {
+        return this.status == CLOSED;
+    }
+
     public void setEventBasic(EventBasic eventBasic) {
         this.validateOpenStatus();
         this.eventBasic = eventBasic;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTickets.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTickets.java
@@ -2,6 +2,7 @@ package band.gosrock.domain.domains.issuedTicket.domain;
 
 
 import band.gosrock.domain.common.vo.IssuedTicketInfoVo;
+import band.gosrock.domain.domains.event.domain.Event;
 import java.util.List;
 import lombok.Getter;
 
@@ -35,12 +36,17 @@ public class IssuedTickets {
         else return String.format("%s ~ %s (%d매)", nos.get(0), nos.get(size - 1), size);
     }
 
-    public IssuedTicketsStage getIssuedTicketsStage() {
+    public IssuedTicketsStage getIssuedTicketsStage(Event event) {
         if (getTotalQuantity() == 0) return IssuedTicketsStage.APPROVE_WAITING;
         List<IssuedTicketStatus> issuedTicketStatuses = getIssuedTicketStatuses();
         if (isCanceled(issuedTicketStatuses)) {
             return IssuedTicketsStage.CANCELED;
         }
+        // 정상 발급된 티켓이 . 지난 공연이라면 지난 공연으로 통일.
+        if (event.isClosed()) {
+            return IssuedTicketsStage.PASSED_EVENT;
+        }
+
         if (isBeforeEntrance(issuedTicketStatuses)) return IssuedTicketsStage.BEFORE_ENTRANCE;
         if (isAfterEntrance(issuedTicketStatuses)) return IssuedTicketsStage.AFTER_ENTRANCE;
         return IssuedTicketsStage.ENTERING;

--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketsStage.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketsStage.java
@@ -16,7 +16,9 @@ public enum IssuedTicketsStage {
     // 입장중
     ENTERING("ENTERING", "입장중"),
     // 취소됨
-    CANCELED("CANCELED", "취소됨");
+    CANCELED("CANCELED", "취소됨"),
+
+    PASSED_EVENT("PASSED_EVENT", "지난공연");
     private final String value;
 
     @JsonValue private final String kr;


### PR DESCRIPTION
## 개요
- close #548 

## 작업사항
- 공연이 지난공연으로 상태가 변경되었을 때 
- 주문내역에서의 티켓 상태 정보를 지난 공연으로 보여줍니당.

## 변경로직
- 내용을 적어주세요.