### PR TITLE
fix : 이벤트 조회에서 요청갯수와, 쿼리결과 갯수가 같아도, hasNext 체크를 해야한다

### DIFF
--- a/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.java
+++ b/DuDoong-Domain/src/main/java/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.java
@@ -60,8 +60,8 @@ public class EventCustomRepositoryImpl implements EventCustomRepository {
                         .limit(pageable.getPageSize() + 1)
                         .fetch();
 
-        final long remainingSize = Math.max(pageable.getPageSize() - openEvents.size(), 0);
-        if (remainingSize > 0) {
+        final long remainingSize = pageable.getPageSize() - openEvents.size();
+        if (remainingSize >= 0) {
             openEvents.addAll(queryClosedEventsByKeywordAndSize(keyword, pageable, remainingSize));
         }
         return SliceUtil.valueOf(openEvents, pageable);


### PR DESCRIPTION
## 개요
- close #issueNumber

## 작업사항
- 이벤트 조회가 OPEN 다음 종료된것들도 불러오는 데,
- 12개가 OPEN 된 12개랑 같으면, hasNext 가 false 로 옴 ( 종료된 공연 쿼리를 한번 더 안날려서 )
- 해당로직 처리

## 변경로직
- 내용을 적어주세요.