### PR TITLE
fix: Swagger admin-token 보안 스킴 추가

### DIFF
--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminCommentController.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminCommentController.kt
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/internal-api/v1/comments")
-@SecurityRequirement(name = "access-token")
+@SecurityRequirement(name = "admin-token")
 @Tag(name = "Admin")
 class AdminCommentController(
     private val adminGetCommentsUseCase: AdminGetCommentsUseCase,

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminDashboardController.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminDashboardController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/internal-api/v1")
-@SecurityRequirement(name = "access-token")
+@SecurityRequirement(name = "admin-token")
 @Tag(name = "Admin")
 class AdminDashboardController(
     private val getDashboardUseCase: GetDashboardUseCase,

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminEventController.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminEventController.kt
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/internal-api/v1/events")
-@SecurityRequirement(name = "access-token")
+@SecurityRequirement(name = "admin-token")
 @Tag(name = "Admin")
 class AdminEventController(
     private val adminGetEventsUseCase: AdminGetEventsUseCase,

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminOrderController.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminOrderController.kt
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/internal-api/v1/orders")
-@SecurityRequirement(name = "access-token")
+@SecurityRequirement(name = "admin-token")
 @Tag(name = "Admin")
 class AdminOrderController(
     private val adminGetOrdersUseCase: AdminGetOrdersUseCase,

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminUserController.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminUserController.kt
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/internal-api/v1/users")
-@SecurityRequirement(name = "access-token")
+@SecurityRequirement(name = "admin-token")
 @Tag(name = "Admin")
 class AdminUserController(
     private val adminGetUsersUseCase: AdminGetUsersUseCase,

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/admin/controller/AdminAuthController.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/admin/controller/AdminAuthController.kt
@@ -70,7 +70,7 @@ class AdminAuthController(
     }
 
     @Operation(summary = "현재 어드민 유저 정보 조회")
-    @SecurityRequirement(name = "access-token")
+    @SecurityRequirement(name = "admin-token")
     @GetMapping("/me")
     fun getAdminMe(@CurrentUserId userId: Long): AdminUserDetailResponse {
         return adminGetMeUseCase.execute(userId)

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/SwaggerConfig.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/SwaggerConfig.kt
@@ -65,6 +65,14 @@ class SwaggerConfig(
                     .`in`(SecurityScheme.In.HEADER)
                     .name("Authorization"),
             )
+            .addSecuritySchemes(
+                "admin-token",
+                SecurityScheme()
+                    .type(SecurityScheme.Type.APIKEY)
+                    .`in`(SecurityScheme.In.HEADER)
+                    .name("X-Admin-Token")
+                    .description("Admin JWT 토큰 (aud:admin 포함)"),
+            )
 
     @Bean
     fun modelResolver(objectMapper: ObjectMapper): ModelResolver = ModelResolver(objectMapper)


### PR DESCRIPTION
## Summary

- SwaggerConfig에 `X-Admin-Token` 헤더 보안 스킴(APIKEY) 추가
- Admin 컨트롤러의 `@SecurityRequirement`를 `access-token` → `admin-token`으로 변경

## Test plan

- [ ] `./gradlew compileKotlin` 빌드 성공
- [ ] Swagger UI에서 admin-token 보안 스킴 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)