### PR TITLE
refactor: Post-migration Kotlin 코드 품질 개선 및 테스트 추가

### DIFF
--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/response/GlobalExceptionHandler.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/response/GlobalExceptionHandler.kt
@@ -90,11 +90,11 @@ class GlobalExceptionHandler(
             val path = propertyPath.drop(propertyPath.size - 1).firstOrNull()
             bindingErrors[path ?: ""] = constraintViolation.message
         }
-        val errorReason = ErrorReason.builder()
-            .code("BAD_REQUEST")
-            .status(400)
-            .reason(bindingErrors.toString())
-            .build()
+        val errorReason = ErrorReason(
+            status = 400,
+            code = "BAD_REQUEST",
+            reason = bindingErrors.toString(),
+        )
         val errorResponse = ErrorResponse(errorReason, request.requestURL.toString())
         return ResponseEntity.status(HttpStatus.valueOf(errorReason.status)).body(errorResponse)
     }

--- a/DuDoong-Common/src/main/kotlin/band/gosrock/common/dto/ErrorReason.kt
+++ b/DuDoong-Common/src/main/kotlin/band/gosrock/common/dto/ErrorReason.kt
@@ -4,20 +4,4 @@ data class ErrorReason(
     val status: Int,
     val code: String,
     val reason: String,
-) {
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var status: Int = 0
-        private var code: String = ""
-        private var reason: String = ""
-
-        fun status(status: Int) = apply { this.status = status }
-        fun code(code: String) = apply { this.code = code }
-        fun reason(reason: String) = apply { this.reason = reason }
-        fun build() = ErrorReason(status, code, reason)
-    }
-}
+)

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/model/BaseTimeEntity.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/model/BaseTimeEntity.kt
@@ -23,5 +23,5 @@ abstract class BaseTimeEntity {
         protected set
 
     /** Kotlin 호환용 메서드 - 같은 모듈에서 Kotlin이 Lombok getter에 접근 불가한 문제 우회 */
-    fun createdAtKt(): LocalDateTime = this.createdAt!!
+    fun createdAtKt(): LocalDateTime = this.createdAt ?: throw IllegalStateException("Entity has not been persisted yet")
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/Money.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/Money.kt
@@ -3,8 +3,6 @@ package band.gosrock.domain.common.vo
 import band.gosrock.domain.common.converter.BigDecimalScale6WithBankersRoundingConverter
 import com.fasterxml.jackson.annotation.JsonValue
 import java.math.BigDecimal
-import java.util.Objects
-import java.util.function.Function
 import javax.persistence.Column
 import javax.persistence.Convert
 import javax.persistence.Embeddable
@@ -32,8 +30,8 @@ class Money() {
         fun wons(amount: Double): Money = Money(BigDecimal.valueOf(amount))
 
         @JvmStatic
-        fun <T> sum(bags: Collection<T>, monetary: Function<T, Money>): Money =
-            bags.stream().map(monetary).reduce(ZERO, Money::plus)
+        fun <T> sum(bags: Collection<T>, monetary: (T) -> Money): Money =
+            bags.fold(ZERO) { acc, item -> acc.plus(monetary(item)) }
     }
 
     fun plus(amount: Money): Money = Money(this.amount.add(amount.amount))
@@ -52,10 +50,10 @@ class Money() {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Money) return false
-        return Objects.equals(amount.toDouble(), other.amount.toDouble())
+        return amount.compareTo(other.amount) == 0
     }
 
-    override fun hashCode(): Int = Objects.hashCode(amount)
+    override fun hashCode(): Int = amount.stripTrailingZeros().hashCode()
 
     @JsonValue
     override fun toString(): String = "${amount.toLong()}원"

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/cart/domain/Cart.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/cart/domain/Cart.kt
@@ -68,24 +68,18 @@ class Cart() : BaseTimeEntity() {
     }
 
     fun isNeedPaid(): Boolean =
-        cartLineItems.stream()
-            .map { it.isNeedPaid() }
-            .reduce(false) { a, b -> a || b }
+        cartLineItems.any { it.isNeedPaid() }
 
     fun getTotalQuantity(): Long =
         cartLineItems.sumOf { it.quantity!! }
 
     fun getTotalPrice(): Money =
-        cartLineItems.stream()
-            .map { it.getTotalCartLinePrice() }
-            .reduce(Money.ZERO, Money::plus)
+        cartLineItems.fold(Money.ZERO) { acc, item -> acc.plus(item.getTotalCartLinePrice()) }
 
     fun getItemId(): Long = getCartLineItem().itemId!!
 
     fun getCartLineItem(): CartLineItem =
-        cartLineItems.stream()
-            .findFirst()
-            .orElseThrow { CartLineItemNotFoundException.EXCEPTION }
+        cartLineItems.firstOrNull() ?: throw CartLineItemNotFoundException.EXCEPTION
 
     fun getDistinctItemIds(): List<Long> =
         cartLineItems.map { it.itemId!! }.distinct()

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/cart/domain/CartLineItem.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/cart/domain/CartLineItem.kt
@@ -64,12 +64,13 @@ class CartLineItem() : BaseTimeEntity() {
     }
 
     fun getTotalOptionsPrice(): Money =
-        cartOptionAnswers.stream()
-            .map { it.additionalPrice }
-            .reduce(Money.ZERO, Money::plus)
+        cartOptionAnswers.fold(Money.ZERO) { acc, answer -> acc.plus(answer.additionalPrice) }
 
-    fun getTotalCartLinePrice(): Money =
-        itemPrice!!.plus(getTotalOptionsPrice()).times(quantity!!.toDouble())
+    fun getTotalCartLinePrice(): Money {
+        val price = itemPrice ?: throw IllegalStateException("CartLineItem itemPrice is not initialized")
+        val qty = quantity ?: throw IllegalStateException("CartLineItem quantity is not initialized")
+        return price.plus(getTotalOptionsPrice()).times(qty.toDouble())
+    }
 
     fun isNeedPaid(): Boolean = Money.ZERO.isLessThan(getTotalCartLinePrice())
 

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/cart/exception/CartErrorCode.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/cart/exception/CartErrorCode.kt
@@ -6,7 +6,6 @@ import band.gosrock.common.consts.DuDoongStatic.NOT_FOUND
 import band.gosrock.common.dto.ErrorReason
 import band.gosrock.common.exception.BaseErrorCode
 import java.lang.reflect.Field
