### PR TITLE
fix: SecurityFilterChain 중복 등록 오류 수정 (Java 21)

### DIFF
--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/ServletFilterConfig.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/ServletFilterConfig.kt
@@ -19,7 +19,7 @@ class ServletFilterConfig(
 ) : WebMvcConfigurer {
 
     @Bean
-    fun securityFilterChain(
+    fun securityFilterRegistration(
         @Qualifier(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME)
         securityFilter: Filter,
     ): FilterRegistrationBean<Filter> {


### PR DESCRIPTION
## Summary

- `ServletFilterConfig`의 `securityFilterChain` → `securityFilterRegistration`으로 메서드명 변경
- Java 21 + Tomcat에서 `springSecurityFilterChain` 이름 충돌로 기동 실패하던 문제 해결

## 원인

`securityFilterChain`이라는 Bean 이름이 Spring Security 내부의 `SecurityFilterChain` Bean과 충돌. Java 17에서는 우연히 동작했으나 Java 21에서는 Tomcat이 중복 필터 등록을 거부.

## 검증

- [x] `./gradlew :DuDoong-Api:build -x test` — BUILD SUCCESSFUL
- [x] `./gradlew :DuDoong-Api:test` — BUILD SUCCESSFUL (전체 테스트 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)