### PR TITLE
feat: CORS에 internal-admin 도메인 추가

### DIFF
--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/security/CorsConfig.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/security/CorsConfig.kt
@@ -14,6 +14,8 @@ class CorsConfig(
         val allowedOriginPatterns = mutableListOf(
             "https://dudoong.com",
             "https://staging.dudoong.com",
+            "https://internal-admin.dudoong.com",
+            "https://internal-admin.staging.dudoong.com",
             "http://localhost:3000",
             "http://localhost:5173"
         )


### PR DESCRIPTION
## Summary

- `CorsConfig.kt`에 internal-admin 도메인 2개 추가
  - `https://internal-admin.dudoong.com`
  - `https://internal-admin.staging.dudoong.com`
- 새 어드민 대시보드가 cross-origin으로 API 호출하기 위해 필요

## 관련 이슈

close #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)