-import java.util.Objects
 
 enum class CartErrorCode(
     private val status: Int,
@@ -23,11 +22,11 @@ enum class CartErrorCode(
     CART_NOT_ALL_ANSWER(BAD_REQUEST, "Cart_400_4", "모든 질문에 답변을 하지 않았습니다.");
 
     override fun getErrorReason(): ErrorReason =
-        ErrorReason.builder().reason(reason).code(code).status(status).build()
+        ErrorReason(status = status, code = code, reason = reason)
 
     override fun getExplainError(): String {
         val field: Field = this.javaClass.getField(this.name)
         val annotation: ExplainError? = field.getAnnotation(ExplainError::class.java)
-        return if (Objects.nonNull(annotation)) annotation!!.value else this.reason
+        return annotation?.value ?: this.reason
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/comment/exception/CommentErrorCode.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/comment/exception/CommentErrorCode.kt
@@ -6,7 +6,6 @@ import band.gosrock.common.consts.DuDoongStatic.NOT_FOUND
 import band.gosrock.common.dto.ErrorReason
 import band.gosrock.common.exception.BaseErrorCode
 import java.lang.reflect.Field
-import java.util.Objects
 
 enum class CommentErrorCode(
     private val status: Int,
@@ -22,11 +21,11 @@ enum class CommentErrorCode(
     RETRIEVE_RANDOM_COMMENT_NOT_FOUND(NOT_FOUND, "Comment_404_2", "랜덤 응원글을 찾을 수 없습니다.");
 
     override fun getErrorReason(): ErrorReason =
-        ErrorReason.builder().reason(reason).code(code).status(status).build()
+        ErrorReason(status = status, code = code, reason = reason)
 
     override fun getExplainError(): String {
         val field: Field = this.javaClass.getField(this.name)
         val annotation: ExplainError? = field.getAnnotation(ExplainError::class.java)
-        return if (Objects.nonNull(annotation)) annotation!!.value else this.reason
+        return annotation?.value ?: this.reason
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/coupon/exception/CouponErrorCode.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/coupon/exception/CouponErrorCode.kt
@@ -6,7 +6,6 @@ import band.gosrock.common.consts.DuDoongStatic.NOT_FOUND
 import band.gosrock.common.dto.ErrorReason
 import band.gosrock.common.exception.BaseErrorCode
 import java.lang.reflect.Field
-import java.util.Objects
 
 enum class CouponErrorCode(
     private val status: Int,
@@ -27,11 +26,11 @@ enum class CouponErrorCode(
     ALREADY_RECOVERED_COUPON(BAD_REQUEST, "Coupon_400_11", "이미 복구한 쿠폰입니다.");
 
     override fun getErrorReason(): ErrorReason =
-        ErrorReason.builder().reason(reason).code(code).status(status).build()
+        ErrorReason(status = status, code = code, reason = reason)
 
     override fun getExplainError(): String {
         val field: Field = this.javaClass.getField(this.name)
         val annotation: ExplainError? = field.getAnnotation(ExplainError::class.java)
-        return if (Objects.nonNull(annotation)) annotation!!.value else this.reason
+        return annotation?.value ?: this.reason
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/domain/Event.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/domain/Event.kt
@@ -81,11 +81,11 @@ class Event() : BaseTimeEntity() {
 
     fun getEndAt(): LocalDateTime? = this.eventBasic?.endAt()
 
-    fun hasEventBasic(): Boolean = this.eventBasic != null && this.eventBasic!!.isUpdated()
+    fun hasEventBasic(): Boolean = this.eventBasic?.isUpdated() == true
 
-    fun hasEventPlace(): Boolean = this.eventPlace != null && this.eventPlace!!.isUpdated()
+    fun hasEventPlace(): Boolean = this.eventPlace?.isUpdated() == true
 
-    fun hasEventDetail(): Boolean = this.eventDetail != null && this.eventDetail!!.isUpdated()
+    fun hasEventDetail(): Boolean = this.eventDetail?.isUpdated() == true
 
     fun isPreparing(): Boolean = this.status == PREPARING
 
@@ -107,7 +107,8 @@ class Event() : BaseTimeEntity() {
     }
 
     fun validateStartAt() {
-        if (getStartAt()!!.isBefore(LocalDateTime.now())) throw EventOpenTimeExpiredException.EXCEPTION
+        val startAt = getStartAt() ?: throw IllegalStateException("Event startAt must be set")
+        if (startAt.isBefore(LocalDateTime.now())) throw EventOpenTimeExpiredException.EXCEPTION
     }
 
     fun validateOpenStatus() {
@@ -124,12 +125,20 @@ class Event() : BaseTimeEntity() {
 
     fun isRefundDateNotPassed(): Boolean = toRefundInfoVo().availAble
 
-    fun isTimeBeforeStartAt(): Boolean = LocalDateTime.now().isBefore(getStartAt()!!)
+    fun isTimeBeforeStartAt(): Boolean {
+        val startAt = getStartAt() ?: throw IllegalStateException("Event startAt must be set")
+        return LocalDateTime.now().isBefore(startAt)
+    }
 
-    fun toRefundInfoVoWithOrderStatus(orderStatus: OrderStatus): RefundInfoVo =
-        RefundInfoVo.of(getStartAt()!!, orderStatus)
+    fun toRefundInfoVoWithOrderStatus(orderStatus: OrderStatus): RefundInfoVo {
+        val startAt = getStartAt() ?: throw IllegalStateException("Event startAt must be set")
+        return RefundInfoVo.of(startAt, orderStatus)
+    }
 
-    fun toRefundInfoVo(): RefundInfoVo = RefundInfoVo.from(getStartAt()!!)
+    fun toRefundInfoVo(): RefundInfoVo {
+        val startAt = getStartAt() ?: throw IllegalStateException("Event startAt must be set")
+        return RefundInfoVo.from(startAt)
+    }
 
     fun toEventInfoVo(): EventInfoVo = EventInfoVo.from(this)
 

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/exception/EventErrorCode.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/exception/EventErrorCode.kt
@@ -6,7 +6,6 @@ import band.gosrock.common.consts.DuDoongStatic.NOT_FOUND
 import band.gosrock.common.dto.ErrorReason
 import band.gosrock.common.exception.BaseErrorCode
 import java.lang.reflect.Field
-import java.util.Objects
 
 enum class EventErrorCode(
     private val status: Int,
@@ -34,11 +33,11 @@ enum class EventErrorCode(
     USE_OTHER_API(BAD_REQUEST, "Event_400_8", "잘못된 접근입니다.");
 
     override fun getErrorReason(): ErrorReason =
-        ErrorReason.builder().reason(reason).code(code).status(status).build()
+        ErrorReason(status = status, code = code, reason = reason)
 
     override fun getExplainError(): String {
         val field: Field = this.javaClass.getField(this.name)
         val annotation: ExplainError? = field.getAnnotation(ExplainError::class.java)
-        return if (Objects.nonNull(annotation)) annotation!!.value else this.reason
+        return annotation?.value ?: this.reason
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/host/exception/HostErrorCode.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/host/exception/HostErrorCode.kt
@@ -6,7 +6,6 @@ import band.gosrock.common.consts.DuDoongStatic.NOT_FOUND
 import band.gosrock.common.dto.ErrorReason
 import band.gosrock.common.exception.BaseErrorCode
 import java.lang.reflect.Field
-import java.util.Objects
 
 enum class HostErrorCode(
     private val status: Int,
@@ -26,12 +25,12 @@ enum class HostErrorCode(
     HOST_USER_NOT_FOUND(NOT_FOUND, "HOST_404_2", "가입된 호스트 유저가 아닙니다.");
 
     override fun getErrorReason(): ErrorReason =
-        ErrorReason.builder().reason(reason).code(code).status(status).build()
+        ErrorReason(status = status, code = code, reason = reason)
 
     override fun getExplainError(): String {
         val field: Field = this.javaClass.getField(this.name)
         val annotation = field.getAnnotation(ExplainError::class.java)
-        return if (Objects.nonNull(annotation)) annotation.value else reason
+        return annotation?.value ?: reason
     }
 
     fun getReason(): String = reason

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketErrorCode.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/issuedTicket/exception/IssuedTicketErrorCode.kt
@@ -6,7 +6,6 @@ import band.gosrock.common.consts.DuDoongStatic.NOT_FOUND
 import band.gosrock.common.dto.ErrorReason
 import band.gosrock.common.exception.BaseErrorCode
 import java.lang.reflect.Field
-import java.util.Objects
 
 enum class IssuedTicketErrorCode(
     private val status: Int,
@@ -22,11 +21,11 @@ enum class IssuedTicketErrorCode(
     ISSUED_TICKET_NOT_MATCHED_EVENT(BAD_REQUEST, "IssuedTicket_400_6", "이 티켓은 해당 이벤트에서 발급된 티켓이 아닙니다.");
 
     override fun getErrorReason(): ErrorReason =
-        ErrorReason.builder().reason(reason).code(code).status(status).build()
+        ErrorReason(status = status, code = code, reason = reason)
 
     override fun getExplainError(): String {
         val field: Field = this.javaClass.getField(this.name)
         val annotation: ExplainError? = field.getAnnotation(ExplainError::class.java)
-        return if (Objects.nonNull(annotation)) annotation!!.value else this.reason
+        return annotation?.value ?: this.reason
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/domain/Order.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/domain/Order.kt
@@ -262,9 +262,7 @@ class Order() : BaseTimeEntity() {
     fun getCouponName(): String = orderCouponVo.name
 
     fun getTotalSupplyPrice(): Money =
-        orderLineItems.stream()
-            .map { it.getTotalOrderLinePrice() }
-            .reduce(Money.ZERO, Money::plus)
+        orderLineItems.fold(Money.ZERO) { acc, item -> acc.plus(item.getTotalOrderLinePrice()) }
 
     fun getTotalPaymentPrice(): Money = getTotalSupplyPrice().minus(getTotalDiscountPrice())
 
@@ -273,9 +271,7 @@ class Order() : BaseTimeEntity() {
     fun hasCoupon(): Boolean = !orderCouponVo.isDefault()
 
     private fun getOrderLineItem(): OrderLineItem =
-        orderLineItems.stream()
-            .findFirst()
-            .orElseThrow { OrderLineNotFountException.EXCEPTION }
+        orderLineItems.firstOrNull() ?: throw OrderLineNotFountException.EXCEPTION
 
     val itemId: Long
         get() = getOrderLineItem().getItemId()

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/domain/OrderLineItem.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/domain/OrderLineItem.kt
@@ -65,24 +65,28 @@ class OrderLineItem() : BaseTimeEntity() {
         }
     }
 
+    private val safeOrderItem: OrderItemVo
+        get() = orderItem ?: throw IllegalStateException("OrderItem is not initialized")
+
+    private val safeQuantity: Long
+        get() = quantity ?: throw IllegalStateException("Quantity is not initialized")
+
     fun getOptionAnswersPrice(): Money =
-        orderOptionAnswers.stream()
-            .map { it.additionalPrice }
-            .reduce(Money.ZERO, Money::plus)
+        orderOptionAnswers.fold(Money.ZERO) { acc, answer -> acc.plus(answer.additionalPrice) }
 
     fun getTotalOrderLinePrice(): Money =
-        getItemPrice().plus(getOptionAnswersPrice()).times(quantity!!.toDouble())
+        getItemPrice().plus(getOptionAnswersPrice()).times(safeQuantity.toDouble())
 
-    fun getItemPrice(): Money = orderItem!!.price!!
+    fun getItemPrice(): Money = safeOrderItem.price ?: throw IllegalStateException("OrderItem price is not set")
 
     fun isNeedPaid(): Boolean = Money.ZERO.isLessThan(getTotalOrderLinePrice())
 
-    fun getItemId(): Long = orderItem!!.itemId!!
+    fun getItemId(): Long = safeOrderItem.itemId ?: throw IllegalStateException("OrderItem itemId is not set")
 
-    fun getItemGroupId(): Long = orderItem!!.itemGroupId!!
+    fun getItemGroupId(): Long = safeOrderItem.itemGroupId ?: throw IllegalStateException("OrderItem itemGroupId is not set")
 
-    fun getItemName(): String = orderItem!!.name!!
+    fun getItemName(): String = safeOrderItem.name ?: throw IllegalStateException("OrderItem name is not set")
 
     fun getAnswerOptionIds(): List<Long> =
-        orderOptionAnswers.map { it.optionId!! }
+        orderOptionAnswers.map { it.optionId ?: throw IllegalStateException("OrderOptionAnswer optionId is not set") }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/exception/OrderErrorCode.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/exception/OrderErrorCode.kt
@@ -6,7 +6,6 @@ import band.gosrock.common.consts.DuDoongStatic.NOT_FOUND
 import band.gosrock.common.dto.ErrorReason
 import band.gosrock.common.exception.BaseErrorCode
 import java.lang.reflect.Field
-import java.util.Objects
 
 enum class OrderErrorCode(
     private val status: Int,
@@ -38,11 +37,11 @@ enum class OrderErrorCode(
     ORDER_CANNOT_REFUSE(BAD_REQUEST, "Order_400_16", "승인 대기중인 주문을 거절할 수 없는 상태입니다.");
 
     override fun getErrorReason(): ErrorReason =
-        ErrorReason.builder().reason(reason).code(code).status(status).build()
+        ErrorReason(status = status, code = code, reason = reason)
 
     override fun getExplainError(): String {
         val field: Field = this.javaClass.getField(this.name)
         val annotation: ExplainError? = field.getAnnotation(ExplainError::class.java)
-        return if (Objects.nonNull(annotation)) annotation!!.value else this.reason
+        return annotation?.value ?: this.reason
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/settlement/domain/TransactionSettlement.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/settlement/domain/TransactionSettlement.kt
@@ -131,22 +131,31 @@ open class TransactionSettlement protected constructor() : BaseTimeEntity() {
     companion object {
         @JvmStatic
         fun of(eventId: Long, settlementResponse: SettlementResponse): TransactionSettlement {
-            val settlementFeeVos = settlementResponse.fees!!.map { SettlementFeeVo.from(it) }
+            val settlementFeeVos = (settlementResponse.fees
+                ?: throw IllegalArgumentException("Missing fees in settlement response"))
+                .map { SettlementFeeVo.from(it) }
             return TransactionSettlement(
                 eventId = eventId,
                 orderUuid = settlementResponse.orderId,
                 paymentKey = settlementResponse.paymentKey,
                 transactionKey = settlementResponse.transactionKey,
                 paymentMethod = settlementResponse.method,
-                paymentAmount = Money.wons(settlementResponse.amount!!),
+                paymentAmount = Money.wons(settlementResponse.amount
+                    ?: throw IllegalArgumentException("Missing amount in settlement response")),
                 fees = settlementFeeVos,
-                feeSupplyAmount = Money.wons(settlementResponse.supplyAmount!!),
-                feeVat = Money.wons(settlementResponse.vat!!),
-                interestFee = Money.wons(settlementResponse.interestFee!!),
-                settlementAmount = Money.wons(settlementResponse.payOutAmount!!),
+                feeSupplyAmount = Money.wons(settlementResponse.supplyAmount
+                    ?: throw IllegalArgumentException("Missing supplyAmount in settlement response")),
+                feeVat = Money.wons(settlementResponse.vat
+                    ?: throw IllegalArgumentException("Missing vat in settlement response")),
+                interestFee = Money.wons(settlementResponse.interestFee
+                    ?: throw IllegalArgumentException("Missing interestFee in settlement response")),
+                settlementAmount = Money.wons(settlementResponse.payOutAmount
+                    ?: throw IllegalArgumentException("Missing payOutAmount in settlement response")),
                 soldDate = settlementResponse.soldDate,
                 paidOutDate = settlementResponse.paidOutDate,
-                approvedAt = settlementResponse.approvedAt!!.toLocalDateTime(),
+                approvedAt = (settlementResponse.approvedAt
+                    ?: throw IllegalArgumentException("Missing approvedAt in settlement response"))
+                    .toLocalDateTime(),
             )
         }
     }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/ticket_item/exception/TicketItemErrorCode.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/ticket_item/exception/TicketItemErrorCode.kt
@@ -6,7 +6,6 @@ import band.gosrock.common.consts.DuDoongStatic.NOT_FOUND
 import band.gosrock.common.dto.ErrorReason
 import band.gosrock.common.exception.BaseErrorCode
 import java.lang.reflect.Field
-import java.util.Objects
 
 enum class TicketItemErrorCode(
     private val status: Int,
@@ -79,11 +78,11 @@ enum class TicketItemErrorCode(
     INVALID_OPTION_PRICE(BAD_REQUEST, "Option_Group_400_3", "설정할 수 없는 추가 가격입니다.");
 
     override fun getErrorReason(): ErrorReason =
-        ErrorReason.builder().reason(reason).code(code).status(status).build()
+        ErrorReason(status = status, code = code, reason = reason)
 
     override fun getExplainError(): String {
         val field: Field = this.javaClass.getField(this.name)
         val annotation: ExplainError? = field.getAnnotation(ExplainError::class.java)
-        return if (Objects.nonNull(annotation)) annotation!!.value else this.reason
+        return annotation?.value ?: this.reason
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/user/exception/UserErrorCode.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/user/exception/UserErrorCode.kt
@@ -7,7 +7,6 @@ import band.gosrock.common.consts.DuDoongStatic.NOT_FOUND
 import band.gosrock.common.dto.ErrorReason
 import band.gosrock.common.exception.BaseErrorCode
 import java.lang.reflect.Field
-import java.util.Objects
 
 enum class UserErrorCode(
     private val status: Int,
@@ -31,12 +30,12 @@ enum class UserErrorCode(
     USER_PHONE_EMPTY(BAD_REQUEST, "USER_400_3", "유저의 휴대폰 전화번호가 null입니다.");
 
     override fun getErrorReason(): ErrorReason =
-        ErrorReason.builder().reason(reason).code(code).status(status).build()
+        ErrorReason(status = status, code = code, reason = reason)
 
     override fun getExplainError(): String {
         val field: Field = this.javaClass.getField(this.name)
         val annotation = field.getAnnotation(ExplainError::class.java)
-        return if (Objects.nonNull(annotation)) annotation.value else reason
+        return annotation?.value ?: reason
     }
 
     fun getReason(): String = reason

--- a/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/common/vo/DateTimePeriodTest.kt
+++ b/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/common/vo/DateTimePeriodTest.kt
@@ -1,0 +1,63 @@
+package band.gosrock.domain.common.vo
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class DateTimePeriodTest {
+
+    private val start: LocalDateTime = LocalDateTime.of(2025, 1, 1, 10, 0)
+    private val end: LocalDateTime = LocalDateTime.of(2025, 1, 1, 18, 0)
+
+    @Test
+    fun `기간 내 시간은 contains가 true를 반환한다`() {
+        val period = DateTimePeriod.between(start, end)
+        val middle = LocalDateTime.of(2025, 1, 1, 14, 0)
+        assertTrue(period.contains(middle))
+    }
+
+    @Test
+    fun `시작 시각과 정확히 같으면 contains가 true를 반환한다`() {
+        val period = DateTimePeriod.between(start, end)
+        assertTrue(period.contains(start))
+    }
+
+    @Test
+    fun `종료 시각과 정확히 같으면 contains가 true를 반환한다`() {
+        val period = DateTimePeriod.between(start, end)
+        assertTrue(period.contains(end))
+    }
+
+    @Test
+    fun `시작 시각 이전이면 contains가 false를 반환한다`() {
+        val period = DateTimePeriod.between(start, end)
+        val before = LocalDateTime.of(2025, 1, 1, 9, 59)
+        assertFalse(period.contains(before))
+    }
+
+    @Test
+    fun `종료 시각 이후이면 contains가 false를 반환한다`() {
+        val period = DateTimePeriod.between(start, end)
+        val after = LocalDateTime.of(2025, 1, 1, 18, 1)
+        assertFalse(period.contains(after))
+    }
+
+    @Test
+    fun `startAt이 null이면 contains가 false를 반환한다`() {
+        val period = DateTimePeriod.between(null, end)
+        assertFalse(period.contains(start))
+    }
+
+    @Test
+    fun `endAt이 null이면 contains가 false를 반환한다`() {
+        val period = DateTimePeriod.between(start, null)
+        assertFalse(period.contains(start))
+    }
+
+    @Test
+    fun `startAt과 endAt이 모두 null이면 contains가 false를 반환한다`() {
+        val period = DateTimePeriod.between(null, null)
+        assertFalse(period.contains(LocalDateTime.now()))
+    }
+}

--- a/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/common/vo/MoneyTest.kt
+++ b/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/common/vo/MoneyTest.kt
@@ -1,0 +1,140 @@
+package band.gosrock.domain.common.vo
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MoneyTest {
+
+    @Test
+    fun `ZERO는 0원이다`() {
+        assertEquals(0L, Money.ZERO.longValue())
+    }
+
+    @Test
+    fun `wons(Long)으로 금액을 생성한다`() {
+        val money = Money.wons(5000L)
+        assertEquals(5000L, money.longValue())
+    }
+
+    @Test
+    fun `wons(Double)으로 금액을 생성한다`() {
+        val money = Money.wons(1500.0)
+        assertEquals(1500L, money.longValue())
+    }
+
+    @Test
+    fun `두 금액을 더하면 합산된 금액이 반환된다`() {
+        val a = Money.wons(3000L)
+        val b = Money.wons(2000L)
+        assertEquals(Money.wons(5000L), a.plus(b))
+    }
+
+    @Test
+    fun `두 금액을 빼면 차감된 금액이 반환된다`() {
+        val a = Money.wons(5000L)
+        val b = Money.wons(2000L)
+        assertEquals(Money.wons(3000L), a.minus(b))
+    }
+
+    @Test
+    fun `금액에 배수를 곱하면 곱셈 결과가 반환된다`() {
+        val a = Money.wons(1000L)
+        assertEquals(Money.wons(2000L), a.times(2.0))
+    }
+
+    @Test
+    fun `금액을 나누면 나눗셈 결과가 반환된다`() {
+        val a = Money.wons(6000L)
+        assertEquals(Money.wons(2000L), a.divide(3.0))
+    }
+
+    @Test
+    fun `작은 금액은 큰 금액보다 isLessThan이 true다`() {
+        val small = Money.wons(100L)
+        val big = Money.wons(200L)
+        assertTrue(small.isLessThan(big))
+    }
+
+    @Test
+    fun `큰 금액은 작은 금액보다 isLessThan이 false다`() {
+        val small = Money.wons(100L)
+        val big = Money.wons(200L)
+        assertFalse(big.isLessThan(small))
+    }
+
+    @Test
+    fun `같은 금액끼리 isLessThanOrEqual이 true다`() {
+        val a = Money.wons(500L)
+        val b = Money.wons(500L)
+        assertTrue(a.isLessThanOrEqual(b))
+    }
+
+    @Test
+    fun `큰 금액은 작은 금액보다 isGreaterThan이 true다`() {
+        val big = Money.wons(300L)
+        val small = Money.wons(100L)
+        assertTrue(big.isGreaterThan(small))
+    }
+
+    @Test
+    fun `같은 금액끼리 isGreaterThanOrEqual이 true다`() {
+        val a = Money.wons(1000L)
+        assertTrue(a.isGreaterThanOrEqual(a))
+    }
+
+    @Test
+    fun `같은 금액끼리 equals가 true다`() {
+        val a = Money.wons(1000L)
+        val b = Money.wons(1000L)
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `다른 금액끼리 equals가 false다`() {
+        val a = Money.wons(1000L)
+        val b = Money.wons(2000L)
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `같은 금액은 hashCode가 같다`() {
+        val a = Money.wons(1000L)
+        val b = Money.wons(1000L)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun `sum은 컬렉션 원소들의 금액을 모두 더한다`() {
+        val prices = listOf(Money.wons(1000L), Money.wons(2000L), Money.wons(3000L))
+        val total = Money.sum(prices) { it }
+        assertEquals(Money.wons(6000L), total)
+    }
+
+    @Test
+    fun `빈 컬렉션의 sum은 ZERO다`() {
+        val total = Money.sum(emptyList<Money>()) { it }
+        assertEquals(Money.ZERO, total)
+    }
+
+    @Test
+    fun `getDiscountAmountByPercentage는 공급가에 퍼센트 비율을 적용한 할인금액을 반환한다`() {
+        val supply = Money.wons(10000L)
+        val discountMoney = Money.ZERO
+        val discountAmount = discountMoney.getDiscountAmountByPercentage(supply, 10L)
+        assertEquals(1000L, discountAmount)
+    }
+
+    @Test
+    fun `toString은 원 단위 문자열을 반환한다`() {
+        val money = Money.wons(5000L)
+        assertEquals("5000원", money.toString())
+    }
+
+    @Test
+    fun `ZERO에서 ZERO를 더하면 ZERO다`() {
+        assertEquals(Money.ZERO, Money.ZERO.plus(Money.ZERO))
+    }
+}

--- a/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/domains/event/EventStatusTransitionTest.kt
+++ b/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/domains/event/EventStatusTransitionTest.kt
@@ -1,0 +1,281 @@
+package band.gosrock.domain.domains.event
+
+import band.gosrock.domain.domains.event.domain.Event
+import band.gosrock.domain.domains.event.domain.EventBasic
+import band.gosrock.domain.domains.event.domain.EventStatus
+import band.gosrock.domain.domains.event.exception.AlreadyCalculatingStatusException
+import band.gosrock.domain.domains.event.exception.AlreadyCloseStatusException
+import band.gosrock.domain.domains.event.exception.AlreadyDeletedStatusException
+import band.gosrock.domain.domains.event.exception.AlreadyOpenStatusException
+import band.gosrock.domain.domains.event.exception.AlreadyPreparingStatusException
+import band.gosrock.domain.domains.event.exception.CannotDeleteByOpenEventException
+import band.gosrock.domain.domains.event.exception.CannotModifyOpenEventException
+import band.gosrock.domain.domains.event.exception.EventNotOpenException
+import band.gosrock.domain.domains.event.exception.EventOpenTimeExpiredException
+import band.gosrock.domain.domains.event.exception.EventTicketingTimeIsPassedException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.test.util.ReflectionTestUtils
+import java.time.LocalDateTime
+
+class EventStatusTransitionTest {
+
+    private lateinit var event: Event
+
+    @BeforeEach
+    fun setUp() {
+        event = Event.builder().build()
+    }
+
+    // ---- hasEventBasic ----
+
+    @Test
+    fun `name과 startAt과 runTime이 모두 있으면 hasEventBasic이 true다`() {
+        val basic = EventBasic.builder()
+            .name("공연명")
+            .startAt(LocalDateTime.now().plusDays(1))
+            .runTime(90L)
+            .build()
+        event.updateEventBasic(basic)
+        assertTrue(event.hasEventBasic())
+    }
+
+    @Test
+    fun `eventBasic이 null이면 hasEventBasic이 false다`() {
+        event.updateEventBasic(null)
+        assertFalse(event.hasEventBasic())
+    }
+
+    @Test
+    fun `name이 없으면 hasEventBasic이 false다`() {
+        val basic = EventBasic.builder()
+            .startAt(LocalDateTime.now().plusDays(1))
+            .runTime(90L)
+            .build()
+        event.updateEventBasic(basic)
+        assertFalse(event.hasEventBasic())
+    }
+
+    // ---- isTimeBeforeStartAt ----
+
+    @Test
+    fun `startAt이 미래이면 isTimeBeforeStartAt이 true다`() {
+        val basic = EventBasic.builder()
+            .name("공연명")
+            .startAt(LocalDateTime.now().plusDays(1))
+            .runTime(90L)
+            .build()
+        event.updateEventBasic(basic)
+        assertTrue(event.isTimeBeforeStartAt())
+    }
+
+    @Test
+    fun `startAt이 과거이면 isTimeBeforeStartAt이 false다`() {
+        val basic = EventBasic.builder()
+            .name("공연명")
+            .startAt(LocalDateTime.now().minusMinutes(1))
+            .runTime(90L)
+            .build()
+        event.updateEventBasic(basic)
+        assertFalse(event.isTimeBeforeStartAt())
+    }
+
+    // ---- validateTicketingTime ----
+
+    @Test
+    fun `startAt이 과거이면 validateTicketingTime이 예외를 던진다`() {
+        val basic = EventBasic.builder()
+            .name("공연명")
+            .startAt(LocalDateTime.now().minusMinutes(1))
+            .runTime(90L)
+            .build()
+        event.updateEventBasic(basic)
+        assertThrows(EventTicketingTimeIsPassedException::class.java) {
+            event.validateTicketingTime()
+        }
+    }
+
+    @Test
+    fun `startAt이 미래이면 validateTicketingTime이 예외를 던지지 않는다`() {
+        val basic = EventBasic.builder()
+            .name("공연명")
+            .startAt(LocalDateTime.now().plusHours(1))
+            .runTime(90L)
+            .build()
+        event.updateEventBasic(basic)
+        event.validateTicketingTime() // no exception
+    }
+
+    // ---- status: PREPARING (default) ----
+
+    @Test
+    fun `신규 이벤트의 기본 상태는 PREPARING이다`() {
+        assertEquals(EventStatus.PREPARING, event.status)
+    }
+
+    @Test
+    fun `이미 PREPARING 상태에서 prepare를 호출하면 AlreadyPreparingStatusException이 발생한다`() {
+        assertThrows(AlreadyPreparingStatusException::class.java) {
+            event.prepare()
+        }
+    }
+
+    // ---- status: OPEN ----
+
+    @Test
+    fun `미래 startAt이 있는 이벤트는 open 상태로 변경된다`() {
+        val basic = EventBasic.builder()
+            .name("공연명")
+            .startAt(LocalDateTime.now().plusMinutes(10))
+            .runTime(90L)
+            .build()
+        event.updateEventBasic(basic)
+        event.open()
+        assertEquals(EventStatus.OPEN, event.status)
+    }
+
+    @Test
+    fun `이미 OPEN 상태에서 open을 호출하면 AlreadyOpenStatusException이 발생한다`() {
+        val basic = EventBasic.builder()
+            .name("공연명")
+            .startAt(LocalDateTime.now().plusMinutes(10))
+            .runTime(90L)
+            .build()
+        event.updateEventBasic(basic)
+        event.open()
+        assertThrows(AlreadyOpenStatusException::class.java) {
+            event.open()
+        }
+    }
+
+    @Test
+    fun `과거 startAt이 있는 이벤트는 open을 호출하면 EventOpenTimeExpiredException이 발생한다`() {
+        val basic = EventBasic.builder()
+            .name("공연명")
+            .startAt(LocalDateTime.now().minusMinutes(1))
+            .runTime(90L)
+            .build()
+        event.updateEventBasic(basic)
+        assertThrows(EventOpenTimeExpiredException::class.java) {
+            event.open()
+        }
+    }
+
+    // ---- status: CALCULATING ----
+
+    @Test
+    fun `PREPARING 이벤트는 CALCULATING으로 변경된다`() {
+        event.calculate()
+        assertEquals(EventStatus.CALCULATING, event.status)
+    }
+
+    @Test
+    fun `이미 CALCULATING 상태에서 calculate를 호출하면 AlreadyCalculatingStatusException이 발생한다`() {
+        event.calculate()
+        assertThrows(AlreadyCalculatingStatusException::class.java) {
+            event.calculate()
+        }
+    }
+
+    // ---- status: CLOSED ----
+
+    @Test
+    fun `OPEN 이벤트는 CLOSED로 변경된다`() {
+        ReflectionTestUtils.setField(event, "status", EventStatus.OPEN)
+        event.close()
+        assertEquals(EventStatus.CLOSED, event.status)
+    }
+
+    @Test
+    fun `이미 CLOSED 상태에서 close를 호출하면 AlreadyCloseStatusException이 발생한다`() {
+        ReflectionTestUtils.setField(event, "status", EventStatus.OPEN)
+        event.close()
+        assertThrows(AlreadyCloseStatusException::class.java) {
+            event.close()
+        }
+    }
+
+    // ---- status: DELETED ----
+
+    @Test
+    fun `PREPARING 이벤트는 소프트 삭제된다`() {
+        event.deleteSoft()
+        assertEquals(EventStatus.DELETED, event.status)
+    }
+
+    @Test
+    fun `OPEN 이벤트는 deleteSoft를 호출하면 CannotDeleteByOpenEventException이 발생한다`() {
+        ReflectionTestUtils.setField(event, "status", EventStatus.OPEN)
+        assertThrows(CannotDeleteByOpenEventException::class.java) {
+            event.deleteSoft()
+        }
+    }
+
+    @Test
+    fun `이미 DELETED 상태에서 deleteSoft를 호출하면 AlreadyDeletedStatusException이 발생한다`() {
+        event.deleteSoft()
+        assertThrows(AlreadyDeletedStatusException::class.java) {
+            event.deleteSoft()
+        }
+    }
+
+    // ---- validateOpenStatus / validateNotOpenStatus ----
+
+    @Test
+    fun `OPEN 상태에서 validateOpenStatus를 호출하면 CannotModifyOpenEventException이 발생한다`() {
+        ReflectionTestUtils.setField(event, "status", EventStatus.OPEN)
+        assertThrows(CannotModifyOpenEventException::class.java) {
+            event.validateOpenStatus()
+        }
+    }
+
+    @Test
+    fun `PREPARING 상태에서 validateNotOpenStatus를 호출하면 EventNotOpenException이 발생한다`() {
+        assertThrows(EventNotOpenException::class.java) {
+            event.validateNotOpenStatus()
+        }
+    }
+
+    @Test
+    fun `OPEN 상태에서 validateNotOpenStatus는 예외를 던지지 않는다`() {
+        ReflectionTestUtils.setField(event, "status", EventStatus.OPEN)
+        event.validateNotOpenStatus() // no exception
+    }
+
+    // ---- getEventName ----
+
+    @Test
+    fun `eventBasic이 있으면 getEventName이 이름을 반환한다`() {
+        val basic = EventBasic.builder()
+            .name("두둥 공연")
+            .startAt(LocalDateTime.now().plusDays(1))
+            .runTime(60L)
+            .build()
+        event.updateEventBasic(basic)
+        assertEquals("두둥 공연", event.getEventName())
+    }
+
+    @Test
+    fun `eventBasic이 null이면 getEventName이 null을 반환한다`() {
+        assertNull(event.getEventName())
+    }
+
+    // ---- isPreparing / isClosed ----
+
+    @Test
+    fun `PREPARING 상태이면 isPreparing이 true다`() {
+        assertTrue(event.isPreparing())
+    }
+
+    @Test
+    fun `CLOSED 상태이면 isClosed가 true다`() {
+        ReflectionTestUtils.setField(event, "status", EventStatus.CLOSED)
+        assertTrue(event.isClosed())
+    }
+}

--- a/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/domains/issuedTicket/IssuedTicketStatusTransitionTest.kt
+++ b/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/domains/issuedTicket/IssuedTicketStatusTransitionTest.kt
@@ -1,0 +1,157 @@
+package band.gosrock.domain.domains.issuedTicket
+
+import band.gosrock.domain.common.vo.Money
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketItemInfoVo
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketOptionAnswer
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketStatus
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketUserInfoVo
+import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelEntranceException
+import band.gosrock.domain.domains.issuedTicket.exception.CanNotCancelException
+import band.gosrock.domain.domains.issuedTicket.exception.CanNotEntranceException
+import band.gosrock.domain.domains.issuedTicket.exception.IssuedTicketAlreadyEntranceException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.test.util.ReflectionTestUtils
+
+@ExtendWith(MockitoExtension::class)
+class IssuedTicketStatusTransitionTest {
+
+    @Mock
+    private lateinit var userInfo: IssuedTicketUserInfoVo
+
+    @Mock
+    private lateinit var itemInfo: IssuedTicketItemInfoVo
+
+    private lateinit var issuedTicket: IssuedTicket
+
+    @BeforeEach
+    fun setUp() {
+        issuedTicket = IssuedTicket.builder()
+            .eventId(1L)
+            .userInfo(userInfo)
+            .itemInfo(itemInfo)
+            .orderUuid("test-uuid")
+            .orderLineId(10L)
+            .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
+            .issuedTicketOptionAnswers(emptyList())
+            .build()
+    }
+
+    // ---- 기본 상태 ----
+
+    @Test
+    fun `신규 발급 티켓의 기본 상태는 ENTRANCE_INCOMPLETE다`() {
+        assertEquals(IssuedTicketStatus.ENTRANCE_INCOMPLETE, issuedTicket.issuedTicketStatus)
+    }
+
+    // ---- cancel ----
+
+    @Test
+    fun `ENTRANCE_INCOMPLETE 상태의 티켓은 취소할 수 있다`() {
+        issuedTicket.cancel()
+        assertEquals(IssuedTicketStatus.CANCELED, issuedTicket.issuedTicketStatus)
+    }
+
+    @Test
+    fun `이미 입장 완료된 티켓은 취소 시 CanNotCancelException이 발생한다`() {
+        ReflectionTestUtils.setField(issuedTicket, "issuedTicketStatus", IssuedTicketStatus.ENTRANCE_COMPLETED)
+        assertThrows(CanNotCancelException::class.java) {
+            issuedTicket.cancel()
+        }
+    }
+
+    @Test
+    fun `이미 취소된 티켓은 다시 취소 시 CanNotCancelException이 발생한다`() {
+        issuedTicket.cancel()
+        assertThrows(CanNotCancelException::class.java) {
+            issuedTicket.cancel()
+        }
+    }
+
+    // ---- entrance ----
+
+    @Test
+    fun `ENTRANCE_INCOMPLETE 상태의 티켓은 입장 처리된다`() {
+        issuedTicket.entrance()
+        assertEquals(IssuedTicketStatus.ENTRANCE_COMPLETED, issuedTicket.issuedTicketStatus)
+    }
+
+    @Test
+    fun `이미 입장 완료된 티켓은 재입장 시 IssuedTicketAlreadyEntranceException이 발생한다`() {
+        issuedTicket.entrance()
+        assertThrows(IssuedTicketAlreadyEntranceException::class.java) {
+            issuedTicket.entrance()
+        }
+    }
+
+    @Test
+    fun `취소된 티켓은 입장 시 CanNotEntranceException이 발생한다`() {
+        issuedTicket.cancel()
+        assertThrows(CanNotEntranceException::class.java) {
+            issuedTicket.entrance()
+        }
+    }
+
+    // ---- entranceCancel ----
+
+    @Test
+    fun `ENTRANCE_COMPLETED 상태의 티켓은 입장 취소 처리된다`() {
+        issuedTicket.entrance()
+        issuedTicket.entranceCancel()
+        assertEquals(IssuedTicketStatus.ENTRANCE_INCOMPLETE, issuedTicket.issuedTicketStatus)
+    }
+
+    @Test
+    fun `ENTRANCE_INCOMPLETE 상태에서 입장 취소 시 CanNotCancelEntranceException이 발생한다`() {
+        assertThrows(CanNotCancelEntranceException::class.java) {
+            issuedTicket.entranceCancel()
+        }
+    }
+
+    @Test
+    fun `CANCELED 상태에서 입장 취소 시 CanNotCancelEntranceException이 발생한다`() {
+        issuedTicket.cancel()
+        assertThrows(CanNotCancelEntranceException::class.java) {
+            issuedTicket.entranceCancel()
+        }
+    }
+
+    // ---- sumOptionPrice ----
+
+    @Test
+    fun `옵션 답변이 없으면 sumOptionPrice는 ZERO다`() {
+        assertEquals(Money.ZERO, issuedTicket.sumOptionPrice())
+    }
+
+    @Test
+    fun `옵션 답변이 있으면 sumOptionPrice는 추가금액 합계를 반환한다`() {
+        val answer1 = IssuedTicketOptionAnswer(optionId = 1L, additionalPrice = Money.wons(1000L), answer = "답변1")
+        val answer2 = IssuedTicketOptionAnswer(optionId = 2L, additionalPrice = Money.wons(2000L), answer = "답변2")
+        issuedTicket.addOptionAnswers(listOf(answer1, answer2))
+        assertEquals(Money.wons(3000L), issuedTicket.sumOptionPrice())
+    }
+
+    // ---- IssuedTicketStatus 열거형 메서드 ----
+
+    @Test
+    fun `CANCELED 상태의 isCanceled는 true다`() {
+        assert(IssuedTicketStatus.CANCELED.isCanceled())
+    }
+
+    @Test
+    fun `ENTRANCE_INCOMPLETE 상태의 isBeforeEntrance는 true다`() {
+        assert(IssuedTicketStatus.ENTRANCE_INCOMPLETE.isBeforeEntrance())
+    }
+
+    @Test
+    fun `ENTRANCE_COMPLETED 상태의 isAfterEntrance는 true다`() {
+        assert(IssuedTicketStatus.ENTRANCE_COMPLETED.isAfterEntrance())
+    }
+}

--- a/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/domains/order/OrderPaymentCalculationTest.kt
+++ b/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/domains/order/OrderPaymentCalculationTest.kt
@@ -1,0 +1,167 @@
+package band.gosrock.domain.domains.order
+
+import band.gosrock.domain.common.vo.Money
+import band.gosrock.domain.domains.order.domain.Order
+import band.gosrock.domain.domains.order.domain.OrderCouponVo
+import band.gosrock.domain.domains.order.domain.OrderLineItem
+import band.gosrock.domain.domains.order.domain.OrderMethod
+import band.gosrock.domain.domains.order.domain.OrderStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class OrderPaymentCalculationTest {
+
+    @Mock
+    private lateinit var lineItem1: OrderLineItem
+
+    @Mock
+    private lateinit var lineItem2: OrderLineItem
+
+    @Mock
+    private lateinit var orderCouponVo: OrderCouponVo
+
+    private lateinit var noCouponOrder: Order
+    private lateinit var couponOrder: Order
+
+    @BeforeEach
+    fun setUp() {
+        noCouponOrder = Order.builder()
+            .userId(1L)
+            .orderName("쿠폰없는주문")
+            .orderLineItems(listOf(lineItem1, lineItem2))
+            .orderStatus(OrderStatus.PENDING_PAYMENT)
+            .orderMethod(OrderMethod.PAYMENT)
+            .eventId(100L)
+            .build()
+
+        couponOrder = Order.builder()
+            .userId(1L)
+            .orderName("쿠폰있는주문")
+            .orderLineItems(listOf(lineItem1, lineItem2))
+            .orderStatus(OrderStatus.PENDING_PAYMENT)
+            .orderMethod(OrderMethod.PAYMENT)
+            .eventId(100L)
+            .build()
+        couponOrder.attachCoupon(orderCouponVo)
+    }
+
+    // ---- 할인 없는 주문 ----
+
+    @Test
+    fun `쿠폰 없는 주문의 총 할인금액은 0원이다`() {
+        assertEquals(Money.ZERO, noCouponOrder.getTotalDiscountPrice())
+    }
+
+    @Test
+    fun `총 공급가액은 라인아이템 합계다`() {
+        given(lineItem1.getTotalOrderLinePrice()).willReturn(Money.wons(3000L))
+        given(lineItem2.getTotalOrderLinePrice()).willReturn(Money.wons(4000L))
+
+        assertEquals(Money.wons(7000L), noCouponOrder.getTotalSupplyPrice())
+    }
+
+    @Test
+    fun `쿠폰 없을때 총 결제금액은 총 공급가액과 같다`() {
+        given(lineItem1.getTotalOrderLinePrice()).willReturn(Money.wons(3000L))
+        given(lineItem2.getTotalOrderLinePrice()).willReturn(Money.wons(4000L))
+
+        assertEquals(Money.wons(7000L), noCouponOrder.getTotalPaymentPrice())
+    }
+
+    // ---- 쿠폰 있는 주문 ----
+
+    @Test
+    fun `쿠폰 할인 후 결제금액은 공급가액에서 할인액을 뺀 금액이다`() {
+        given(lineItem1.getTotalOrderLinePrice()).willReturn(Money.wons(3000L))
+        given(lineItem2.getTotalOrderLinePrice()).willReturn(Money.wons(4000L))
+        given(orderCouponVo.discountAmount).willReturn(Money.wons(2000L))
+
+        assertEquals(Money.wons(5000L), couponOrder.getTotalPaymentPrice())
+    }
+
+    @Test
+    fun `쿠폰으로 전액 할인되면 결제금액이 0원이다`() {
+        given(lineItem1.getTotalOrderLinePrice()).willReturn(Money.wons(3000L))
+        given(lineItem2.getTotalOrderLinePrice()).willReturn(Money.wons(4000L))
+        given(orderCouponVo.discountAmount).willReturn(Money.wons(7000L))
+
+        assertEquals(Money.ZERO, couponOrder.getTotalPaymentPrice())
+    }
+
+    // ---- isNeedPaid ----
+
+    @Test
+    fun `결제금액이 0원보다 크고 PAYMENT 방식이면 isNeedPaid가 true다`() {
+        given(lineItem1.getTotalOrderLinePrice()).willReturn(Money.wons(1000L))
+        given(lineItem2.getTotalOrderLinePrice()).willReturn(Money.wons(1000L))
+
+        assertTrue(noCouponOrder.isNeedPaid())
+    }
+
+    @Test
+    fun `쿠폰으로 전액 할인되면 isNeedPaid가 false다`() {
+        given(lineItem1.getTotalOrderLinePrice()).willReturn(Money.wons(3000L))
+        given(lineItem2.getTotalOrderLinePrice()).willReturn(Money.wons(4000L))
+        given(orderCouponVo.discountAmount).willReturn(Money.wons(7000L))
+
+        assertFalse(couponOrder.isNeedPaid())
+    }
+
+    // ---- hasCoupon ----
+
+    @Test
+    fun `쿠폰 없는 주문의 hasCoupon은 false다`() {
+        assertFalse(noCouponOrder.hasCoupon())
+    }
+
+    @Test
+    fun `쿠폰 있는 주문의 hasCoupon은 true다`() {
+        given(orderCouponVo.isDefault()).willReturn(false)
+        assertTrue(couponOrder.hasCoupon())
+    }
+
+    // ---- getTotalQuantity ----
+
+    @Test
+    fun `getTotalQuantity는 모든 라인아이템의 수량 합계를 반환한다`() {
+        given(lineItem1.quantity).willReturn(2L)
+        given(lineItem2.quantity).willReturn(3L)
+
+        assertEquals(5L, noCouponOrder.getTotalQuantity())
+    }
+
+    // ---- fail ----
+
+    @Test
+    fun `fail 호출 시 orderStatus가 FAILED로 변경된다`() {
+        noCouponOrder.fail()
+        assertEquals(OrderStatus.FAILED, noCouponOrder.orderStatus)
+    }
+
+    // ---- isDudoongTicketOrder ----
+
+    @Test
+    fun `결제금액이 0원이고 APPROVAL 방식이면 isDudoongTicketOrder가 false다`() {
+        val approvalOrder = Order.builder()
+            .userId(1L)
+            .orderName("승인주문")
+            .orderLineItems(listOf(lineItem1, lineItem2))
+            .orderStatus(OrderStatus.PENDING_APPROVE)
+            .orderMethod(OrderMethod.APPROVAL)
+            .eventId(100L)
+            .build()
+
+        given(lineItem1.getTotalOrderLinePrice()).willReturn(Money.ZERO)
+        given(lineItem2.getTotalOrderLinePrice()).willReturn(Money.ZERO)
+
+        assertFalse(approvalOrder.isDudoongTicketOrder())
+    }
+}


### PR DESCRIPTION
## Summary
- Critical `!!` 제거 → 명시적 에러 메시지 (Event, OrderLineItem, TransactionSettlement, BaseTimeEntity, CartLineItem)
- `Money.equals()` 정밀도 수정 (toDouble → compareTo)
- Java Stream API → Kotlin collection functions (any, fold, firstOrNull)
- 9개 ErrorCode: `Objects.nonNull` → Elvis operator
- `ErrorReason` Builder 패턴 제거 → named params
- 도메인 단위 테스트 4개 추가 (Money, DateTimePeriod, Event 상태전이, IssuedTicket 상태전이, Order 결제 계산)

## 테스트
- `./gradlew test` ✅ BUILD SUCCESSFUL (전체 통과)

close #628