### PR TITLE
feat: Java 21 + Gradle 8.5 업그레이드 및 CI/CD 현대화

### DIFF
--- a/.github/workflows/BuildApiServer.yml
+++ b/.github/workflows/BuildApiServer.yml
@@ -9,48 +9,47 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 17 ]
+        java-version: [ 21 ]
     outputs:
       version: ${{ steps.get_version.outputs.BRANCH_NAME }}
 
     steps:
       - name: Check Out The Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'corretto'
+          distribution: 'temurin'
 
       - name: Get the version
         id: get_version
         run: |
           RELEASE_VERSION_WITHOUT_V="$(cut -d'v' -f2 <<< ${GITHUB_REF#refs/*/})"
-          echo ::set-output name=VERSION::$RELEASE_VERSION_WITHOUT_V 
+          echo "VERSION=$RELEASE_VERSION_WITHOUT_V" >> $GITHUB_OUTPUT
 
       #테스트 수행용 도커 컴포즈
       - name: Start containers
         run: docker compose up -d
 
       - name: Gradle Build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
 
       - name: Execute Gradle build
         run: ./gradlew :DuDoong-Api:build --no-daemon
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: ./DuDoong-Api
           push: true
           tags: water0641/dudoong-api:${{ steps.get_version.outputs.VERSION }}
-

--- a/.github/workflows/BuildBatchServer.yml
+++ b/.github/workflows/BuildBatchServer.yml
@@ -9,50 +9,49 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 17 ]
+        java-version: [ 21 ]
     outputs:
       version: ${{ steps.get_version.outputs.BRANCH_NAME }}
 
     steps:
       - name: Check Out The Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'corretto'
+          distribution: 'temurin'
 
       - name: Get the version
         id: get_version
         run: |
           RELEASE_VERSION_WITHOUT_V="$(cut -d'v' -f2 <<< ${GITHUB_REF#refs/*/})"
-          echo ::set-output name=VERSION::$RELEASE_VERSION_WITHOUT_V 
+          echo "VERSION=$RELEASE_VERSION_WITHOUT_V" >> $GITHUB_OUTPUT
 
       #테스트 수행용 도커 컴포즈
       - name: Start containers
         run: docker compose up -d
 
       - name: Gradle Build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
 
       - name: Execute Gradle build
         run: ./gradlew :DuDoong-Batch:build --no-daemon
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: ./DuDoong-Batch
           push: true
           tags: |
             water0641/dudoong-batch:${{ steps.get_version.outputs.VERSION }}
             water0641/dudoong-batch:latest
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: SetUp JDK 17
-        uses: actions/setup-java@v2
+      - name: SetUp JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: "17"
-          distribution: 'adopt'
+          java-version: "21"
+          distribution: 'temurin'
 
       - name: Gradle Caching
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/DuDoong-Api/Dockerfile
+++ b/DuDoong-Api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 EXPOSE 8080
 

--- a/DuDoong-Batch/Dockerfile
+++ b/DuDoong-Batch/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 EXPOSE 8080
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,8 +33,9 @@ subprojects {
     apply(plugin = "org.jetbrains.kotlin.kapt")
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        }
     }
 
     // JPA 엔티티 클래스를 open으로 만들어 Hibernate 프록시 및 Mockito 서브클래스 목킹 지원
@@ -54,9 +55,9 @@ subprojects {
     }
 
     tasks.withType<KotlinCompile> {
-        kotlinOptions {
-            freeCompilerArgs += "-Xjsr305=strict"
-            jvmTarget = "17"
+        compilerOptions {
+            freeCompilerArgs.add("-Xjsr305=strict")
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
         }
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}
+
 rootProject.name = "DuDoong"
 include("DuDoong-Domain")
 include("DuDoong-Infrastructure")


### PR DESCRIPTION
## Summary

- **Gradle 7.4 → 8.5** (foojay toolchain auto-download 플러그인 추가)
- **Java 17 → 21** (toolchain 방식으로 KAPT 호환성 확보)
- **Kotlin jvmTarget 17 → 21** (`compilerOptions` API 사용)
- **Dockerfile**: `openjdk:17-alpine` → `eclipse-temurin:21-jre-alpine` (Api, Batch)
- **GitHub Actions**: checkout/setup-java v2~v3 → v4, `set-output` → `$GITHUB_OUTPUT`, distribution `temurin`

## 검증

- [x] `./gradlew :DuDoong-Api:build -x test` — BUILD SUCCESSFUL
- [x] `./gradlew :DuDoong-Batch:build -x test` — BUILD SUCCESSFUL
- Warning만 존재 (deprecated annotation, parameter naming — 기존과 동일)

## 관련 이슈

close #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)