### PR TITLE
fix: QueryDSL 집계 쿼리 null NPE 수정

### DIFF
--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/statistic/query/IssuedTicketQueryRepository.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/statistic/query/IssuedTicketQueryRepository.kt
@@ -28,6 +28,7 @@ class IssuedTicketQueryRepository(
             )
             .from(issuedTicket)
             .fetchFirst()
+            ?: IssuedTicketStatistic(0L, 0L)
 
     private fun enteredCountEx(eventId: Long): Expression<Long> =
         ExpressionUtils.`as`(

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/statistic/query/OrderQueryRepository.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/statistic/query/OrderQueryRepository.kt
@@ -31,6 +31,7 @@ class OrderQueryRepository(
             )
             .from(order)
             .fetchFirst()
+            ?: OrderStatistic(0L, 0L, BigDecimal.ZERO)
 
     private fun doneCountEx(eventId: Long): Expression<Long> =
         ExpressionUtils.`as`(

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/statistic/query/result/OrderStatistic.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/statistic/query/result/OrderStatistic.kt
@@ -3,8 +3,8 @@ package band.gosrock.api.statistic.query.result
 import band.gosrock.domain.common.vo.Money
 import java.math.BigDecimal
 
-class OrderStatistic(doneCount: Long, notApprovedCount: Long, sellAmount: BigDecimal) {
+class OrderStatistic(doneCount: Long, notApprovedCount: Long, sellAmount: BigDecimal?) {
     val DoneCount: Long = doneCount
     val notApprovedCount: Long = notApprovedCount
-    val sellAmount: Money = Money.wons(sellAmount.toLong())
+    val sellAmount: Money = Money.wons((sellAmount ?: BigDecimal.ZERO).toLong())
 }

--- a/DuDoong-Api/src/test/kotlin/band/gosrock/api/statistic/query/result/IssuedTicketStatisticTest.kt
+++ b/DuDoong-Api/src/test/kotlin/band/gosrock/api/statistic/query/result/IssuedTicketStatisticTest.kt
@@ -1,0 +1,34 @@
+package band.gosrock.api.statistic.query.result
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class IssuedTicketStatisticTest {
+
+    @Test
+    fun `발급 0건 입장 0건이면 미입장도 0건이다`() {
+        val statistic = IssuedTicketStatistic(0L, 0L)
+
+        assertEquals(0L, statistic.issuedCount)
+        assertEquals(0L, statistic.enteredCount)
+        assertEquals(0L, statistic.notEnteredCount)
+    }
+
+    @Test
+    fun `발급 10건 입장 3건이면 미입장 7건이다`() {
+        val statistic = IssuedTicketStatistic(10L, 3L)
+
+        assertEquals(10L, statistic.issuedCount)
+        assertEquals(3L, statistic.enteredCount)
+        assertEquals(7L, statistic.notEnteredCount)
+    }
+
+    @Test
+    fun `전원 입장하면 미입장 0건이다`() {
+        val statistic = IssuedTicketStatistic(5L, 5L)
+
+        assertEquals(5L, statistic.issuedCount)
+        assertEquals(5L, statistic.enteredCount)
+        assertEquals(0L, statistic.notEnteredCount)
+    }
+}

--- a/DuDoong-Api/src/test/kotlin/band/gosrock/api/statistic/query/result/OrderStatisticTest.kt
+++ b/DuDoong-Api/src/test/kotlin/band/gosrock/api/statistic/query/result/OrderStatisticTest.kt
@@ -1,0 +1,35 @@
+package band.gosrock.api.statistic.query.result
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class OrderStatisticTest {
+
+    @Test
+    fun `sellAmount가 null이면 0원으로 처리된다`() {
+        val statistic = OrderStatistic(0L, 0L, null)
+
+        assertEquals(0L, statistic.DoneCount)
+        assertEquals(0L, statistic.notApprovedCount)
+        assertEquals(0, statistic.sellAmount.amount.compareTo(BigDecimal.ZERO))
+    }
+
+    @Test
+    fun `sellAmount가 정상값이면 Money로 변환된다`() {
+        val statistic = OrderStatistic(5L, 2L, BigDecimal.valueOf(50000))
+
+        assertEquals(5L, statistic.DoneCount)
+        assertEquals(2L, statistic.notApprovedCount)
+        assertEquals(50000L, statistic.sellAmount.longValue())
+    }
+
+    @Test
+    fun `모든 값이 0이면 정상 생성된다`() {
+        val statistic = OrderStatistic(0L, 0L, BigDecimal.ZERO)
+
+        assertEquals(0L, statistic.DoneCount)
+        assertEquals(0L, statistic.notApprovedCount)
+        assertEquals(0L, statistic.sellAmount.longValue())
+    }
+}

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/issuedTicket/repository/IssuedTicketCustomRepositoryImpl.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/issuedTicket/repository/IssuedTicketCustomRepositoryImpl.kt
@@ -47,7 +47,7 @@ class IssuedTicketCustomRepositoryImpl(
                 issuedTicketStatusNotCanceled()
             )
 
-        return PageableExecutionUtils.getPage(issuedTickets, pageable) { countQuery.fetchOne()!! }
+        return PageableExecutionUtils.getPage(issuedTickets, pageable) { countQuery.fetchOne() ?: 0L }
     }
 
     override fun find(issuedTicketId: Long): Optional<IssuedTicket> {

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/repository/OrderCustomRepositoryImpl.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/repository/OrderCustomRepositoryImpl.kt
@@ -86,7 +86,7 @@ class OrderCustomRepositoryImpl(
                 condition.getSearchStringFilter()
             )
 
-        return PageableExecutionUtils.getPage(orders, pageable) { countQuery.fetchOne()!! }
+        return PageableExecutionUtils.getPage(orders, pageable) { countQuery.fetchOne() ?: 0L }
     }
 
     override fun findRecentOrder(userId: Long): Optional<Order> {


### PR DESCRIPTION
## Summary

주문 0건 이벤트에서 통계 조회 시 NPE 크래시 수정 (staging에서 발견)

### 수정 내용 (4곳)
- `OrderStatistic.sellAmount`: `BigDecimal` → `BigDecimal?` (SUM null 대응)
- `OrderQueryRepository.fetchFirst()`: `?: OrderStatistic(0L, 0L, BigDecimal.ZERO)` fallback
- `IssuedTicketQueryRepository.fetchFirst()`: `?: IssuedTicketStatistic(0L, 0L)` fallback
- `fetchOne()!!` → `?: 0L` (OrderCustomRepositoryImpl, IssuedTicketCustomRepositoryImpl)

### 테스트
- [x] `OrderStatisticTest` — null/정상값/0값 3개 케이스
- [x] `IssuedTicketStatisticTest` — 0건/정상/전원입장 3개 케이스
- [x] 전체 테스트 통과
- [x] prod 프로필 기동 확인

## 관련 이슈

close #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)