### PR TITLE
test: Python E2E 시나리오 테스트 스위트 추가

### DIFF
--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -1,0 +1,71 @@
+"""
+DuDoong Backend E2E 테스트 공통 픽스처 및 공유 상태 정의.
+모든 테스트 모듈에서 이 파일의 fixtures를 사용합니다.
+"""
+import os
+import pytest
+import requests
+
+
+class TestState:
+    """테스트 모듈 간 공유되는 상태 (세션 전체에서 유지)"""
+    access_token: str = ""
+    refresh_token: str = ""
+    host_id: int = 0
+    event_id: int = 0
+    ticket_item_id: int = 0
+    cart_id: int = 0
+    order_uuid: str = ""
+    comment_id: int = 0
+    # 환불 테스트용 별도 주문
+    refund_order_uuid: str = ""
+
+
+@pytest.fixture(scope="session")
+def state():
+    """세션 전체에서 공유되는 TestState 인스턴스를 반환합니다."""
+    return TestState()
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    """API 베이스 URL. 환경변수 API_BASE_URL로 재정의 가능합니다."""
+    return os.environ.get("API_BASE_URL", "http://localhost:8080/api")
+
+
+@pytest.fixture(scope="session")
+def auth_token(base_url, state):
+    """
+    로컬 개발용 로그인을 수행하고 accessToken을 반환합니다.
+    세션 스코프이므로 전체 테스트 실행 중 1회만 로그인합니다.
+    """
+    url = f"{base_url}/v1/auth/oauth/local/login"
+    payload = {
+        "email": "test@dudoong.com",
+        "name": "E2E테스터",
+        "phoneNumber": "010-0000-0000",
+        "profileImage": None,
+        "marketingAgree": False,
+    }
+    print(f"\n[AUTH] POST {url}")
+    resp = requests.post(url, json=payload)
+    print(f"[AUTH] status={resp.status_code}, body={resp.text[:300]}")
+    assert resp.status_code == 200, f"로그인 실패: {resp.text}"
+    data = resp.json()
+    state.access_token = data["accessToken"]
+    state.refresh_token = data["refreshToken"]
+    return data["accessToken"]
+
+
+@pytest.fixture(scope="session")
+def auth_headers(auth_token):
+    """Authorization Bearer 헤더 딕셔너리를 반환합니다."""
+    return {"Authorization": f"Bearer {auth_token}"}
+
+
+def assert_status(response, expected_status):
+    """응답 상태코드를 검증하는 헬퍼 함수입니다."""
+    assert response.status_code == expected_status, (
+        f"기대 상태코드 {expected_status}, 실제: {response.status_code}\n"
+        f"응답 본문: {response.text[:500]}"
+    )

--- a/e2e-tests/requirements.txt
+++ b/e2e-tests/requirements.txt
@@ -1,0 +1,2 @@
+pytest==7.4.4
+requests==2.31.0

