### PR TITLE
refactor: ThreadLocal 인증 → @CurrentUserId ArgumentResolver 전환

### DIFF
--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/controller/AuthController.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/controller/AuthController.kt
@@ -15,6 +15,7 @@ import band.gosrock.api.auth.service.RegisterUseCase
 import band.gosrock.api.auth.service.WithDrawUseCase
 import band.gosrock.api.auth.service.helper.CookieHelper
 import band.gosrock.api.config.rateLimit.UserRateLimiter
+import band.gosrock.api.config.security.CurrentUserId
 import band.gosrock.common.annotation.ApiErrorCodeExample
 import band.gosrock.common.annotation.DevelopOnlyApi
 import band.gosrock.infrastructure.outer.api.oauth.exception.KakaoKauthErrorCode
@@ -167,16 +168,16 @@ class AuthController(
     @Operation(summary = "회원탈퇴를 합니다.")
     @SecurityRequirement(name = "access-token")
     @DeleteMapping("/me")
-    fun withDrawUser(): ResponseEntity<Void> {
-        withDrawUseCase.execute()
+    fun withDrawUser(@CurrentUserId userId: Long): ResponseEntity<Void> {
+        withDrawUseCase.execute(userId)
         return ResponseEntity.ok().headers(cookieHelper.deleteCookies()).body(null)
     }
 
     @Operation(summary = "로그아웃을 합니다.")
     @SecurityRequirement(name = "access-token")
     @PostMapping("/logout")
-    fun logoutUser(): ResponseEntity<Void> {
-        logoutUseCase.execute()
+    fun logoutUser(@CurrentUserId userId: Long): ResponseEntity<Void> {
+        logoutUseCase.execute(userId)
         return ResponseEntity.ok().headers(cookieHelper.deleteCookies()).body(null)
     }
 

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/LogoutUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/LogoutUseCase.kt
@@ -1,6 +1,5 @@
 package band.gosrock.api.auth.service
 
-import band.gosrock.api.config.security.SecurityUtils
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.user.adaptor.RefreshTokenAdaptor
 
@@ -9,8 +8,7 @@ class LogoutUseCase(
     private val refreshTokenAdaptor: RefreshTokenAdaptor
 ) {
 
-    fun execute() {
-        val currentUserId = SecurityUtils.getCurrentUserId()
-        refreshTokenAdaptor.deleteByUserId(currentUserId)
+    fun execute(userId: Long) {
+        refreshTokenAdaptor.deleteByUserId(userId)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/WithDrawUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/WithDrawUseCase.kt
@@ -1,7 +1,6 @@
 package band.gosrock.api.auth.service
 
 import band.gosrock.api.auth.service.helper.KakaoOauthHelper
-import band.gosrock.api.config.security.SecurityUtils
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.user.adaptor.RefreshTokenAdaptor
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor
@@ -17,12 +16,11 @@ class WithDrawUseCase(
 ) {
 
     @Transactional
-    fun execute() {
-        val currentUserId = SecurityUtils.getCurrentUserId()
-        refreshTokenAdaptor.deleteByUserId(currentUserId)
-        val user = userAdaptor.queryUser(currentUserId)
+    fun execute(userId: Long) {
+        refreshTokenAdaptor.deleteByUserId(userId)
+        val user = userAdaptor.queryUser(userId)
         val oid = user.oauthInfo!!.oid!!
-        userDomainService.withDrawUser(currentUserId)
+        userDomainService.withDrawUser(userId)
         kakaoOauthHelper.unlink(oid)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/cart/controller/CartController.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/cart/controller/CartController.kt
@@ -5,6 +5,7 @@ import band.gosrock.api.cart.model.dto.request.AddCartRequest
 import band.gosrock.api.cart.model.dto.response.CartResponse
 import band.gosrock.api.cart.service.CreateCartUseCase
 import band.gosrock.api.cart.service.ReadCartUseCase
+import band.gosrock.api.config.security.CurrentUserId
 import band.gosrock.common.annotation.ApiErrorExceptionsExample
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
@@ -27,13 +28,13 @@ class CartController(
     @Operation(summary = "상품을 장바구니에 담습니다. 상품에 답변해야하는 응답이 있다면, 응답도 보내주시면 됩니다.")
     @ApiErrorExceptionsExample(CreateCartExceptionDocs::class)
     @PostMapping
-    fun createCartLines(@RequestBody @Valid addCartRequest: AddCartRequest): CartResponse {
-        return createCartUseCase.execute(addCartRequest)
+    fun createCartLines(@CurrentUserId userId: Long, @RequestBody @Valid addCartRequest: AddCartRequest): CartResponse {
+        return createCartUseCase.execute(userId, addCartRequest)
     }
 
     @Operation(summary = "사용자가 최근에 만들었던 장바구니를 불러옵니다. 없으면 data null (구현 안해도 됨)")
     @GetMapping("/recent")
-    fun getRecentMyCart(): CartResponse? {
-        return readCartUseCase.execute()
+    fun getRecentMyCart(@CurrentUserId userId: Long): CartResponse? {
+        return readCartUseCase.execute(userId)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/cart/service/CreateCartUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/cart/service/CreateCartUseCase.kt
@@ -3,7 +3,6 @@ package band.gosrock.api.cart.service
 import band.gosrock.api.cart.model.dto.request.AddCartRequest
 import band.gosrock.api.cart.model.dto.response.CartResponse
 import band.gosrock.api.cart.model.mapper.CartMapper
-import band.gosrock.api.config.security.SecurityUtils
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.cart.service.CartDomainService
 import org.springframework.transaction.annotation.Transactional
@@ -14,10 +13,9 @@ class CreateCartUseCase(
     private val cartMapper: CartMapper,
 ) {
     @Transactional
-    fun execute(addCartRequest: AddCartRequest): CartResponse {
-        val currentUserId = SecurityUtils.getCurrentUserId()
-        val cart = cartMapper.toEntity(addCartRequest, currentUserId)
-        val cartId = cartDomainService.createCart(cart, currentUserId)
+    fun execute(userId: Long, addCartRequest: AddCartRequest): CartResponse {
+        val cart = cartMapper.toEntity(addCartRequest, userId)
+        val cartId = cartDomainService.createCart(cart, userId)
         return cartMapper.toCartResponse(cartId)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/cart/service/ReadCartUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/cart/service/ReadCartUseCase.kt
@@ -2,7 +2,6 @@ package band.gosrock.api.cart.service
 
 import band.gosrock.api.cart.model.dto.response.CartResponse
 import band.gosrock.api.cart.model.mapper.CartMapper
-import band.gosrock.api.config.security.SecurityUtils
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.cart.adaptor.CartAdaptor
 import org.springframework.transaction.annotation.Transactional
@@ -14,9 +13,8 @@ class ReadCartUseCase(
 ) {
     /** 내가 지금 가지고 있는 장바구니를 리턴합니다. 에러 상황은 아니기때문에 없으면 null 리턴합니다. */
     @Transactional(readOnly = true)
-    fun execute(): CartResponse? {
-        val currentUserId = SecurityUtils.getCurrentUserId()
-        return cartAdaptor.findCartByUserId(currentUserId)
+    fun execute(userId: Long): CartResponse? {
+        return cartAdaptor.findCartByUserId(userId)
             .map { cartMapper.toCartResponse(it) }
             .orElse(null)
     }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/comment/controller/CommentController.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/comment/controller/CommentController.kt
@@ -11,6 +11,7 @@ import band.gosrock.api.comment.service.RetrieveCommentCountUseCase
 import band.gosrock.api.comment.service.RetrieveCommentUseCase
 import band.gosrock.api.comment.service.RetrieveRandomCommentUseCase
 import band.gosrock.api.common.slice.SliceResponse
+import band.gosrock.api.config.security.CurrentUserId
 import band.gosrock.common.annotation.DisableSwaggerSecurity
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
@@ -45,17 +46,19 @@ class CommentController(
     @Operation(summary = "응원글을 생성합니다.")
     @PostMapping
     fun postComment(
+        @CurrentUserId userId: Long,
         @RequestBody @Valid createCommentRequest: CreateCommentRequest,
         @PathVariable eventId: Long,
-    ): CreateCommentResponse = createCommentUseCase.execute(eventId, createCommentRequest)
+    ): CreateCommentResponse = createCommentUseCase.execute(userId, eventId, createCommentRequest)
 
     @DisableSwaggerSecurity
     @Operation(summary = "응원글을 조회합니다.")
     @GetMapping
     fun getComments(
+        @CurrentUserId userId: Long,
         @PathVariable eventId: Long,
         @ParameterObject @PageableDefault(size = 10) pageable: Pageable,
-    ): SliceResponse<RetrieveCommentDTO> = retrieveCommentUseCase.execute(eventId, pageable)
+    ): SliceResponse<RetrieveCommentDTO> = retrieveCommentUseCase.execute(userId, eventId, pageable)
 
     @Operation(summary = "[어드민 기능] 응원글을 삭제합니다.")
     @DeleteMapping("/{commentId}")

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/comment/service/CreateCommentUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/comment/service/CreateCommentUseCase.kt
@@ -3,22 +3,22 @@ package band.gosrock.api.comment.service
 import band.gosrock.api.comment.mapper.CommentMapper
 import band.gosrock.api.comment.model.request.CreateCommentRequest
 import band.gosrock.api.comment.model.response.CreateCommentResponse
-import band.gosrock.api.common.UserUtils
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.comment.adaptor.CommentAdaptor
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class CreateCommentUseCase(
-    private val userUtils: UserUtils,
+    private val userAdaptor: UserAdaptor,
     private val commentMapper: CommentMapper,
     private val commentAdaptor: CommentAdaptor,
     private val eventAdaptor: EventAdaptor,
 ) {
     @Transactional
-    fun execute(eventId: Long, createDTO: CreateCommentRequest): CreateCommentResponse {
-        val currentUser = userUtils.getCurrentUser()
+    fun execute(userId: Long, eventId: Long, createDTO: CreateCommentRequest): CreateCommentResponse {
+        val currentUser = userAdaptor.queryUser(userId)
         val event = eventAdaptor.findById(eventId)
         val comment = commentAdaptor.save(commentMapper.toEntity(currentUser, event, createDTO))
         return commentMapper.toCreateCommentResponse(comment, currentUser)

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/comment/service/DeleteCommentUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/comment/service/DeleteCommentUseCase.kt
@@ -1,7 +1,6 @@
 package band.gosrock.api.comment.service
 
 import band.gosrock.api.comment.mapper.CommentMapper
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.common.aop.hostRole.FindHostFrom.EVENT_ID
 import band.gosrock.api.common.aop.hostRole.HostQualification.MANAGER
 import band.gosrock.api.common.aop.hostRole.HostRolesAllowed
@@ -12,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class DeleteCommentUseCase(
-    private val userUtils: UserUtils,
     private val commentMapper: CommentMapper,
     private val eventService: EventService,
     private val commentDomainService: CommentDomainService,

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/comment/service/RetrieveCommentUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/comment/service/RetrieveCommentUseCase.kt
@@ -2,7 +2,6 @@ package band.gosrock.api.comment.service
 
 import band.gosrock.api.comment.mapper.CommentMapper
 import band.gosrock.api.comment.model.response.RetrieveCommentDTO
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.common.slice.SliceResponse
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.comment.dto.condition.CommentCondition
@@ -13,12 +12,10 @@ import org.springframework.data.domain.Pageable
 class RetrieveCommentUseCase(
     private val commentMapper: CommentMapper,
     private val eventAdaptor: EventAdaptor,
-    private val userUtils: UserUtils,
 ) {
-    fun execute(eventId: Long, pageable: Pageable): SliceResponse<RetrieveCommentDTO> {
+    fun execute(userId: Long, eventId: Long, pageable: Pageable): SliceResponse<RetrieveCommentDTO> {
         val event = eventAdaptor.findById(eventId)
-        val currentUserId = userUtils.getCurrentUserId()
         val commentCondition = CommentCondition(event.id!!, pageable)
-        return commentMapper.toRetrieveCommentListResponse(commentCondition, currentUserId)
+        return commentMapper.toRetrieveCommentListResponse(commentCondition, userId)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/WebMvcConfig.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/WebMvcConfig.kt
@@ -1,0 +1,16 @@
+package band.gosrock.api.config
+
+import band.gosrock.api.config.security.CurrentUserIdResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig(
+    private val currentUserIdResolver: CurrentUserIdResolver,
+) : WebMvcConfigurer {
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(currentUserIdResolver)
+    }
+}

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/security/CurrentUserId.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/security/CurrentUserId.kt
@@ -1,0 +1,5 @@
+package band.gosrock.api.config.security
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CurrentUserId

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/security/CurrentUserIdResolver.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/security/CurrentUserIdResolver.kt
@@ -1,0 +1,23 @@
+package band.gosrock.api.config.security
+
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class CurrentUserIdResolver : HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean =
+        parameter.hasParameterAnnotation(CurrentUserId::class.java) &&
+            parameter.parameterType == Long::class.java
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): Long = SecurityUtils.getCurrentUserId()
+}

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/coupon/controller/CouponController.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/coupon/controller/CouponController.kt
@@ -1,5 +1,6 @@
 package band.gosrock.api.coupon.controller
 
+import band.gosrock.api.config.security.CurrentUserId
 import band.gosrock.api.coupon.dto.reqeust.CreateCouponCampaignRequest
 import band.gosrock.api.coupon.dto.response.CreateCouponCampaignResponse
 import band.gosrock.api.coupon.dto.response.CreateUserCouponResponse
@@ -31,24 +32,27 @@ class CouponController(
     @Operation(summary = "쿠폰 캠페인 생성 API")
     @PostMapping("/campaigns")
     fun createCouponCampaign(
+        @CurrentUserId userId: Long,
         @RequestBody @Valid createCouponCampaignRequest: CreateCouponCampaignRequest,
     ): CreateCouponCampaignResponse {
-        return createCouponUseCase.execute(createCouponCampaignRequest)
+        return createCouponUseCase.execute(userId, createCouponCampaignRequest)
     }
 
     @Operation(summary = "유저 쿠폰 발급 API")
     @PostMapping("/campaigns/{coupon_code}")
     fun createUserCoupon(
+        @CurrentUserId userId: Long,
         @PathVariable("coupon_code") couponCode: String,
     ): CreateUserCouponResponse {
-        return createUserCouponUseCase.execute(couponCode)
+        return createUserCouponUseCase.execute(userId, couponCode)
     }
 
     @Operation(summary = "내 쿠폰 조회 API")
     @GetMapping("")
     fun getAllMyIssuedCoupons(
+        @CurrentUserId userId: Long,
         @RequestParam(required = false, defaultValue = "true") expired: Boolean,
     ): ReadIssuedCouponResponse {
-        return readIssuedCouponUseCase.execute(expired)
+        return readIssuedCouponUseCase.execute(userId, expired)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/coupon/service/CreateCouponUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/coupon/service/CreateCouponUseCase.kt
@@ -1,25 +1,25 @@
 package band.gosrock.api.coupon.service
 
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.coupon.dto.reqeust.CreateCouponCampaignRequest
 import band.gosrock.api.coupon.dto.response.CreateCouponCampaignResponse
 import band.gosrock.api.coupon.mapper.CouponCampaignMapper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.coupon.service.CreateCouponCampaignDomainService
 import band.gosrock.domain.domains.host.service.HostService
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class CreateCouponUseCase(
-    private val userUtils: UserUtils,
+    private val userAdaptor: UserAdaptor,
     private val createCouponCampaignDomainService: CreateCouponCampaignDomainService,
     private val hostService: HostService,
     private val couponCampaignMapper: CouponCampaignMapper,
 ) {
     @Transactional
-    fun execute(createCouponCampaignRequest: CreateCouponCampaignRequest): CreateCouponCampaignResponse {
+    fun execute(userId: Long, createCouponCampaignRequest: CreateCouponCampaignRequest): CreateCouponCampaignResponse {
         // 존재하는 유저인지 검증
-        val user = userUtils.getCurrentUser()
+        val user = userAdaptor.queryUser(userId)
         // 이미 생성된 쿠폰 코드인지 검증
         createCouponCampaignDomainService.checkCouponCodeExists(createCouponCampaignRequest.couponCode)
         // 쿠폰 생성

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/coupon/service/CreateUserCouponUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/coupon/service/CreateUserCouponUseCase.kt
@@ -1,24 +1,24 @@
 package band.gosrock.api.coupon.service
 
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.coupon.dto.response.CreateUserCouponResponse
 import band.gosrock.api.coupon.mapper.IssuedCouponMapper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.coupon.adaptor.CouponCampaignAdaptor
 import band.gosrock.domain.domains.coupon.service.CreateIssuedCouponDomainService
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class CreateUserCouponUseCase(
-    private val userUtils: UserUtils,
+    private val userAdaptor: UserAdaptor,
     private val issuedCouponMapper: IssuedCouponMapper,
     private val couponCampaignAdaptor: CouponCampaignAdaptor,
     private val createIssuedCouponDomainService: CreateIssuedCouponDomainService,
 ) {
     @Transactional
-    fun execute(couponCode: String): CreateUserCouponResponse {
+    fun execute(userId: Long, couponCode: String): CreateUserCouponResponse {
         // 존재하는 유저인지 검증
-        val user = userUtils.getCurrentUser()
+        val user = userAdaptor.queryUser(userId)
         // 쿠폰 코드 검증
         val couponCampaign = couponCampaignAdaptor.findByCouponCode(couponCode)
         // 재고 감소 및 쿠폰 발급

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/coupon/service/ReadIssuedCouponUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/coupon/service/ReadIssuedCouponUseCase.kt
@@ -1,23 +1,23 @@
 package band.gosrock.api.coupon.service
 
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.coupon.dto.response.ReadIssuedCouponResponse
 import band.gosrock.api.coupon.mapper.IssuedCouponMapper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.coupon.adaptor.IssuedCouponAdaptor
 import band.gosrock.domain.domains.coupon.domain.IssuedCoupon
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class ReadIssuedCouponUseCase(
-    private val userUtils: UserUtils,
+    private val userAdaptor: UserAdaptor,
     private val issuedCouponAdaptor: IssuedCouponAdaptor,
     private val issuedCouponMapper: IssuedCouponMapper,
 ) {
     @Transactional(readOnly = true)
-    fun execute(expired: Boolean): ReadIssuedCouponResponse {
+    fun execute(userId: Long, expired: Boolean): ReadIssuedCouponResponse {
         // 존재하는 유저인지 검증
-        val user = userUtils.getCurrentUser()
+        val user = userAdaptor.queryUser(userId)
 
         val issuedCoupons = issuedCouponAdaptor.findAllByUserId(user.id!!)
         // 사용 가능 쿠폰 조회 (사용 이전, 유효 기간 이전)

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/controller/EventController.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/controller/EventController.kt
@@ -19,6 +19,7 @@ import band.gosrock.api.event.service.SearchEventsUseCase
 import band.gosrock.api.event.service.UpdateEventBasicUseCase
 import band.gosrock.api.event.service.UpdateEventDetailUseCase
 import band.gosrock.api.event.service.UpdateEventStatusUseCase
+import band.gosrock.api.config.security.CurrentUserId
 import band.gosrock.common.annotation.DisableSwaggerSecurity
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
@@ -55,9 +56,10 @@ class EventController(
     @Operation(summary = "자신이 관리 중인 이벤트 리스트를 가져옵니다.")
     @GetMapping
     fun getAllEventByUser(
+        @CurrentUserId userId: Long,
         @ParameterObject @PageableDefault(size = 10) pageable: Pageable
     ): SliceResponse<EventProfileResponse> {
-        return readUserHostEventListUseCase.execute(pageable)
+        return readUserHostEventListUseCase.execute(userId, pageable)
     }
 
     @Operation(summary = "이벤트 이름을 키워드로 검색하여 최신순으로 가져옵니다.")
@@ -72,15 +74,15 @@ class EventController(
 
     @Operation(summary = "공연 기본 정보를 등록하여, 새로운 이벤트(공연)를 생성합니다")
     @PostMapping
-    fun createEvent(@RequestBody @Valid createEventRequest: CreateEventRequest): EventResponse {
-        return createEventUseCase.execute(createEventRequest)
+    fun createEvent(@CurrentUserId userId: Long, @RequestBody @Valid createEventRequest: CreateEventRequest): EventResponse {
+        return createEventUseCase.execute(userId, createEventRequest)
     }
 
     @Operation(summary = "공연 상세 정보를 가져옵니다.")
     @DisableSwaggerSecurity
     @GetMapping("/{eventId}")
-    fun getEventDetailById(@PathVariable eventId: Long): EventDetailResponse {
-        return readEventDetailUseCase.execute(eventId)
+    fun getEventDetailById(@CurrentUserId userId: Long, @PathVariable eventId: Long): EventDetailResponse {
+        return readEventDetailUseCase.execute(userId, eventId)
     }
 
     @Operation(summary = "공연 체크리스트 가져오기")

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/service/CreateEventUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/service/CreateEventUseCase.kt
@@ -1,6 +1,5 @@
 package band.gosrock.api.event.service
 
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.event.model.dto.request.CreateEventRequest
 import band.gosrock.api.event.model.dto.response.EventResponse
 import band.gosrock.api.event.model.mapper.EventMapper
@@ -11,14 +10,12 @@ import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class CreateEventUseCase(
-    private val userUtils: UserUtils,
     private val hostService: HostService,
     private val eventService: EventService,
     private val eventMapper: EventMapper
 ) {
     @Transactional
-    fun execute(createEventRequest: CreateEventRequest): EventResponse {
-        val userId = userUtils.getCurrentUserId()
+    fun execute(userId: Long, createEventRequest: CreateEventRequest): EventResponse {
         // 슈퍼 호스트 이상만 공연 생성 가능
         hostService.validateManagerHostUser(createEventRequest.hostId!!, userId)
         val event = eventMapper.toEntity(createEventRequest)

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/service/ReadEventDetailUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/service/ReadEventDetailUseCase.kt
@@ -1,6 +1,5 @@
 package band.gosrock.api.event.service
 
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.event.model.dto.response.EventDetailResponse
 import band.gosrock.api.event.model.mapper.EventMapper
 import band.gosrock.common.annotation.UseCase
@@ -12,15 +11,13 @@ import org.springframework.transaction.annotation.Transactional
 @UseCase
 @Transactional(readOnly = true)
 class ReadEventDetailUseCase(
-    private val userUtils: UserUtils,
     private val eventAdaptor: EventAdaptor,
     private val eventMapper: EventMapper,
     private val hostAdaptor: HostAdaptor
 ) {
-    fun execute(eventId: Long): EventDetailResponse {
+    fun execute(userId: Long, eventId: Long): EventDetailResponse {
         val event = eventAdaptor.findById(eventId)
         val host = hostAdaptor.findById(event.hostId!!)
-        val userId = userUtils.getCurrentUserId()
         // 호스트 유저가 아닐 경우 준비 상태일 때 조회할 수 없음
         if (event.isPreparing() && !host.isActiveHostUserId(userId)) {
             throw EventNotOpenException.EXCEPTION

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/service/ReadUserEventProfilesUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/service/ReadUserEventProfilesUseCase.kt
@@ -1,6 +1,5 @@
 package band.gosrock.api.event.service
 
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.common.slice.SliceResponse
 import band.gosrock.api.event.model.dto.response.EventProfileResponse
 import band.gosrock.api.event.model.mapper.EventMapper
@@ -12,11 +11,9 @@ import org.springframework.transaction.annotation.Transactional
 @UseCase
 @Transactional(readOnly = true)
 class ReadUserEventProfilesUseCase(
-    private val userUtils: UserUtils,
     private val eventMapper: EventMapper
 ) {
-    fun execute(pageable: Pageable): SliceResponse<EventProfileResponse> {
-        val userId = userUtils.getCurrentUserId()
+    fun execute(userId: Long, pageable: Pageable): SliceResponse<EventProfileResponse> {
         return SliceResponse.of(eventMapper.toEventProfileResponseSlice(userId, pageable))
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/controller/HostController.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/controller/HostController.kt
@@ -22,6 +22,7 @@ import band.gosrock.api.host.service.RejectHostUseCase
 import band.gosrock.api.host.service.UpdateHostProfileUseCase
 import band.gosrock.api.host.service.UpdateHostSlackUrlUseCase
 import band.gosrock.api.host.service.UpdateHostUserRoleUseCase
+import band.gosrock.api.config.security.CurrentUserId
 import band.gosrock.domain.common.vo.UserProfileVo
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
@@ -62,9 +63,10 @@ class HostController(
     @Operation(summary = "내가 속한 호스트 리스트를 가져옵니다.")
     @GetMapping
     fun getAllHosts(
+        @CurrentUserId userId: Long,
         @ParameterObject @PageableDefault(size = 10) pageable: Pageable
     ): SliceResponse<HostProfileResponse> {
-        return readHostsUseCase.execute(pageable)
+        return readHostsUseCase.execute(userId, pageable)
     }
 
     @Operation(summary = "고유 아이디에 해당하는 호스트 정보를 가져옵니다.")
@@ -93,20 +95,20 @@ class HostController(
 
     @Operation(summary = "호스트 간편 생성. 호스트를 생성한 유저 자신은 마스터 호스트가 됩니다.")
     @PostMapping
-    fun createHost(@RequestBody @Valid createEventRequest: CreateHostRequest): HostResponse {
-        return createHostUseCase.execute(createEventRequest)
+    fun createHost(@CurrentUserId userId: Long, @RequestBody @Valid createEventRequest: CreateHostRequest): HostResponse {
+        return createHostUseCase.execute(userId, createEventRequest)
     }
 
     @Operation(summary = "초대 받은 호스트에 가입합니다.")
     @PostMapping("/{hostId}/join")
-    fun joinHost(@PathVariable hostId: Long): HostDetailResponse {
-        return joinHostUseCase.execute(hostId)
+    fun joinHost(@CurrentUserId userId: Long, @PathVariable hostId: Long): HostDetailResponse {
+        return joinHostUseCase.execute(userId, hostId)
     }
 
     @Operation(summary = "호스트 초대를 거절합니다.")
     @PostMapping("/{hostId}/reject")
-    fun rejectHost(@PathVariable hostId: Long): HostDetailResponse {
-        return rejectHostUseCase.execute(hostId)
+    fun rejectHost(@CurrentUserId userId: Long, @PathVariable hostId: Long): HostDetailResponse {
+        return rejectHostUseCase.execute(userId, hostId)
     }
 
     @Operation(summary = "다른 유저를 호스트 유저로 초대합니다.")

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/service/CreateHostUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/service/CreateHostUseCase.kt
@@ -1,24 +1,23 @@
 package band.gosrock.api.host.service
 
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.host.model.dto.request.CreateHostRequest
 import band.gosrock.api.host.model.dto.response.HostResponse
 import band.gosrock.api.host.model.mapper.HostMapper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.host.service.HostService
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class CreateHostUseCase(
-    private val userUtils: UserUtils,
+    private val userAdaptor: UserAdaptor,
     private val hostService: HostService,
     private val hostMapper: HostMapper,
 ) {
     @Transactional
-    fun execute(createHostRequest: CreateHostRequest): HostResponse {
+    fun execute(userId: Long, createHostRequest: CreateHostRequest): HostResponse {
         // 존재하는 유저인지 검증
-        val user = userUtils.getCurrentUser()
-        val userId = user.id!!
+        userAdaptor.queryUser(userId)
         // 호스트 생성
         val host = hostService.createHost(hostMapper.toEntity(createHostRequest, userId))
         // 생성한 유저를 마스터 권한으로 등록

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/service/JoinHostUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/service/JoinHostUseCase.kt
@@ -1,6 +1,5 @@
 package band.gosrock.api.host.service
 
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.host.model.dto.response.HostDetailResponse
 import band.gosrock.api.host.model.mapper.HostMapper
 import band.gosrock.common.annotation.UseCase
@@ -10,14 +9,12 @@ import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class JoinHostUseCase(
-    private val userUtils: UserUtils,
     private val hostService: HostService,
     private val hostAdaptor: HostAdaptor,
     private val hostMapper: HostMapper,
 ) {
     @Transactional
-    fun execute(hostId: Long): HostDetailResponse {
-        val userId = userUtils.getCurrentUserId()
+    fun execute(userId: Long, hostId: Long): HostDetailResponse {
         val host = hostAdaptor.findById(hostId)
 
         return hostMapper.toHostDetailResponse(hostService.activateHostUser(host, userId))

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/service/ReadHostProfilesUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/service/ReadHostProfilesUseCase.kt
@@ -1,6 +1,5 @@
 package band.gosrock.api.host.service
 
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.common.slice.SliceResponse
 import band.gosrock.api.host.model.dto.response.HostProfileResponse
 import band.gosrock.common.annotation.UseCase
@@ -10,14 +9,10 @@ import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class ReadHostProfilesUseCase(
-    private val userUtils: UserUtils,
     private val hostAdaptor: HostAdaptor,
 ) {
     @Transactional(readOnly = true)
-    fun execute(pageable: Pageable): SliceResponse<HostProfileResponse> {
-        val user = userUtils.getCurrentUser()
-        val userId = user.id!!
-
+    fun execute(userId: Long, pageable: Pageable): SliceResponse<HostProfileResponse> {
         return SliceResponse.of(
             hostAdaptor
                 .querySliceHostsByUserId(userId, pageable)

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/service/RejectHostUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/service/RejectHostUseCase.kt
@@ -1,6 +1,5 @@
 package band.gosrock.api.host.service
 
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.host.model.dto.response.HostDetailResponse
 import band.gosrock.api.host.model.mapper.HostMapper
 import band.gosrock.common.annotation.UseCase
@@ -10,14 +9,12 @@ import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class RejectHostUseCase(
-    private val userUtils: UserUtils,
     private val hostService: HostService,
     private val hostAdaptor: HostAdaptor,
     private val hostMapper: HostMapper,
 ) {
     @Transactional
-    fun execute(hostId: Long): HostDetailResponse {
-        val userId = userUtils.getCurrentUserId()
+    fun execute(userId: Long, hostId: Long): HostDetailResponse {
         val host = hostAdaptor.findById(hostId)
 
         return hostMapper.toHostDetailResponse(hostService.removeHostUser(host, userId))

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/issuedTicket/controller/IssuedTicketController.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/issuedTicket/controller/IssuedTicketController.kt
@@ -1,5 +1,6 @@
 package band.gosrock.api.issuedTicket.controller
 
+import band.gosrock.api.config.security.CurrentUserId
 import band.gosrock.api.issuedTicket.dto.response.RetrieveIssuedTicketDetailResponse
 import band.gosrock.api.issuedTicket.service.ReadIssuedTicketUseCase
 import io.swagger.v3.oas.annotations.Operation
@@ -20,7 +21,7 @@ class IssuedTicketController(
 
     @Operation(summary = "발급 티켓 가져오기 API 입니다.")
     @GetMapping(value = ["/{uuid}"], produces = ["application/json; charset=utf-8"])
-    fun getIssuedTicket(@PathVariable uuid: String): RetrieveIssuedTicketDetailResponse {
-        return readIssuedTicketUseCase.execute(uuid)
+    fun getIssuedTicket(@CurrentUserId userId: Long, @PathVariable uuid: String): RetrieveIssuedTicketDetailResponse {
+        return readIssuedTicketUseCase.execute(userId, uuid)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/issuedTicket/service/ReadIssuedTicketUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/issuedTicket/service/ReadIssuedTicketUseCase.kt
@@ -1,6 +1,5 @@
 package band.gosrock.api.issuedTicket.service
 
-import band.gosrock.api.config.security.SecurityUtils
 import band.gosrock.api.issuedTicket.dto.response.RetrieveIssuedTicketDetailResponse
 import band.gosrock.api.issuedTicket.mapper.IssuedTicketMapper
 import band.gosrock.common.annotation.UseCase
@@ -13,11 +12,11 @@ class ReadIssuedTicketUseCase(
     /**
      * 발급 티켓 상세 정보 API
      *
+     * @param userId 현재 사용자 id
      * @param uuid 발급 티켓 id
      * @return RetrieveIssuedTicketDetailResponse
      */
-    fun execute(uuid: String): RetrieveIssuedTicketDetailResponse {
-        val currentUserId = SecurityUtils.getCurrentUserId()
-        return issuedTicketMapper.toIssuedTicketDetailResponse(currentUserId, uuid)
+    fun execute(userId: Long, uuid: String): RetrieveIssuedTicketDetailResponse {
+        return issuedTicketMapper.toIssuedTicketDetailResponse(userId, uuid)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/controller/OrderController.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/controller/OrderController.kt
@@ -17,6 +17,7 @@ import band.gosrock.api.order.service.CreateTossOrderUseCase
 import band.gosrock.api.order.service.FreeOrderUseCase
 import band.gosrock.api.order.service.ReadOrderUseCase
 import band.gosrock.api.order.service.RefundOrderUseCase
+import band.gosrock.api.config.security.CurrentUserId
 import band.gosrock.common.annotation.ApiErrorExceptionsExample
 import band.gosrock.common.annotation.DevelopOnlyApi
 import band.gosrock.infrastructure.outer.api.tossPayments.dto.response.PaymentsResponse
@@ -56,47 +57,49 @@ class OrderController(
     @Operation(summary = "주문을 생성합니다. 장바구니 아이디를 주문서로 변환하는 작업을 합니다.")
     @ApiErrorExceptionsExample(CreateOrderExceptionDocs::class)
     @PostMapping("/")
-    fun createOrder(@RequestBody @Valid createOrderRequest: CreateOrderRequest): CreateOrderResponse =
-        createOrderUseCase.execute(createOrderRequest)
+    fun createOrder(@CurrentUserId userId: Long, @RequestBody @Valid createOrderRequest: CreateOrderRequest): CreateOrderResponse =
+        createOrderUseCase.execute(userId, createOrderRequest)
 
     @Operation(summary = "결제 확인하기 . successUrl 로 돌아온 웹페이지에서 query 로 받은 응답값을 서버로 보냅니당.")
     @ApiErrorExceptionsExample(ConfirmOrderExceptionDocs::class)
     @PostMapping("/{order_uuid}/confirm")
     fun confirmOrder(
+        @CurrentUserId userId: Long,
         @PathVariable("order_uuid") orderUuid: String,
         @RequestBody confirmOrderRequest: ConfirmOrderRequest,
-    ): OrderResponse = confirmOrderUseCase.execute(orderUuid, confirmOrderRequest)
+    ): OrderResponse = confirmOrderUseCase.execute(userId, orderUuid, confirmOrderRequest)
 
     @Operation(summary = "주문을 무료로 결제합니다. 선착순 방식 결제 0원일 때 지원")
     @ApiErrorExceptionsExample(FreeOrderExceptionDocs::class)
     @PostMapping("/{order_uuid}/free")
-    fun freeOrder(@PathVariable("order_uuid") orderUuid: String): OrderResponse =
-        freeOrderUseCase.execute(orderUuid)
+    fun freeOrder(@CurrentUserId userId: Long, @PathVariable("order_uuid") orderUuid: String): OrderResponse =
+        freeOrderUseCase.execute(userId, orderUuid)
 
     @Operation(summary = "결제 환불요청. 본인이 구매한 오더를 환불 시킵니다.! (본인 용)")
     @ApiErrorExceptionsExample(RefundOrderExceptionDocs::class)
     @PostMapping("/{order_uuid}/refund")
-    fun refundOrder(@PathVariable("order_uuid") orderUuid: String): OrderResponse =
-        refundOrderUseCase.execute(orderUuid)
+    fun refundOrder(@CurrentUserId userId: Long, @PathVariable("order_uuid") orderUuid: String): OrderResponse =
+        refundOrderUseCase.execute(userId, orderUuid)
 
     @Operation(summary = "결제 조회. 결제 조회 권한은 주문 본인")
     @GetMapping("/{order_uuid}")
-    fun getOrderDetail(@PathVariable("order_uuid") orderUuid: String): OrderResponse =
-        readOrderUseCase.getOrderDetail(orderUuid)
+    fun getOrderDetail(@CurrentUserId userId: Long, @PathVariable("order_uuid") orderUuid: String): OrderResponse =
+        readOrderUseCase.getOrderDetail(userId, orderUuid)
 
     @Operation(summary = "결제 아이디로 발급된 티켓 조회")
     @GetMapping("/{order_uuid}/tickets")
-    fun getOrderTickets(@PathVariable("order_uuid") orderUuid: String): OrderTicketResponse =
-        readOrderUseCase.getOrderTickets(orderUuid)
+    fun getOrderTickets(@CurrentUserId userId: Long, @PathVariable("order_uuid") orderUuid: String): OrderTicketResponse =
+        readOrderUseCase.getOrderTickets(userId, orderUuid)
 
     @Operation(summary = "최근 예매내역 조회")
     @GetMapping("/recent")
-    fun getRecentOrder(): OrderBriefElement? = readOrderUseCase.getRecentOrder()
+    fun getRecentOrder(@CurrentUserId userId: Long): OrderBriefElement? = readOrderUseCase.getRecentOrder(userId)
 
     @Operation(summary = "마이페이지 내 예매목록 조회")
     @GetMapping
     fun getMyOrders(
+        @CurrentUserId userId: Long,
         @ParameterObject @RequestParam showing: Boolean,
         @ParameterObject @PageableDefault pageable: Pageable,
-    ): SliceResponse<OrderBriefElement> = readOrderUseCase.getMyOrders(showing, pageable)
+    ): SliceResponse<OrderBriefElement> = readOrderUseCase.getMyOrders(userId, showing, pageable)
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/ConfirmOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/ConfirmOrderUseCase.kt
@@ -1,6 +1,5 @@
 package band.gosrock.api.order.service
 
-import band.gosrock.api.config.security.SecurityUtils
 import band.gosrock.api.order.model.dto.request.ConfirmOrderRequest
 import band.gosrock.api.order.model.dto.response.OrderResponse
 import band.gosrock.api.order.model.mapper.OrderMapper
@@ -13,14 +12,13 @@ class ConfirmOrderUseCase(
     private val orderConfirmService: OrderConfirmService,
     private val orderMapper: OrderMapper,
 ) {
-    fun execute(orderUuid: String, confirmOrderRequest: ConfirmOrderRequest): OrderResponse {
-        val currentUserId = SecurityUtils.getCurrentUserId()
+    fun execute(userId: Long, orderUuid: String, confirmOrderRequest: ConfirmOrderRequest): OrderResponse {
         val confirmPaymentsRequest = ConfirmPaymentsRequest.builder()
             .paymentKey(confirmOrderRequest.paymentKey)
             .amount(confirmOrderRequest.amount)
             .orderId(orderUuid)
             .build()
-        val confirmOrderUuid = orderConfirmService.execute(confirmPaymentsRequest, currentUserId)
+        val confirmOrderUuid = orderConfirmService.execute(confirmPaymentsRequest, userId)
         return orderMapper.toOrderResponse(confirmOrderUuid)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/CreateOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/CreateOrderUseCase.kt
@@ -1,6 +1,5 @@
 package band.gosrock.api.order.service
 
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.order.model.dto.request.CreateOrderRequest
 import band.gosrock.api.order.model.dto.response.CreateOrderResponse
 import band.gosrock.api.order.model.mapper.OrderMapper
@@ -10,17 +9,15 @@ import band.gosrock.domain.domains.order.service.CreateOrderService
 @UseCase
 class CreateOrderUseCase(
     private val createOrderService: CreateOrderService,
-    private val userUtils: UserUtils,
     private val orderMapper: OrderMapper,
 ) {
-    fun execute(createOrderRequest: CreateOrderRequest): CreateOrderResponse {
-        val user = userUtils.getCurrentUser()
+    fun execute(userId: Long, createOrderRequest: CreateOrderRequest): CreateOrderResponse {
         val couponId = createOrderRequest.couponId
         val cartId = createOrderRequest.cartId!!
         return if (couponId == null) {
-            orderMapper.toCreateOrderResponse(createOrderService.withOutCoupon(cartId, user.id!!))
+            orderMapper.toCreateOrderResponse(createOrderService.withOutCoupon(cartId, userId))
         } else {
-            orderMapper.toCreateOrderResponse(createOrderService.withCoupon(cartId, user.id!!, couponId))
+            orderMapper.toCreateOrderResponse(createOrderService.withCoupon(cartId, userId, couponId))
         }
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/FreeOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/FreeOrderUseCase.kt
@@ -1,6 +1,5 @@
 package band.gosrock.api.order.service
 
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.order.model.dto.response.OrderResponse
 import band.gosrock.api.order.model.mapper.OrderMapper
 import band.gosrock.common.annotation.UseCase
@@ -10,10 +9,9 @@ import band.gosrock.domain.domains.order.service.FreeOrderService
 class FreeOrderUseCase(
     private val freeOrderService: FreeOrderService,
     private val orderMapper: OrderMapper,
-    private val userUtils: UserUtils,
 ) {
-    fun execute(orderUuid: String): OrderResponse {
-        val confirmOrderUuid = freeOrderService.execute(orderUuid, userUtils.getCurrentUserId())
+    fun execute(userId: Long, orderUuid: String): OrderResponse {
+        val confirmOrderUuid = freeOrderService.execute(orderUuid, userId)
         return orderMapper.toOrderResponse(confirmOrderUuid)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/ReadOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/ReadOrderUseCase.kt
@@ -1,6 +1,5 @@
 package band.gosrock.api.order.service
 
-import band.gosrock.api.common.UserUtils
 import band.gosrock.api.common.aop.hostRole.FindHostFrom.EVENT_ID
 import band.gosrock.api.common.aop.hostRole.HostQualification.GUEST
 import band.gosrock.api.common.aop.hostRole.HostRolesAllowed
@@ -27,32 +26,29 @@ class ReadOrderUseCase(
     private val orderMapper: OrderMapper,
     private val orderAdaptor: OrderAdaptor,
     private val orderValidator: OrderValidator,
-    private val userUtils: UserUtils,
     private val issuedTicketAdaptor: IssuedTicketAdaptor,
 ) {
-    fun getOrderDetail(orderUuid: String): OrderResponse {
-        val order = getMyOrder(orderUuid)
+    fun getOrderDetail(userId: Long, orderUuid: String): OrderResponse {
+        val order = getMyOrder(userId, orderUuid)
         return orderMapper.toOrderResponse(order)
     }
 
-    private fun getMyOrder(orderUuid: String): Order {
+    private fun getMyOrder(userId: Long, orderUuid: String): Order {
         val order = orderAdaptor.findByOrderUuid(orderUuid)
-        orderValidator.validOwner(order, userUtils.getCurrentUserId())
+        orderValidator.validOwner(order, userId)
         return order
     }
 
-    fun getRecentOrder(): OrderBriefElement? {
-        val currentUserId = userUtils.getCurrentUserId()
-        val recentOrder = orderAdaptor.findRecentOrderByUserId(currentUserId)
+    fun getRecentOrder(userId: Long): OrderBriefElement? {
+        val recentOrder = orderAdaptor.findRecentOrderByUserId(userId)
         return recentOrder.map { orderMapper.toOrderBriefElement(it) }.orElse(null)
     }
 
-    fun getMyOrders(showing: Boolean, pageable: Pageable): SliceResponse<OrderBriefElement> {
-        val currentUserId = userUtils.getCurrentUserId()
+    fun getMyOrders(userId: Long, showing: Boolean, pageable: Pageable): SliceResponse<OrderBriefElement> {
         val condition = if (showing == true) {
-            FindMyPageOrderCondition.onShowing(currentUserId)
+            FindMyPageOrderCondition.onShowing(userId)
         } else {
-            FindMyPageOrderCondition.notShowing(currentUserId)
+            FindMyPageOrderCondition.notShowing(userId)
         }
         val ordersWithPagination = orderAdaptor.findMyOrders(condition, pageable)
         val orderBriefElements = orderMapper.toOrderBriefsResponse(ordersWithPagination)
@@ -75,8 +71,8 @@ class ReadOrderUseCase(
         return orderMapper.toOrderResponse(order)
     }
 
-    fun getOrderTickets(orderUuid: String): OrderTicketResponse {
-        val order = getMyOrder(orderUuid)
+    fun getOrderTickets(userId: Long, orderUuid: String): OrderTicketResponse {
+        val order = getMyOrder(userId, orderUuid)
         return orderMapper.toOrderTicketResponse(order)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/RefundOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/RefundOrderUseCase.kt
@@ -1,6 +1,5 @@
 package band.gosrock.api.order.service
 
-import band.gosrock.api.config.security.SecurityUtils
 import band.gosrock.api.order.model.dto.response.OrderResponse
 import band.gosrock.api.order.model.mapper.OrderMapper
 import band.gosrock.common.annotation.UseCase
@@ -12,9 +11,8 @@ class RefundOrderUseCase(
     private val withdrawOrderService: WithdrawOrderService,
     private val orderMapper: OrderMapper,
 ) {
-    fun execute(orderUuid: String): OrderResponse {
-        val currentUserId = SecurityUtils.getCurrentUserId()
-        withdrawOrderService.refundOrder(orderUuid, currentUserId)
+    fun execute(userId: Long, orderUuid: String): OrderResponse {
+        withdrawOrderService.refundOrder(orderUuid, userId)
         return orderMapper.toOrderResponse(orderUuid)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/user/controller/UserController.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/user/controller/UserController.kt
@@ -1,6 +1,6 @@
 package band.gosrock.api.user.controller
 
-
+import band.gosrock.api.config.security.CurrentUserId
 import band.gosrock.api.user.service.MarketingUserUseCase
 import band.gosrock.api.user.service.ReadUserUseCase
 import band.gosrock.domain.common.vo.UserInfoVo
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-
 
 @RestController
 @RequestMapping("/v1/users")
@@ -24,19 +23,19 @@ class UserController(
 
     @Operation(summary = "내 유저 정보를 불러 옵니다.")
     @GetMapping("/me")
-    fun getMyUserInfo(): UserInfoVo {
-        return readUserUseCase.execute()
+    fun getMyUserInfo(@CurrentUserId userId: Long): UserInfoVo {
+        return readUserUseCase.execute(userId)
     }
 
     @Operation(summary = "메일 동의 여부를 토글링 합니다")
     @PatchMapping("/me/mail")
-    fun toggleMailReceiveAgree(): UserInfoVo {
-        return marketingUserUseCase.toggleMailAgree()
+    fun toggleMailReceiveAgree(@CurrentUserId userId: Long): UserInfoVo {
+        return marketingUserUseCase.toggleMailAgree(userId)
     }
 
     @Operation(summary = "마케팅 동의 여부를 토글링 합니다")
     @PatchMapping("/me/marketing")
-    fun toggleMarketingAgree(): UserInfoVo {
-        return marketingUserUseCase.toggleMarketAgree()
+    fun toggleMarketingAgree(@CurrentUserId userId: Long): UserInfoVo {
+        return marketingUserUseCase.toggleMarketAgree(userId)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/user/service/MarketingUserUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/user/service/MarketingUserUseCase.kt
@@ -1,30 +1,28 @@
 package band.gosrock.api.user.service
 
-
-import band.gosrock.api.common.UserUtils
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.common.vo.UserInfoVo
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor
 import band.gosrock.domain.domains.user.service.UserDomainService
-
 
 @UseCase
 class MarketingUserUseCase(
-    private val userUtils: UserUtils,
+    private val userAdaptor: UserAdaptor,
     private val userDomainService: UserDomainService,
 ) {
 
-    fun execute(): UserInfoVo {
-        val currentUser = userUtils.getCurrentUser()
+    fun execute(userId: Long): UserInfoVo {
+        val currentUser = userAdaptor.queryUser(userId)
         return currentUser.toUserInfoVo()
     }
 
-    fun toggleMailAgree(): UserInfoVo {
-        userDomainService.toggleMailAgree(userUtils.getCurrentUserId())
-        return userUtils.getCurrentUser().toUserInfoVo()
+    fun toggleMailAgree(userId: Long): UserInfoVo {
+        userDomainService.toggleMailAgree(userId)
+        return userAdaptor.queryUser(userId).toUserInfoVo()
     }
 
-    fun toggleMarketAgree(): UserInfoVo {
-        userDomainService.toggleMarketAgree(userUtils.getCurrentUserId())
-        return userUtils.getCurrentUser().toUserInfoVo()
+    fun toggleMarketAgree(userId: Long): UserInfoVo {
+        userDomainService.toggleMarketAgree(userId)
+        return userAdaptor.queryUser(userId).toUserInfoVo()
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/user/service/ReadUserUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/user/service/ReadUserUseCase.kt
@@ -1,18 +1,16 @@
 package band.gosrock.api.user.service
 
-
-import band.gosrock.api.common.UserUtils
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.common.vo.UserInfoVo
-
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor
 
 @UseCase
 class ReadUserUseCase(
-    private val userUtils: UserUtils,
+    private val userAdaptor: UserAdaptor,
 ) {
 
-    fun execute(): UserInfoVo {
-        val currentUser = userUtils.getCurrentUser()
+    fun execute(userId: Long): UserInfoVo {
+        val currentUser = userAdaptor.queryUser(userId)
         return currentUser.toUserInfoVo()
     }
 }


### PR DESCRIPTION
## Summary

- `@CurrentUserId` 커스텀 어노테이션 + `CurrentUserIdResolver` (HandlerMethodArgumentResolver) 생성
- `WebMvcConfig`에 resolver 등록
- **10개 Controller**: 모든 인증 필요 엔드포인트에 `@CurrentUserId userId: Long` 파라미터 추가
- **22개 UseCase**: `SecurityUtils.getCurrentUserId()` / `UserUtils` → `userId: Long` 파라미터로 대체
- `UserUtils.getCurrentUser()` → `UserAdaptor.queryUser(userId)` 직접 호출로 변경
- `UserUtils`는 AOP aspects (HostRole/HostPartner)에서만 유지
- 인프라 (ThrottlingInterceptor, GlobalExceptionHandler)는 SecurityUtils 유지 (ArgumentResolver 범위 밖)

## 변경 효과
- UseCase 시그니처만 보고 인증 필요 여부 판단 가능
- 테스트에서 `execute(1L, request)` 직접 호출 가능 (SecurityContextHolder 목킹 불필요)
- Swagger 문서에 userId 파라미터 자동 숨김

## 빌드 확인
- `./gradlew clean compileKotlin` ✅ BUILD SUCCESSFUL

close #629