### PR TITLE
fix: CORS staging 서브도메인 1단계로 변경

### DIFF
--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/security/CorsConfig.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/security/CorsConfig.kt
@@ -15,7 +15,7 @@ class CorsConfig(
             "https://dudoong.com",
             "https://staging.dudoong.com",
             "https://internal-admin.dudoong.com",
-            "https://internal-admin.staging.dudoong.com",
+            "https://staging-internal-admin.dudoong.com",
             "http://localhost:3000",
             "http://localhost:5173"
         )


### PR DESCRIPTION
## Summary

- CORS 허용 목록: `internal-admin.staging.dudoong.com` → `staging-internal-admin.dudoong.com`
- ACM 와일드카드(`*.dudoong.com`) 인증서 호환을 위한 변경

머지 후 Api-v2.0.1 태그 릴리스 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)