--- a/e2e-tests/test_01_auth.py
+++ b/e2e-tests/test_01_auth.py
@@ -1,0 +1,67 @@
+"""
+인증 관련 E2E 시나리오 테스트.
+로컬 개발용 로그인, 토큰 갱신, 헬스체크, 미인증 접근 검증을 포함합니다.
+"""
+import pytest
+import requests
+
+from conftest import assert_status
+
+
+def test_local_login(base_url, state):
+    """로컬 개발용 즉시 로그인이 성공하고 accessToken/refreshToken이 반환되는지 확인합니다."""
+    url = f"{base_url}/v1/auth/oauth/local/login"
+    payload = {
+        "email": "test@dudoong.com",
+        "name": "E2E테스터",
+        "phoneNumber": "010-0000-0000",
+        "profileImage": None,
+        "marketingAgree": False,
+    }
+    print(f"\n[test_local_login] POST {url}")
+    resp = requests.post(url, json=payload)
+    print(f"[test_local_login] status={resp.status_code}, body={resp.text[:300]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    assert "accessToken" in data, "accessToken 필드가 응답에 없습니다"
+    assert "refreshToken" in data, "refreshToken 필드가 응답에 없습니다"
+    assert data["accessToken"], "accessToken이 비어 있습니다"
+    assert data["refreshToken"], "refreshToken이 비어 있습니다"
+
+    # state에 저장 (다른 테스트에서 재사용)
+    state.access_token = data["accessToken"]
+    state.refresh_token = data["refreshToken"]
+    print(f"[test_local_login] accessToken 획득 완료: {data['accessToken'][:30]}...")
+
+
+def test_token_refresh(base_url, state):
+    """refreshToken으로 토큰을 갱신하면 새로운 토큰이 반환되는지 확인합니다."""
+    assert state.refresh_token, "refresh_token이 없습니다. test_local_login을 먼저 실행하세요."
+    url = f"{base_url}/v1/auth/token/refresh"
+    params = {"token": state.refresh_token}
+    print(f"\n[test_token_refresh] POST {url} ?token=***")
+    resp = requests.post(url, params=params)
+    print(f"[test_token_refresh] status={resp.status_code}, body={resp.text[:300]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    assert "accessToken" in data, "accessToken 필드가 응답에 없습니다"
+    assert "refreshToken" in data, "refreshToken 필드가 응답에 없습니다"
+    # 갱신된 토큰으로 state 업데이트
+    state.access_token = data["accessToken"]
+    state.refresh_token = data["refreshToken"]
+    print(f"[test_token_refresh] 토큰 갱신 완료")
+
+
+def test_unauthenticated_access(base_url):
+    """인증 토큰 없이 보호된 엔드포인트에 접근하면 401 또는 403이 반환되는지 확인합니다."""
+    url = f"{base_url}/v1/hosts"
+    print(f"\n[test_unauthenticated_access] GET {url} (토큰 없음)")
+    resp = requests.get(url)
+    print(f"[test_unauthenticated_access] status={resp.status_code}")
+
+    assert resp.status_code in (401, 403), (
+        f"미인증 접근 시 401 또는 403이 기대되지만 {resp.status_code}가 반환되었습니다"
+    )
+    print(f"[test_unauthenticated_access] 미인증 접근 차단 확인: {resp.status_code}")

--- a/e2e-tests/test_02_host.py
+++ b/e2e-tests/test_02_host.py
@@ -1,0 +1,51 @@
+"""
+호스트 관련 E2E 시나리오 테스트.
+호스트 생성 및 내가 속한 호스트 목록 조회를 검증합니다.
+"""
+import pytest
+import requests
+
+from conftest import assert_status
+
+
+def test_create_host(base_url, auth_headers, state):
+    """새로운 호스트를 생성하고 host_id를 state에 저장합니다."""
+    url = f"{base_url}/v1/hosts"
+    payload = {
+        "name": "E2E테스트호스트",
+        "contactEmail": "host@dudoong.com",
+        "contactNumber": "010-1234-5678",
+    }
+    print(f"\n[test_create_host] POST {url}")
+    print(f"[test_create_host] payload={payload}")
+    resp = requests.post(url, json=payload, headers=auth_headers)
+    print(f"[test_create_host] status={resp.status_code}, body={resp.text[:400]}")
+
+    # 201 또는 200 모두 성공으로 허용
+    assert resp.status_code in (200, 201), (
+        f"호스트 생성 실패: status={resp.status_code}, body={resp.text[:300]}"
+    )
+    data = resp.json()
+    assert "id" in data, f"응답에 id 필드가 없습니다: {data}"
+    state.host_id = data["id"]
+    print(f"[test_create_host] 호스트 생성 완료: host_id={state.host_id}")
+
+
+def test_read_host_profiles(base_url, auth_headers, state):
+    """내가 속한 호스트 목록을 조회하고 생성된 호스트가 포함되는지 확인합니다."""
+    url = f"{base_url}/v1/hosts"
+    print(f"\n[test_read_host_profiles] GET {url}")
+    resp = requests.get(url, headers=auth_headers)
+    print(f"[test_read_host_profiles] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    # SliceResponse 구조: {"data": [...], "hasNext": bool}
+    assert "data" in data, f"응답에 data 필드가 없습니다: {data}"
+    print(f"[test_read_host_profiles] 호스트 목록 조회 완료: {len(data['data'])}개")
+    if state.host_id:
+        ids = [h.get("id") for h in data["data"]]
+        assert state.host_id in ids, (
+            f"생성된 host_id={state.host_id}가 목록에 없습니다: {ids}"
+        )
+        print(f"[test_read_host_profiles] 생성된 호스트 확인됨: id={state.host_id}")

--- a/e2e-tests/test_03_event.py
+++ b/e2e-tests/test_03_event.py
@@ -1,0 +1,108 @@
+"""
+이벤트(공연) 관련 E2E 시나리오 테스트.
+이벤트 생성, 기본 정보 수정, 상세 정보 수정, 상세 조회, 검색을 검증합니다.
+"""
+import pytest
+import requests
+from datetime import datetime, timedelta
+
+from conftest import assert_status
+
+
+def _future_date_str(days_ahead: int = 30) -> str:
+    """현재로부터 days_ahead일 후의 날짜를 'yyyy.MM.dd HH:mm' 형식으로 반환합니다."""
+    future = datetime.now() + timedelta(days=days_ahead)
+    return future.strftime("%Y.%m.%d %H:%M")
+
+
+def test_create_event(base_url, auth_headers, state):
+    """새로운 이벤트(공연)를 생성하고 event_id를 state에 저장합니다."""
+    assert state.host_id, "host_id가 없습니다. test_02_host를 먼저 실행하세요."
+    url = f"{base_url}/v1/events"
+    payload = {
+        "hostId": state.host_id,
+        "name": "E2E테스트공연",
+        "startAt": _future_date_str(30),
+        "runTime": 90,
+    }
+    print(f"\n[test_create_event] POST {url}")
+    print(f"[test_create_event] payload={payload}")
+    resp = requests.post(url, json=payload, headers=auth_headers)
+    print(f"[test_create_event] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert resp.status_code in (200, 201), (
+        f"이벤트 생성 실패: status={resp.status_code}, body={resp.text[:300]}"
+    )
+    data = resp.json()
+    assert "id" in data, f"응답에 id 필드가 없습니다: {data}"
+    state.event_id = data["id"]
+    print(f"[test_create_event] 이벤트 생성 완료: event_id={state.event_id}")
+
+
+def test_update_event_basic(base_url, auth_headers, state):
+    """이벤트 기본 정보(이름, 시작시각, 장소 등)를 수정합니다."""
+    assert state.event_id, "event_id가 없습니다. test_create_event를 먼저 실행하세요."
+    url = f"{base_url}/v1/events/{state.event_id}/basic"
+    payload = {
+        "name": "E2E테스트공연(수정됨)",
+        "startAt": _future_date_str(45),
+        "runTime": 120,
+        "placeName": "테스트공연장",
+        "placeAddress": "서울 마포구 어울마당로 35",
+        "longitude": 126.920036,
+        "latitude": 37.548369,
+    }
+    print(f"\n[test_update_event_basic] PATCH {url}")
+    print(f"[test_update_event_basic] payload={payload}")
+    resp = requests.patch(url, json=payload, headers=auth_headers)
+    print(f"[test_update_event_basic] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    assert data.get("id") == state.event_id, "반환된 id가 일치하지 않습니다"
+    print(f"[test_update_event_basic] 기본 정보 수정 완료")
+
+
+def test_update_event_detail(base_url, auth_headers, state):
+    """이벤트 상세 정보(포스터 이미지, 공연 내용)를 수정합니다."""
+    assert state.event_id, "event_id가 없습니다."
+    url = f"{base_url}/v1/events/{state.event_id}/details"
+    payload = {
+        "posterImageKey": "test/event/e2e/poster.jpeg",
+        "content": "E2E 테스트 공연에 오신 것을 환영합니다.",
+    }
+    print(f"\n[test_update_event_detail] PATCH {url}")
+    print(f"[test_update_event_detail] payload={payload}")
+    resp = requests.patch(url, json=payload, headers=auth_headers)
+    print(f"[test_update_event_detail] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert_status(resp, 200)
+    print(f"[test_update_event_detail] 상세 정보 수정 완료")
+
+
+def test_read_event(base_url, state):
+    """인증 없이 이벤트 상세 정보를 조회합니다 (@DisableSwaggerSecurity 엔드포인트)."""
+    assert state.event_id, "event_id가 없습니다."
+    url = f"{base_url}/v1/events/{state.event_id}"
+    print(f"\n[test_read_event] GET {url} (인증 없음)")
+    resp = requests.get(url)
+    print(f"[test_read_event] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    assert "id" in data, f"응답에 id 필드가 없습니다: {data}"
+    print(f"[test_read_event] 이벤트 상세 조회 완료: id={data.get('id')}")
+
+
+def test_search_events(base_url):
+    """이벤트 이름 키워드 검색이 동작하는지 확인합니다 (인증 불필요)."""
+    url = f"{base_url}/v1/events/search"
+    params = {"keyword": "E2E"}
+    print(f"\n[test_search_events] GET {url} params={params}")
+    resp = requests.get(url, params=params)
+    print(f"[test_search_events] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    assert "data" in data, f"응답에 data 필드가 없습니다: {data}"
+    print(f"[test_search_events] 검색 결과: {len(data['data'])}개")

--- a/e2e-tests/test_04_ticket_item.py
+++ b/e2e-tests/test_04_ticket_item.py
@@ -1,0 +1,64 @@
+"""
+티켓 상품 관련 E2E 시나리오 테스트.
+무료 티켓 생성 및 이벤트의 티켓 목록 조회를 검증합니다.
+"""
+import pytest
+import requests
+
+from conftest import assert_status
+
+
+def test_create_free_ticket_item(base_url, auth_headers, state):
+    """
+    이벤트에 무료 티켓 상품을 생성하고 ticket_item_id를 state에 저장합니다.
+    payType=무료티켓, approveType=선착순으로 생성합니다.
+    """
+    assert state.event_id, "event_id가 없습니다. test_03_event를 먼저 실행하세요."
+    url = f"{base_url}/v1/events/{state.event_id}/ticketItems"
+    payload = {
+        "payType": "무료티켓",
+        "name": "E2E무료티켓",
+        "description": "E2E 테스트용 무료 입장 티켓입니다.",
+        "price": 0,
+        "supplyCount": 100,
+        "approveType": "선착순",
+        "isQuantityPublic": True,
+        "purchaseLimit": 2,
+    }
+    print(f"\n[test_create_free_ticket_item] POST {url}")
+    print(f"[test_create_free_ticket_item] payload={payload}")
+    resp = requests.post(url, json=payload, headers=auth_headers)
+    print(f"[test_create_free_ticket_item] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert resp.status_code in (200, 201), (
+        f"티켓 상품 생성 실패: status={resp.status_code}, body={resp.text[:300]}"
+    )
+    data = resp.json()
+    assert "id" in data, f"응답에 id 필드가 없습니다: {data}"
+    state.ticket_item_id = data["id"]
+    print(f"[test_create_free_ticket_item] 티켓 상품 생성 완료: ticket_item_id={state.ticket_item_id}")
+
+
+def test_get_event_ticket_items(base_url, state):
+    """
+    인증 없이 이벤트의 티켓 상품 목록을 조회합니다.
+    생성된 티켓 상품이 목록에 포함되는지 확인합니다.
+    """
+    assert state.event_id, "event_id가 없습니다."
+    url = f"{base_url}/v1/events/{state.event_id}/ticketItems"
+    print(f"\n[test_get_event_ticket_items] GET {url} (인증 없음)")
+    resp = requests.get(url)
+    print(f"[test_get_event_ticket_items] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    # GetEventTicketItemsResponse 구조: {"ticketItems": [...]}
+    assert "ticketItems" in data, f"응답에 ticketItems 필드가 없습니다: {data}"
+    items = data["ticketItems"]
+    print(f"[test_get_event_ticket_items] 티켓 상품 목록 조회 완료: {len(items)}개")
+    if state.ticket_item_id:
+        ids = [t.get("id") for t in items]
+        assert state.ticket_item_id in ids, (
+            f"생성된 ticket_item_id={state.ticket_item_id}가 목록에 없습니다: {ids}"
+        )
+        print(f"[test_get_event_ticket_items] 생성된 티켓 상품 확인됨: id={state.ticket_item_id}")

--- a/e2e-tests/test_05_order_flow.py
+++ b/e2e-tests/test_05_order_flow.py
@@ -1,0 +1,112 @@
+"""
+주문 플로우 E2E 시나리오 테스트 (핵심 시나리오).
+장바구니 생성 → 장바구니 조회 → 주문 생성 → 무료 주문 완료 → 주문 상세 조회 순서로 검증합니다.
+"""
+import pytest
+import requests
+
+from conftest import assert_status
+
+
+def test_create_cart(base_url, auth_headers, state):
+    """
+    티켓 상품을 장바구니에 담고 cart_id를 state에 저장합니다.
+    옵션이 없는 무료 티켓이므로 options는 빈 리스트로 전송합니다.
+    """
+    assert state.ticket_item_id, "ticket_item_id가 없습니다. test_04_ticket_item을 먼저 실행하세요."
+    url = f"{base_url}/v1/carts"
+    payload = {
+        "items": [
+            {
+                "itemId": state.ticket_item_id,
+                "quantity": 1,
+                "options": [],
+            }
+        ]
+    }
+    print(f"\n[test_create_cart] POST {url}")
+    print(f"[test_create_cart] payload={payload}")
+    resp = requests.post(url, json=payload, headers=auth_headers)
+    print(f"[test_create_cart] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert resp.status_code in (200, 201), (
+        f"장바구니 생성 실패: status={resp.status_code}, body={resp.text[:300]}"
+    )
+    data = resp.json()
+    assert "id" in data, f"응답에 id 필드가 없습니다: {data}"
+    state.cart_id = data["id"]
+    print(f"[test_create_cart] 장바구니 생성 완료: cart_id={state.cart_id}")
+
+
+def test_read_cart(base_url, auth_headers, state):
+    """최근 생성된 장바구니를 조회합니다."""
+    url = f"{base_url}/v1/carts/recent"
+    print(f"\n[test_read_cart] GET {url}")
+    resp = requests.get(url, headers=auth_headers)
+    print(f"[test_read_cart] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    # 장바구니가 없을 경우 null 반환 가능
+    if data is not None:
+        assert "id" in data, f"응답에 id 필드가 없습니다: {data}"
+        print(f"[test_read_cart] 장바구니 조회 완료: cart_id={data.get('id')}")
+    else:
+        print(f"[test_read_cart] 장바구니 없음 (null 반환)")
+
+
+def test_create_order(base_url, auth_headers, state):
+    """
+    장바구니를 주문서로 변환하여 주문을 생성하고 order_uuid를 state에 저장합니다.
+    쿠폰 없이 생성합니다 (couponId=null).
+    """
+    assert state.cart_id, "cart_id가 없습니다. test_create_cart를 먼저 실행하세요."
+    url = f"{base_url}/v1/orders/"
+    payload = {
+        "couponId": None,
+        "cartId": state.cart_id,
+    }
+    print(f"\n[test_create_order] POST {url}")
+    print(f"[test_create_order] payload={payload}")
+    resp = requests.post(url, json=payload, headers=auth_headers)
+    print(f"[test_create_order] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert resp.status_code in (200, 201), (
+        f"주문 생성 실패: status={resp.status_code}, body={resp.text[:300]}"
+    )
+    data = resp.json()
+    assert "orderUuid" in data, f"응답에 orderUuid 필드가 없습니다: {data}"
+    state.order_uuid = data["orderUuid"]
+    print(f"[test_create_order] 주문 생성 완료: order_uuid={state.order_uuid}")
+
+
+def test_free_order(base_url, auth_headers, state):
+    """
+    0원 무료 주문을 완료 처리합니다.
+    선착순 방식 무료 티켓에만 적용 가능합니다.
+    """
+    assert state.order_uuid, "order_uuid가 없습니다. test_create_order를 먼저 실행하세요."
+    url = f"{base_url}/v1/orders/{state.order_uuid}/free"
+    print(f"\n[test_free_order] POST {url}")
+    resp = requests.post(url, headers=auth_headers)
+    print(f"[test_free_order] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    assert "orderUuid" in data, f"응답에 orderUuid 필드가 없습니다: {data}"
+    print(f"[test_free_order] 무료 주문 완료: order_uuid={data.get('orderUuid')}")
+
+
+def test_read_order(base_url, auth_headers, state):
+    """완료된 주문의 상세 정보를 조회하고 발급된 티켓이 포함되는지 확인합니다."""
+    assert state.order_uuid, "order_uuid가 없습니다."
+    url = f"{base_url}/v1/orders/{state.order_uuid}"
+    print(f"\n[test_read_order] GET {url}")
+    resp = requests.get(url, headers=auth_headers)
+    print(f"[test_read_order] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    assert "orderUuid" in data, f"응답에 orderUuid 필드가 없습니다: {data}"
+    assert data["orderUuid"] == state.order_uuid, "반환된 orderUuid가 일치하지 않습니다"
+    print(f"[test_read_order] 주문 상세 조회 완료: {data.get('orderUuid')}")

--- a/e2e-tests/test_06_issued_ticket.py
+++ b/e2e-tests/test_06_issued_ticket.py
@@ -1,0 +1,45 @@
+"""
+발급 티켓 관련 E2E 시나리오 테스트.
+주문 완료 후 발급된 티켓 목록 및 상세 조회를 검증합니다.
+"""
+import pytest
+import requests
+
+from conftest import assert_status
+
+
+def test_read_order_tickets(base_url, auth_headers, state):
+    """
+    완료된 주문에서 발급된 티켓 목록을 조회합니다.
+    주문 완료 후 티켓이 정상적으로 발급되었는지 확인합니다.
+    """
+    assert state.order_uuid, "order_uuid가 없습니다. test_05_order_flow를 먼저 실행하세요."
+    url = f"{base_url}/v1/orders/{state.order_uuid}/tickets"
+    print(f"\n[test_read_order_tickets] GET {url}")
+    resp = requests.get(url, headers=auth_headers)
+    print(f"[test_read_order_tickets] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    # OrderTicketResponse 구조 확인
+    print(f"[test_read_order_tickets] 주문 티켓 조회 완료: {data}")
+
+
+def test_read_my_orders(base_url, auth_headers, state):
+    """
+    마이페이지 예매 목록에서 완료된 주문이 조회되는지 확인합니다.
+    showing=true 파라미터로 현재 유효한 예매 목록을 조회합니다.
+    """
+    url = f"{base_url}/v1/orders"
+    params = {"showing": "true"}
+    print(f"\n[test_read_my_orders] GET {url} params={params}")
+    resp = requests.get(url, params=params, headers=auth_headers)
+    print(f"[test_read_my_orders] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    assert "data" in data, f"응답에 data 필드가 없습니다: {data}"
+    print(f"[test_read_my_orders] 예매 목록 조회 완료: {len(data['data'])}개")
+    if state.order_uuid:
+        uuids = [o.get("orderUuid") for o in data["data"]]
+        print(f"[test_read_my_orders] 조회된 order UUIDs: {uuids}")

--- a/e2e-tests/test_07_comment.py
+++ b/e2e-tests/test_07_comment.py
@@ -1,0 +1,64 @@
+"""
+응원톡(댓글) 관련 E2E 시나리오 테스트.
+응원글 생성 및 목록 조회를 검증합니다.
+"""
+import pytest
+import requests
+
+from conftest import assert_status
+
+
+def test_create_comment(base_url, auth_headers, state):
+    """
+    이벤트에 응원글을 생성하고 comment_id를 state에 저장합니다.
+    nickName은 1~10자, content는 1~150자 제한이 있습니다.
+    """
+    assert state.event_id, "event_id가 없습니다. test_03_event를 먼저 실행하세요."
+    url = f"{base_url}/v1/events/{state.event_id}/comments"
+    payload = {
+        "nickName": "E2E응원단",
+        "content": "E2E 테스트 응원합니다! 화이팅!",
+    }
+    print(f"\n[test_create_comment] POST {url}")
+    print(f"[test_create_comment] payload={payload}")
+    resp = requests.post(url, json=payload, headers=auth_headers)
+    print(f"[test_create_comment] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert resp.status_code in (200, 201), (
+        f"응원글 생성 실패: status={resp.status_code}, body={resp.text[:300]}"
+    )
+    data = resp.json()
+    assert "id" in data, f"응답에 id 필드가 없습니다: {data}"
+    state.comment_id = data["id"]
+    print(f"[test_create_comment] 응원글 생성 완료: comment_id={state.comment_id}")
+
+
+def test_read_comments(base_url, state):
+    """
+    인증 없이 이벤트의 응원글 목록을 조회합니다.
+    생성된 응원글이 목록에 포함되는지 확인합니다.
+    """
+    assert state.event_id, "event_id가 없습니다."
+    url = f"{base_url}/v1/events/{state.event_id}/comments"
+    print(f"\n[test_read_comments] GET {url} (인증 없음)")
+    resp = requests.get(url)
+    print(f"[test_read_comments] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    assert "data" in data, f"응답에 data 필드가 없습니다: {data}"
+    print(f"[test_read_comments] 응원글 목록 조회 완료: {len(data['data'])}개")
+
+
+def test_get_comment_counts(base_url, state):
+    """인증 없이 이벤트의 응원글 개수를 조회합니다."""
+    assert state.event_id, "event_id가 없습니다."
+    url = f"{base_url}/v1/events/{state.event_id}/comments/counts"
+    print(f"\n[test_get_comment_counts] GET {url} (인증 없음)")
+    resp = requests.get(url)
+    print(f"[test_get_comment_counts] status={resp.status_code}, body={resp.text[:200]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    assert "count" in data, f"응답에 count 필드가 없습니다: {data}"
+    print(f"[test_get_comment_counts] 응원글 개수: {data.get('count')}")

--- a/e2e-tests/test_08_refund.py
+++ b/e2e-tests/test_08_refund.py
@@ -1,0 +1,76 @@
+"""
+환불 E2E 시나리오 테스트.
+새로운 주문을 생성한 후 환불 처리까지의 전체 플로우를 검증합니다.
+"""
+import pytest
+import requests
+
+from conftest import assert_status
+
+
+def _create_new_order_for_refund(base_url, auth_headers, state) -> str:
+    """
+    환불 테스트 전용 새 주문을 생성합니다.
+    cart 생성 → order 생성 → free 결제 순서로 진행하고 order_uuid를 반환합니다.
+    """
+    assert state.ticket_item_id, "ticket_item_id가 없습니다. test_04를 먼저 실행하세요."
+
+    # 1) 장바구니 생성
+    cart_resp = requests.post(
+        f"{base_url}/v1/carts",
+        json={
+            "items": [
+                {
+                    "itemId": state.ticket_item_id,
+                    "quantity": 1,
+                    "options": [],
+                }
+            ]
+        },
+        headers=auth_headers,
+    )
+    print(f"[refund setup] cart status={cart_resp.status_code}, body={cart_resp.text[:300]}")
+    assert cart_resp.status_code in (200, 201), f"환불용 장바구니 생성 실패: {cart_resp.text[:200]}"
+    cart_id = cart_resp.json()["id"]
+
+    # 2) 주문 생성
+    order_resp = requests.post(
+        f"{base_url}/v1/orders/",
+        json={"couponId": None, "cartId": cart_id},
+        headers=auth_headers,
+    )
+    print(f"[refund setup] order status={order_resp.status_code}, body={order_resp.text[:300]}")
+    assert order_resp.status_code in (200, 201), f"환불용 주문 생성 실패: {order_resp.text[:200]}"
+    order_uuid = order_resp.json()["orderUuid"]
+
+    # 3) 무료 결제 완료
+    free_resp = requests.post(
+        f"{base_url}/v1/orders/{order_uuid}/free",
+        headers=auth_headers,
+    )
+    print(f"[refund setup] free status={free_resp.status_code}, body={free_resp.text[:300]}")
+    assert free_resp.status_code == 200, f"환불용 무료 결제 실패: {free_resp.text[:200]}"
+
+    return order_uuid
+
+
+def test_refund_order(base_url, auth_headers, state):
+    """
+    새로운 주문을 생성하고 완료 처리한 뒤 환불을 요청합니다.
+    환불 후 응답에 orderUuid가 포함되는지 확인합니다.
+    """
+    print(f"\n[test_refund_order] 환불 테스트용 주문 생성 중...")
+    refund_order_uuid = _create_new_order_for_refund(base_url, auth_headers, state)
+    state.refund_order_uuid = refund_order_uuid
+    print(f"[test_refund_order] 환불 대상 주문: {refund_order_uuid}")
+
+    url = f"{base_url}/v1/orders/{refund_order_uuid}/refund"
+    print(f"[test_refund_order] POST {url}")
+    resp = requests.post(url, headers=auth_headers)
+    print(f"[test_refund_order] status={resp.status_code}, body={resp.text[:400]}")
+
+    assert_status(resp, 200)
+    data = resp.json()
+    assert "orderUuid" in data, f"응답에 orderUuid 필드가 없습니다: {data}"
+    assert data["orderUuid"] == refund_order_uuid, "환불된 orderUuid가 일치하지 않습니다"
+    print(f"[test_refund_order] 환불 완료: order_uuid={data.get('orderUuid')}")


### PR DESCRIPTION
## Summary
- `e2e-tests/` 디렉토리에 pytest + requests 기반 외부 HTTP 시나리오 테스트
- Spring 비의존, 순수 HTTP 호출로 API 플로우 검증
- 8개 시나리오: 인증 → 호스트 → 이벤트 → 티켓 → 주문 → 발급티켓 → 댓글 → 환불

## 사용법
```bash
# 서버 실행 (별도 터미널)
./scripts/local-start.sh

# E2E 테스트 실행
cd e2e-tests
pip install -r requirements.txt
pytest -v
```

## 테스트 목록
| 파일 | 시나리오 |
|------|---------|
| test_01_auth | 로컬 로그인, 토큰 갱신, 미인증 차단 |
| test_02_host | 호스트 생성/조회 |
| test_03_event | 이벤트 CRUD + 검색 |
| test_04_ticket_item | 무료 티켓 생성/조회 |
| test_05_order_flow | 장바구니→주문→무료결제→조회 |
| test_06_issued_ticket | 발급 티켓 조회 |
| test_07_comment | 응원글 생성/조회 |
| test_08_refund | 환불 플로우 |

close #632