### PR TITLE
refactor: Java 패턴 잔재 제거 — Builder, 보조 생성자 → Kotlin 관용구

### DIFF
--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/model/dto/KakaoUserInfoDto.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/model/dto/KakaoUserInfoDto.kt
@@ -12,15 +12,15 @@ data class KakaoUserInfoDto(
     val name: String?,
     val oauthProvider: OauthProvider
 ) {
-    fun toProfile(): Profile = Profile.builder()
-        .profileImage(profileImage)
-        .phoneNumber(phoneNumber)
-        .name(name ?: "")
-        .email(email ?: "")
-        .build()
+    fun toProfile(): Profile = Profile(
+        profileImage = profileImage,
+        phoneNumber = phoneNumber,
+        name = name ?: "",
+        email = email ?: "",
+    )
 
-    fun toOauthInfo(): OauthInfo = OauthInfo.builder()
-        .oid(oauthId)
-        .provider(oauthProvider)
-        .build()
+    fun toOauthInfo(): OauthInfo = OauthInfo(
+        oid = oauthId,
+        provider = oauthProvider,
+    )
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/model/dto/request/RegisterRequest.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/model/dto/request/RegisterRequest.kt
@@ -12,10 +12,10 @@ data class RegisterRequest(
     val name: String? = null,
     val marketingAgree: Boolean = false
 ) {
-    fun toProfile(): Profile = Profile.builder()
-        .profileImage(profileImage)
-        .phoneNumber(phoneNumber)
-        .name(name ?: "")
-        .email(email ?: "")
-        .build()
+    fun toProfile(): Profile = Profile(
+        profileImage = profileImage,
+        phoneNumber = phoneNumber,
+        name = name ?: "",
+        email = email ?: "",
+    )
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/LocalDevLoginUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/LocalDevLoginUseCase.kt
@@ -14,10 +14,10 @@ class LocalDevLoginUseCase(
     private val tokenGenerateHelper: TokenGenerateHelper
 ) {
     fun execute(registerRequest: RegisterRequest): TokenAndUserResponse {
-        val oauthInfo = OauthInfo.builder()
-            .provider(OauthProvider.KAKAO)
-            .oid(registerRequest.email ?: "anonymous")
-            .build()
+        val oauthInfo = OauthInfo(
+            provider = OauthProvider.KAKAO,
+            oid = registerRequest.email ?: "anonymous",
+        )
 
         val profile = registerRequest.toProfile()
         val user = userDomainService.upsertUser(profile, oauthInfo)

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/helper/KakaoOauthHelper.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/helper/KakaoOauthHelper.kt
@@ -76,10 +76,10 @@ class KakaoOauthHelper(
 
     fun getOauthInfoByIdToken(idToken: String): OauthInfo {
         val oidcDecodePayload = getOIDCDecodePayload(idToken)
-        return OauthInfo.builder()
-            .provider(OauthProvider.KAKAO)
-            .oid(oidcDecodePayload.sub)
-            .build()
+        return OauthInfo(
+            provider = OauthProvider.KAKAO,
+            oid = oidcDecodePayload.sub,
+        )
     }
 
     fun unlink(oid: String) {

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/helper/TokenGenerateHelper.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/helper/TokenGenerateHelper.kt
@@ -32,11 +32,11 @@ class TokenGenerateHelper(
         }
         val newRefreshToken = jwtTokenProvider.generateRefreshToken(userId)
 
-        val newRefreshTokenEntity = RefreshTokenEntity.builder()
-            .refreshToken(newRefreshToken)
-            .id(userId)
-            .ttl(jwtTokenProvider.getRefreshTokenTTlSecond())
-            .build()
+        val newRefreshTokenEntity = RefreshTokenEntity(
+            refreshToken = newRefreshToken,
+            id = userId,
+            ttl = jwtTokenProvider.getRefreshTokenTTlSecond(),
+        )
         refreshTokenAdaptor.save(newRefreshTokenEntity)
 
         return TokenAndUserResponse(

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/cart/model/mapper/CartMapper.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/cart/model/mapper/CartMapper.kt
@@ -79,11 +79,11 @@ class CartMapper(
         val addCartLineDtos = addCartRequest.items
         val itemName = getItemName(addCartLineDtos)
         val cartLineItems = addCartLineDtos.map { addCartLineDto ->
-            CartLineItem.builder()
-                .item(getTicketItem(addCartLineDto))
-                .cartOptionAnswers(getCartOptionAnswers(addCartLineDto))
-                .quantity(addCartLineDto.quantity)
-                .build()
+            CartLineItem.of(
+                item = getTicketItem(addCartLineDto),
+                quantity = addCartLineDto.quantity,
+                cartOptionAnswers = getCartOptionAnswers(addCartLineDto),
+            )
         }
         return Cart.of(cartLineItems, itemName, currentUserId, cartValidator)
     }
@@ -106,9 +106,9 @@ class CartMapper(
     }
 
     private fun getCartOptionAnswer(addCartOptionAnswerDto: AddCartOptionAnswerDto): CartOptionAnswer {
-        return CartOptionAnswer.builder()
-            .option(optionAdaptor.queryOption(addCartOptionAnswerDto.optionId))
-            .answer(addCartOptionAnswerDto.answer)
-            .build()
+        return CartOptionAnswer.of(
+            option = optionAdaptor.queryOption(addCartOptionAnswerDto.optionId),
+            answer = addCartOptionAnswerDto.answer ?: "",
+        )
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/coupon/mapper/CouponCampaignMapper.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/coupon/mapper/CouponCampaignMapper.kt
@@ -15,17 +15,17 @@ class CouponCampaignMapper {
         val couponStockInfo = toCouponStockInfo(createCouponCampaignRequest.issuedAmount)
         val dateTimePeriod = toDateTimePeriod(createCouponCampaignRequest.startAt, createCouponCampaignRequest.endAt)
 
-        return CouponCampaign.builder()
-            .userId(userId)
-            .discountType(createCouponCampaignRequest.discountType)
-            .applyTarget(createCouponCampaignRequest.applyTarget)
-            .validTerm(createCouponCampaignRequest.validTerm)
-            .dateTimePeriod(dateTimePeriod)
-            .couponStockInfo(couponStockInfo)
-            .discountAmount(createCouponCampaignRequest.discountAmount)
-            .couponCode(createCouponCampaignRequest.couponCode)
-            .minimumCost(createCouponCampaignRequest.minimumCost)
-            .build()
+        return CouponCampaign(
+            userId = userId,
+            discountType = createCouponCampaignRequest.discountType,
+            applyTarget = createCouponCampaignRequest.applyTarget,
+            validTerm = createCouponCampaignRequest.validTerm,
+            dateTimePeriod = dateTimePeriod,
+            couponStockInfo = couponStockInfo,
+            discountAmount = createCouponCampaignRequest.discountAmount,
+            couponCode = createCouponCampaignRequest.couponCode,
+            minimumCost = createCouponCampaignRequest.minimumCost,
+        )
     }
 
     companion object {
@@ -39,10 +39,10 @@ class CouponCampaignMapper {
         }
 
         fun toCouponStockInfo(issuedAmount: Long): CouponStockInfo {
-            return CouponStockInfo.builder()
-                .issuedAmount(issuedAmount)
-                .remainingAmount(issuedAmount)
-                .build()
+            return CouponStockInfo(
+                issuedAmount = issuedAmount,
+                remainingAmount = issuedAmount,
+            )
         }
 
         fun toDateTimePeriod(startAt: LocalDateTime, endAt: LocalDateTime): DateTimePeriod {

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/coupon/mapper/IssuedCouponMapper.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/coupon/mapper/IssuedCouponMapper.kt
@@ -13,7 +13,7 @@ class IssuedCouponMapper(
     private val issuedCouponAdaptor: IssuedCouponAdaptor,
 ) {
     fun toEntity(couponCampaign: CouponCampaign, userId: Long): IssuedCoupon {
-        return IssuedCoupon.builder().couponCampaign(couponCampaign).userId(userId).build()
+        return IssuedCoupon(couponCampaign = couponCampaign, userId = userId)
     }
 
     fun toCreateUserCouponResponse(issuedCoupon: IssuedCoupon, couponCampaign: CouponCampaign): CreateUserCouponResponse {

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/model/mapper/EventMapper.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/model/mapper/EventMapper.kt
@@ -29,36 +29,36 @@ class EventMapper(
 ) {
 
     fun toEntity(createEventRequest: CreateEventRequest): Event {
-        return Event.builder()
-            .hostId(createEventRequest.hostId)
-            .name(createEventRequest.name)
-            .startAt(createEventRequest.startAt)
-            .runTime(createEventRequest.runTime)
-            .build()
+        return Event(
+            hostId = createEventRequest.hostId,
+            name = createEventRequest.name,
+            startAt = createEventRequest.startAt,
+            runTime = createEventRequest.runTime,
+        )
     }
 
     fun toEventBasic(updateEventBasicRequest: UpdateEventBasicRequest): EventBasic {
-        return EventBasic.builder()
-            .name(updateEventBasicRequest.name)
-            .runTime(updateEventBasicRequest.runTime)
-            .startAt(updateEventBasicRequest.startAt)
-            .build()
+        return EventBasic(
+            name = updateEventBasicRequest.name,
+            runTime = updateEventBasicRequest.runTime,
+            startAt = updateEventBasicRequest.startAt,
+        )
     }
 
     fun toEventDetail(updateEventDetailRequest: UpdateEventDetailRequest): EventDetail {
-        return EventDetail.builder()
-            .posterImageKey(updateEventDetailRequest.posterImageKey)
-            .content(updateEventDetailRequest.content)
-            .build()
+        return EventDetail(
+            posterImageKey = updateEventDetailRequest.posterImageKey,
+            content = updateEventDetailRequest.content,
+        )
     }
 
     fun toEventPlace(updateEventBasicRequest: UpdateEventBasicRequest): EventPlace {
-        return EventPlace.builder()
-            .placeName(updateEventBasicRequest.placeName)
-            .placeAddress(updateEventBasicRequest.placeAddress)
-            .latitude(updateEventBasicRequest.latitude)
-            .longitude(updateEventBasicRequest.longitude)
-            .build()
+        return EventPlace(
+            placeName = updateEventBasicRequest.placeName,
+            placeAddress = updateEventBasicRequest.placeAddress,
+            latitude = updateEventBasicRequest.latitude,
+            longitude = updateEventBasicRequest.longitude,
+        )
     }
 
     fun toEventDetailResponse(host: Host, event: Event): EventDetailResponse {

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/model/mapper/HostMapper.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/model/mapper/HostMapper.kt
@@ -22,39 +22,39 @@ class HostMapper(
     private val userAdaptor: UserAdaptor,
 ) {
     fun toEntity(createHostRequest: CreateHostRequest, masterUserId: Long): Host {
-        return Host.builder()
-            .name(createHostRequest.name)
-            .contactEmail(createHostRequest.contactEmail)
-            .contactNumber(createHostRequest.contactNumber)
-            .masterUserId(masterUserId)
-            .build()
+        return Host(
+            name = createHostRequest.name,
+            contactEmail = createHostRequest.contactEmail,
+            contactNumber = createHostRequest.contactNumber,
+            masterUserId = masterUserId,
+        )
     }
 
     fun toHostProfile(updateHostRequest: UpdateHostRequest): HostProfile {
-        return HostProfile.builder()
-            .introduce(updateHostRequest.introduce)
-            .profileImageKey(updateHostRequest.profileImageKey)
-            .contactEmail(updateHostRequest.contactEmail)
-            .contactNumber(updateHostRequest.contactNumber)
-            .build()
+        return HostProfile(
+            introduce = updateHostRequest.introduce,
+            profileImageKey = updateHostRequest.profileImageKey,
+            contactEmail = updateHostRequest.contactEmail,
+            contactNumber = updateHostRequest.contactNumber,
+        )
     }
 
     /** 호스트 역할을 지정하여 주입하는 생성자 */
     fun toHostUser(hostId: Long, userId: Long, role: HostRole): HostUser {
         val host = hostAdaptor.findById(hostId)
-        return HostUser.builder().userId(userId).host(host).role(role).build()
+        return HostUser(host = host, userId = userId, role = role)
     }
 
     /** 매니저로 주입하는 생성자 */
     fun toManagerHostUser(hostId: Long, userId: Long): HostUser {
         val host = hostAdaptor.findById(hostId)
-        return HostUser.builder().userId(userId).host(host).role(HostRole.MANAGER).build()
+        return HostUser(host = host, userId = userId, role = HostRole.MANAGER)
     }
 
     /** 마스터 주입하는 생성자 */
     fun toMasterHostUser(hostId: Long, userId: Long): HostUser {
         val host = hostAdaptor.findById(hostId)
-        return HostUser.builder().userId(userId).host(host).role(HostRole.MASTER).build()
+        return HostUser(host = host, userId = userId, role = HostRole.MASTER)
     }
 
     fun toHostInviteUserList(hostId: Long, email: String) =

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/ConfirmOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/ConfirmOrderUseCase.kt
@@ -13,11 +13,11 @@ class ConfirmOrderUseCase(
     private val orderMapper: OrderMapper,
 ) {
     fun execute(userId: Long, orderUuid: String, confirmOrderRequest: ConfirmOrderRequest): OrderResponse {
-        val confirmPaymentsRequest = ConfirmPaymentsRequest.builder()
-            .paymentKey(confirmOrderRequest.paymentKey)
-            .amount(confirmOrderRequest.amount)
-            .orderId(orderUuid)
-            .build()
+        val confirmPaymentsRequest = ConfirmPaymentsRequest(
+            paymentKey = confirmOrderRequest.paymentKey,
+            amount = confirmOrderRequest.amount,
+            orderId = orderUuid,
+        )
         val confirmOrderUuid = orderConfirmService.execute(confirmPaymentsRequest, userId)
         return orderMapper.toOrderResponse(confirmOrderUuid)
     }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/CreateTossOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/CreateTossOrderUseCase.kt
@@ -15,14 +15,14 @@ class CreateTossOrderUseCase(
 ) {
     fun execute(orderUuid: String): PaymentsResponse {
         val order = orderAdaptor.findByOrderUuid(orderUuid)
-        val createPaymentsRequest = CreatePaymentsRequest.builder()
-            .method("카드")
-            .orderName(order.orderName)
-            .orderId(orderUuid)
-            .failUrl("http://localhost:8080/failurl")
-            .successUrl("http://localhost:8080/successUrl")
-            .amount(order.getTotalPaymentPrice().longValue())
-            .build()
+        val createPaymentsRequest = CreatePaymentsRequest(
+            method = "카드",
+            orderName = order.orderName,
+            orderId = orderUuid,
+            failUrl = "http://localhost:8080/failurl",
+            successUrl = "http://localhost:8080/successUrl",
+            amount = order.getTotalPaymentPrice().longValue(),
+        )
         return paymentsCreateClient.execute(createPaymentsRequest)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/ticketItem/mapper/TicketItemMapper.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/ticketItem/mapper/TicketItemMapper.kt
@@ -20,22 +20,22 @@ class TicketItemMapper(
 ) {
 
     fun toTicketItem(createTicketItemRequest: CreateTicketItemRequest, eventId: Long): TicketItem =
-        TicketItem.builder()
-            .payType(createTicketItemRequest.payType)
-            .name(createTicketItemRequest.name)
-            .description(createTicketItemRequest.description)
-            .price(Money.wons(createTicketItemRequest.price!!))
-            .quantity(createTicketItemRequest.supplyCount)
-            .supplyCount(createTicketItemRequest.supplyCount)
-            .purchaseLimit(createTicketItemRequest.purchaseLimit)
-            .type(createTicketItemRequest.approveType)
-            .bankName(createTicketItemRequest.bankName)
-            .accountNumber(createTicketItemRequest.accountNumber)
-            .accountHolder(createTicketItemRequest.accountHolder)
-            .isQuantityPublic(createTicketItemRequest.isQuantityPublic)
-            .isSellable(true)
-            .eventId(eventId)
-            .build()
+        TicketItem(
+            payType = createTicketItemRequest.payType,
+            name = createTicketItemRequest.name,
+            description = createTicketItemRequest.description,
+            price = Money.wons(createTicketItemRequest.price!!),
+            quantity = createTicketItemRequest.supplyCount,
+            supplyCount = createTicketItemRequest.supplyCount,
+            purchaseLimit = createTicketItemRequest.purchaseLimit,
+            type = createTicketItemRequest.approveType,
+            bankName = createTicketItemRequest.bankName,
+            accountNumber = createTicketItemRequest.accountNumber,
+            accountHolder = createTicketItemRequest.accountHolder,
+            isQuantityPublic = createTicketItemRequest.isQuantityPublic,
+            isSellable = true,
+            eventId = eventId,
+        )
 
     @Transactional(readOnly = true)
     fun toGetEventTicketItemsResponse(eventId: Long, isAdmin: Boolean): GetEventTicketItemsResponse {

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/ticketItem/mapper/TicketOptionMapper.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/ticketItem/mapper/TicketOptionMapper.kt
@@ -19,14 +19,14 @@ class TicketOptionMapper(
 ) {
 
     fun toOptionGroup(createTicketOptionRequest: CreateTicketOptionRequest, eventId: Long): OptionGroup =
-        OptionGroup.builder()
-            .eventId(eventId)
-            .type(createTicketOptionRequest.type)
-            .name(createTicketOptionRequest.name)
-            .description(createTicketOptionRequest.description)
-            .isEssential(true)
-            .options(emptyList())
-            .build()
+        OptionGroup(
+            eventId = eventId,
+            type = createTicketOptionRequest.type,
+            name = createTicketOptionRequest.name,
+            description = createTicketOptionRequest.description,
+            isEssential = true,
+            initialOptions = emptyList(),
+        )
 
     @Transactional(readOnly = true)
     fun toGetTicketItemOptionResponse(eventId: Long, ticketItemId: Long): GetTicketItemOptionsResponse {

--- a/DuDoong-Api/src/test/java/band/gosrock/api/email/RegisterUserEventHandlerTest.java
+++ b/DuDoong-Api/src/test/java/band/gosrock/api/email/RegisterUserEventHandlerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.times;
 import band.gosrock.api.email.handler.RegisterUserEventEmailHandler;
 import band.gosrock.api.supports.ApiIntegrateSpringBootTest;
 import band.gosrock.domain.domains.user.domain.OauthInfo;
+import band.gosrock.domain.domains.user.domain.OauthProvider;
 import band.gosrock.domain.domains.user.domain.Profile;
 import band.gosrock.domain.domains.user.service.UserDomainService;
 import org.junit.jupiter.api.Test;
@@ -22,19 +23,8 @@ class RegisterUserEventHandlerTest {
     @Test
     void 유저등록시도메인이벤트가발생해야한다() {
         // given
-        Profile profile = Profile.builder().name("test").email("test@test.com").build();
-        OauthInfo oauthInfo = OauthInfo.builder().provider(band.gosrock.domain.domains.user.domain.OauthProvider.KAKAO).oid("test-oid").build();
-        //        BDDMockito.given(userRepository.save(any())).willReturn(null);
-        //        given(registerUserEventHandler.handleRegisterUserEvent(any())).will(new Answer() {
-        //            @Override
-        //            public UserRegisterEvent answer(InvocationOnMock invocation) throws Throwable
-        // {
-        //                Object[] args = invocation.getArguments();
-        //                UserRegisterEvent userRegisterEvent = (UserRegisterEvent) args[0];
-        //                System.out.println(userRegisterEvent.getUserId());
-        //                return UserRegisterEvent.builder().build();
-        //            }
-        //        });
+        Profile profile = new Profile("test", "test@test.com", null, null);
+        OauthInfo oauthInfo = new OauthInfo(OauthProvider.KAKAO, "test-oid");
         // when
         userDomainService.registerUser(profile, oauthInfo, Boolean.TRUE);
 

--- a/DuDoong-Batch/src/main/kotlin/band/gosrock/helper/SettlementEmailHelper.kt
+++ b/DuDoong-Batch/src/main/kotlin/band/gosrock/helper/SettlementEmailHelper.kt
@@ -18,27 +18,26 @@ class SettlementEmailHelper(
 ) {
 
     private fun getSettlementPdfAttachment(event: Event): RawEmailAttachmentDto =
-        RawEmailAttachmentDto.builder()
-            .fileName(event.getEventName() + "_정산서.pdf")
-            .fileBytes(s3PrivateFileService.downloadEventSettlementPdf(event.id!!))
-            .type("application/pdf")
-            .build()
+        RawEmailAttachmentDto(
+            fileName = event.getEventName() + "_정산서.pdf",
+            fileBytes = s3PrivateFileService.downloadEventSettlementPdf(event.id!!),
+            type = "application/pdf",
+        )
 
     private fun getOrderListExcelAttachment(event: Event): RawEmailAttachmentDto =
-        RawEmailAttachmentDto.builder()
-            .fileName(event.getEventName() + "_주문목록.xlsx")
-            .fileBytes(s3PrivateFileService.downloadEventOrdersExcel(event.id!!))
-            .type("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-            .build()
+        RawEmailAttachmentDto(
+            fileName = event.getEventName() + "_주문목록.xlsx",
+            fileBytes = s3PrivateFileService.downloadEventOrdersExcel(event.id!!),
+            type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
 
     @Throws(MessagingException::class)
     fun sendToAdmin(event: Event) {
-        val sendRawEmailDto =
-            SendRawEmailDto.builder()
-                .bodyHtml(templateEngine.process("eventSettlement", Context()))
-                .recipient("support@dudoong.com")
-                .subject(event.getEventName() + "공연 정산서 어드민 발송 ( 관리자용 )")
-                .build()
+        val sendRawEmailDto = SendRawEmailDto(
+            bodyHtml = templateEngine.process("eventSettlement", Context()),
+            recipient = "support@dudoong.com",
+            subject = event.getEventName() + "공연 정산서 어드민 발송 ( 관리자용 )",
+        )
 
         sendRawEmailDto.addEmailAttachments(getSettlementPdfAttachment(event))
         sendRawEmailDto.addEmailAttachments(getOrderListExcelAttachment(event))
@@ -47,12 +46,11 @@ class SettlementEmailHelper(
 
     @Throws(MessagingException::class)
     fun sendToHost(event: Event, hostUserEmail: String) {
-        val sendRawEmailDto =
-            SendRawEmailDto.builder()
-                .bodyHtml(templateEngine.process("eventSettlement", Context()))
-                .recipient(hostUserEmail)
-                .subject(event.getEventName() + "공연 정산관련 안내")
-                .build()
+        val sendRawEmailDto = SendRawEmailDto(
+            bodyHtml = templateEngine.process("eventSettlement", Context()),
+            recipient = hostUserEmail,
+            subject = event.getEventName() + "공연 정산관련 안내",
+        )
 
         sendRawEmailDto.addEmailAttachments(getSettlementPdfAttachment(event))
         sendRawEmailDto.addEmailAttachments(getOrderListExcelAttachment(event))

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/dto/ProfileViewDto.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/dto/ProfileViewDto.kt
@@ -3,7 +3,7 @@ package band.gosrock.domain.common.dto
 import band.gosrock.domain.common.vo.ImageVo
 import band.gosrock.domain.domains.user.domain.User
 
-class ProfileViewDto private constructor(
+class ProfileViewDto(
     val id: Long?,
     val profileImage: ImageVo?,
     val name: String?,
@@ -16,23 +16,5 @@ class ProfileViewDto private constructor(
                 name = user.profile?.name,
                 profileImage = user.profile?.profileImage,
             )
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var id: Long? = null
-        private var email: String? = null
-        private var phoneNumber: String? = null
-        private var profileImage: ImageVo? = null
-        private var name: String? = null
-
-        fun id(v: Long?) = apply { id = v }
-        fun email(v: String?) = apply { email = v }
-        fun phoneNumber(v: String?) = apply { phoneNumber = v }
-        fun profileImage(v: ImageVo?) = apply { profileImage = v }
-        fun name(v: String?) = apply { name = v }
-        fun build() = ProfileViewDto(id, profileImage, name)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/events/host/HostRegisterSlackEvent.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/events/host/HostRegisterSlackEvent.kt
@@ -3,7 +3,7 @@ package band.gosrock.domain.common.events.host
 import band.gosrock.domain.common.aop.domainEvent.DomainEvent
 import band.gosrock.domain.domains.host.domain.Host
 
-class HostRegisterSlackEvent private constructor(
+class HostRegisterSlackEvent(
     val hostId: Long?,
     val hostName: String?,
 ) : DomainEvent() {
@@ -14,17 +14,6 @@ class HostRegisterSlackEvent private constructor(
                 hostId = host.id,
                 hostName = host.toHostProfileVo().name,
             )
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var hostId: Long? = null
-        private var hostName: String? = null
-        fun hostId(v: Long?) = apply { hostId = v }
-        fun hostName(v: String?) = apply { hostName = v }
-        fun build() = HostRegisterSlackEvent(hostId, hostName)
     }
 
     override fun toString(): String = "HostRegisterSlackEvent(hostId=$hostId, hostName=$hostName)"

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/events/host/HostUserDisabledEvent.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/events/host/HostUserDisabledEvent.kt
@@ -4,7 +4,7 @@ import band.gosrock.domain.common.aop.domainEvent.DomainEvent
 import band.gosrock.domain.domains.host.domain.Host
 import band.gosrock.domain.domains.host.domain.HostUser
 
-class HostUserDisabledEvent private constructor(
+class HostUserDisabledEvent(
     val hostId: Long?,
     val hostName: String?,
     val userId: Long?,
@@ -17,19 +17,6 @@ class HostUserDisabledEvent private constructor(
                 hostName = host.toHostProfileVo().name,
                 userId = hostUser.userId,
             )
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var hostId: Long? = null
-        private var hostName: String? = null
-        private var userId: Long? = null
-        fun hostId(v: Long?) = apply { hostId = v }
-        fun hostName(v: String?) = apply { hostName = v }
-        fun userId(v: Long?) = apply { userId = v }
-        fun build() = HostUserDisabledEvent(hostId, hostName, userId)
     }
 
     override fun toString(): String = "HostUserDisabledEvent(hostId=$hostId, userId=$userId)"

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/events/host/HostUserInvitationEvent.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/events/host/HostUserInvitationEvent.kt
@@ -6,7 +6,7 @@ import band.gosrock.domain.domains.host.domain.Host
 import band.gosrock.domain.domains.host.domain.HostRole
 import band.gosrock.domain.domains.host.domain.HostUser
 
-class HostUserInvitationEvent private constructor(
+class HostUserInvitationEvent(
     val userId: Long?,
     val role: HostRole?,
     val hostProfileVo: HostProfileVo?,
@@ -19,19 +19,6 @@ class HostUserInvitationEvent private constructor(
                 role = hostUser.role,
                 userId = hostUser.userId,
             )
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var userId: Long? = null
-        private var role: HostRole? = null
-        private var hostProfileVo: HostProfileVo? = null
-        fun userId(v: Long?) = apply { userId = v }
-        fun role(v: HostRole?) = apply { role = v }
-        fun hostProfileVo(v: HostProfileVo?) = apply { hostProfileVo = v }
-        fun build() = HostUserInvitationEvent(userId, role, hostProfileVo)
     }
 
     override fun toString(): String = "HostUserInvitationEvent(userId=$userId, role=$role)"

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/events/host/HostUserJoinEvent.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/events/host/HostUserJoinEvent.kt
@@ -2,7 +2,7 @@ package band.gosrock.domain.common.events.host
 
 import band.gosrock.domain.common.aop.domainEvent.DomainEvent
 
-class HostUserJoinEvent private constructor(
+class HostUserJoinEvent(
     val hostId: Long?,
     val userId: Long?,
 ) : DomainEvent() {
@@ -10,17 +10,6 @@ class HostUserJoinEvent private constructor(
         @JvmStatic
         fun of(hostId: Long?, userId: Long?): HostUserJoinEvent =
             HostUserJoinEvent(hostId, userId)
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var hostId: Long? = null
-        private var userId: Long? = null
-        fun hostId(v: Long?) = apply { hostId = v }
-        fun userId(v: Long?) = apply { userId = v }
-        fun build() = HostUserJoinEvent(hostId, userId)
     }
 
     override fun toString(): String = "HostUserJoinEvent(hostId=$hostId, userId=$userId)"

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/events/host/HostUserRoleChangeEvent.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/events/host/HostUserRoleChangeEvent.kt
@@ -5,7 +5,7 @@ import band.gosrock.domain.domains.host.domain.Host
 import band.gosrock.domain.domains.host.domain.HostRole
 import band.gosrock.domain.domains.host.domain.HostUser
 
-class HostUserRoleChangeEvent private constructor(
+class HostUserRoleChangeEvent(
     val hostId: Long?,
     val hostName: String?,
     val role: HostRole?,
@@ -20,21 +20,6 @@ class HostUserRoleChangeEvent private constructor(
                 role = hostUser.role,
                 userId = hostUser.userId,
             )
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var hostId: Long? = null
-        private var hostName: String? = null
-        private var role: HostRole? = null
-        private var userId: Long? = null
-        fun hostId(v: Long?) = apply { hostId = v }
-        fun hostName(v: String?) = apply { hostName = v }
-        fun role(v: HostRole?) = apply { role = v }
-        fun userId(v: Long?) = apply { userId = v }
-        fun build() = HostUserRoleChangeEvent(hostId, hostName, role, userId)
     }
 
     override fun toString(): String = "HostUserRoleChangeEvent(hostId=$hostId, role=$role, userId=$userId)"

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/events/user/UserRegisterEvent.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/events/user/UserRegisterEvent.kt
@@ -2,17 +2,6 @@ package band.gosrock.domain.common.events.user
 
 import band.gosrock.domain.common.aop.domainEvent.DomainEvent
 
-class UserRegisterEvent private constructor(val userId: Long?) : DomainEvent() {
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var userId: Long? = null
-        fun userId(v: Long?) = apply { userId = v }
-        fun build() = UserRegisterEvent(userId)
-    }
-
+class UserRegisterEvent(val userId: Long?) : DomainEvent() {
     override fun toString(): String = "UserRegisterEvent(userId=$userId)"
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/AccountInfoVo.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/AccountInfoVo.kt
@@ -3,20 +3,11 @@ package band.gosrock.domain.common.vo
 import jakarta.persistence.Embeddable
 
 @Embeddable
-class AccountInfoVo() {
-    var bankName: String? = null
-        protected set
-    var accountNumber: String? = null
-        protected set
-    var accountHolder: String? = null
-        protected set
-
-    constructor(bankName: String?, accountNumber: String?, accountHolder: String?) : this() {
-        this.bankName = bankName
-        this.accountNumber = accountNumber
-        this.accountHolder = accountHolder
-    }
-
+class AccountInfoVo(
+    var bankName: String? = null,
+    var accountNumber: String? = null,
+    var accountHolder: String? = null,
+) {
     companion object {
         @JvmStatic
         fun valueOf(bankName: String?, accountNumber: String?, accountHolder: String?): AccountInfoVo =

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/DateTimePeriod.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/DateTimePeriod.kt
@@ -4,20 +4,12 @@ import java.time.LocalDateTime
 import jakarta.persistence.Embeddable
 
 @Embeddable
-open class DateTimePeriod() {
+open class DateTimePeriod(
     // 쿠폰 발행 시작 시각
-    var startAt: LocalDateTime? = null
-        protected set
-
+    var startAt: LocalDateTime? = null,
     // 쿠폰 발행 마감 시각
-    var endAt: LocalDateTime? = null
-        protected set
-
-    constructor(startAt: LocalDateTime?, endAt: LocalDateTime?) : this() {
-        this.startAt = startAt
-        this.endAt = endAt
-    }
-
+    var endAt: LocalDateTime? = null,
+) {
     fun contains(datetime: LocalDateTime): Boolean {
         val start = startAt ?: return false
         val end = endAt ?: return false

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/HostProfileVo.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/HostProfileVo.kt
@@ -2,7 +2,7 @@ package band.gosrock.domain.common.vo
 
 import band.gosrock.domain.domains.host.domain.Host
 
-class HostProfileVo private constructor(
+class HostProfileVo(
     val hostId: Long?,
     val name: String?,
     val introduce: String?,
@@ -25,21 +25,5 @@ class HostProfileVo private constructor(
                 introduce = host.profile?.introduce,
                 profileImage = host.profile?.profileImage,
             )
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var hostId: Long? = null
-        private var name: String? = null
-        private var introduce: String? = null
-        private var profileImage: ImageVo? = null
-
-        fun hostId(v: Long?) = apply { hostId = v }
-        fun name(v: String?) = apply { name = v }
-        fun introduce(v: String?) = apply { introduce = v }
-        fun profileImage(v: ImageVo?) = apply { profileImage = v }
-        fun build() = HostProfileVo(hostId, name, introduce, profileImage)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/HostUserVo.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/HostUserVo.kt
@@ -5,7 +5,7 @@ import band.gosrock.domain.domains.host.domain.HostUser
 import band.gosrock.domain.domains.user.domain.User
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 
-class HostUserVo private constructor(
+class HostUserVo(
     @JsonUnwrapped val userInfoVo: UserInfoVo,
     val role: HostRole?,
     val active: Boolean?,
@@ -26,19 +26,5 @@ class HostUserVo private constructor(
                 active = hostUser.active,
                 role = hostUser.role,
             )
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var userInfoVo: UserInfoVo? = null
-        private var role: HostRole? = null
-        private var active: Boolean? = null
-
-        fun userInfoVo(v: UserInfoVo?) = apply { userInfoVo = v }
-        fun role(v: HostRole?) = apply { role = v }
-        fun active(v: Boolean?) = apply { active = v }
-        fun build() = HostUserVo(userInfoVo!!, role, active)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/ImageVo.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/ImageVo.kt
@@ -5,14 +5,9 @@ import com.fasterxml.jackson.annotation.JsonValue
 import jakarta.persistence.Embeddable
 
 @Embeddable
-class ImageVo() {
-    var imageKey: String? = null
-        protected set
-
-    constructor(key: String?) : this() {
-        this.imageKey = key
-    }
-
+class ImageVo(
+    var imageKey: String? = null,
+) {
     @JsonValue
     fun generateImageUrl(): String? {
         val key = imageKey ?: return null

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/Money.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/Money.kt
@@ -8,17 +8,12 @@ import jakarta.persistence.Convert
 import jakarta.persistence.Embeddable
 
 @Embeddable
-class Money() {
+class Money(
     // DECIMAL(21,6) 타입에 대한 맵핑 상세 정의
     @Column(name = "amount", nullable = false, precision = 21, scale = 6)
     @Convert(converter = BigDecimalScale6WithBankersRoundingConverter::class)
-    var amount: BigDecimal = BigDecimal.ZERO
-        protected set
-
-    constructor(amount: BigDecimal) : this() {
-        this.amount = amount
-    }
-
+    var amount: BigDecimal = BigDecimal.ZERO,
+) {
     companion object {
         @JvmField
         val ZERO: Money = Money.wons(0)

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/OptionAnswerVo.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/OptionAnswerVo.kt
@@ -8,24 +8,4 @@ data class OptionAnswerVo(
     val questionDescription: String?,
     val answer: String?,
     val additionalPrice: Money?,
-) {
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var optionGroupType: OptionGroupType? = null
-        private var questionName: String? = null
-        private var questionDescription: String? = null
-        private var answer: String? = null
-        private var additionalPrice: Money? = null
-
-        fun optionGroupType(v: OptionGroupType?) = apply { optionGroupType = v }
-        fun questionName(v: String?) = apply { questionName = v }
-        fun questionDescription(v: String?) = apply { questionDescription = v }
-        fun answer(v: String?) = apply { answer = v }
-        fun additionalPrice(v: Money?) = apply { additionalPrice = v }
-        fun build() = OptionAnswerVo(optionGroupType, questionName, questionDescription, answer, additionalPrice)
-    }
-}
+)

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/PhoneNumberVo.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/PhoneNumberVo.kt
@@ -9,15 +9,10 @@ import com.google.i18n.phonenumbers.Phonenumber.PhoneNumber
 import jakarta.persistence.Embeddable
 
 @Embeddable
-class PhoneNumberVo() {
+class PhoneNumberVo(
     // +82 10-xxxx-xxxx format 으로 저장.
-    var phoneNumber: String? = null
-        protected set
-
-    constructor(rawPhoneNumber: String?) : this() {
-        this.phoneNumber = rawPhoneNumber
-    }
-
+    var phoneNumber: String? = null,
+) {
     companion object {
         @JvmStatic
         fun valueOf(rawPhoneNumber: String?): PhoneNumberVo = PhoneNumberVo(rawPhoneNumber)

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/UserInfoVo.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/UserInfoVo.kt
@@ -3,7 +3,7 @@ package band.gosrock.domain.common.vo
 import band.gosrock.domain.domains.user.domain.User
 import java.time.LocalDateTime
 
-class UserInfoVo private constructor(
+class UserInfoVo(
     val userId: Long?,
     val userName: String?,
     val email: String?,
@@ -26,29 +26,5 @@ class UserInfoVo private constructor(
                 receiveMail = user.isReceiveEmail(),
                 marketingAgree = user.isAgreeMarketing(),
             )
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var userId: Long? = null
-        private var userName: String? = null
-        private var email: String? = null
-        private var phoneNumber: PhoneNumberVo? = null
-        private var profileImage: ImageVo? = null
-        private var createdAt: LocalDateTime? = null
-        private var receiveMail: Boolean? = null
-        private var marketingAgree: Boolean? = null
-
-        fun userId(v: Long?) = apply { userId = v }
-        fun userName(v: String?) = apply { userName = v }
-        fun email(v: String?) = apply { email = v }
-        fun phoneNumber(v: PhoneNumberVo?) = apply { phoneNumber = v }
-        fun profileImage(v: ImageVo?) = apply { profileImage = v }
-        fun createdAt(v: LocalDateTime?) = apply { createdAt = v }
-        fun receiveMail(v: Boolean?) = apply { receiveMail = v }
-        fun marketingAgree(v: Boolean?) = apply { marketingAgree = v }
-        fun build() = UserInfoVo(userId, userName, email, phoneNumber, profileImage, createdAt, receiveMail, marketingAgree)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/UserProfileVo.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/common/vo/UserProfileVo.kt
@@ -2,7 +2,7 @@ package band.gosrock.domain.common.vo
 
 import band.gosrock.domain.domains.user.domain.User
 
-class UserProfileVo private constructor(
+class UserProfileVo(
     val userId: Long?,
     val userName: String?,
     val email: String?,
@@ -17,21 +17,5 @@ class UserProfileVo private constructor(
                 email = user.profile?.email,
                 profileImage = user.profile?.profileImage,
             )
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var userId: Long? = null
-        private var userName: String? = null
-        private var email: String? = null
-        private var profileImage: ImageVo? = null
-
-        fun userId(v: Long?) = apply { userId = v }
-        fun userName(v: String?) = apply { userName = v }
-        fun email(v: String?) = apply { email = v }
-        fun profileImage(v: ImageVo?) = apply { profileImage = v }
-        fun build() = UserProfileVo(userId, userName, email, profileImage)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/cart/domain/Cart.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/cart/domain/Cart.kt
@@ -48,18 +48,14 @@ class Cart() : BaseTimeEntity() {
             updateCartName(itemName)
         }
 
+        /** 테스트 전용 팩토리 메서드 */
         @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var userId: Long? = null
-        private var cartLineItems: List<CartLineItem> = emptyList()
-        fun userId(userId: Long) = apply { this.userId = userId }
-        fun cartLineItems(cartLineItems: List<CartLineItem>) = apply { this.cartLineItems = cartLineItems }
-        fun build(): Cart = Cart().apply {
-            this.userId = this@Builder.userId
-            this.cartLineItems.addAll(this@Builder.cartLineItems)
+        fun forTest(
+            userId: Long? = null,
+            cartLineItems: List<CartLineItem> = emptyList(),
+        ): Cart = Cart().apply {
+            this.userId = userId
+            this.cartLineItems.addAll(cartLineItems)
         }
     }
 

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/cart/domain/CartLineItem.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/cart/domain/CartLineItem.kt
@@ -48,19 +48,6 @@ class CartLineItem() : BaseTimeEntity() {
                 this.quantity = quantity
                 this.cartOptionAnswers.addAll(cartOptionAnswers)
             }
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var item: TicketItem? = null
-        private var quantity: Long? = null
-        private var cartOptionAnswers: List<CartOptionAnswer> = emptyList()
-        fun item(item: TicketItem) = apply { this.item = item }
-        fun quantity(quantity: Long) = apply { this.quantity = quantity }
-        fun cartOptionAnswers(cartOptionAnswers: List<CartOptionAnswer>) = apply { this.cartOptionAnswers = cartOptionAnswers }
-        fun build(): CartLineItem = of(item!!, quantity!!, cartOptionAnswers)
     }
 
     fun getTotalOptionsPrice(): Money =

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/cart/domain/CartOptionAnswer.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/cart/domain/CartOptionAnswer.kt
@@ -37,25 +37,14 @@ class CartOptionAnswer() : BaseTimeEntity() {
             this.additionalPrice = option.additionalPrice ?: Money.ZERO
             this.answer = answer
         }
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var option: Option? = null
-        private var answer: String? = null
-        fun option(option: Option) = apply { this.option = option }
-        fun answer(answer: String?) = apply { this.answer = answer }
-        fun build(): CartOptionAnswer = of(option!!, answer ?: "")
     }
 
     fun getOptionAnswerVo(option: Option): OptionAnswerVo =
-        OptionAnswerVo.builder()
-            .questionDescription(option.getQuestionDescription())
-            .optionGroupType(option.getQuestionType())
-            .questionName(option.getQuestionName())
-            .answer(answer)
-            .additionalPrice(option.additionalPrice)
-            .build()
+        OptionAnswerVo(
+            questionDescription = option.getQuestionDescription(),
+            optionGroupType = option.getQuestionType(),
+            questionName = option.getQuestionName(),
+            answer = answer,
+            additionalPrice = option.additionalPrice,
+        )
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/coupon/domain/CouponCampaign.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/coupon/domain/CouponCampaign.kt
@@ -21,7 +21,30 @@ import org.hibernate.annotations.DynamicInsert
 
 @DynamicInsert
 @Entity(name = "tbl_coupon_campaign")
-class CouponCampaign() : BaseTimeEntity() {
+class CouponCampaign(
+    var userId: Long? = null,
+
+    @Enumerated(EnumType.STRING)
+    var discountType: DiscountType? = null,
+
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'ALL'")
+    var applyTarget: ApplyTarget? = null,
+
+    var validTerm: Long? = null,
+
+    @Embedded
+    var dateTimePeriod: DateTimePeriod? = null,
+
+    @Embedded
+    var couponStockInfo: CouponStockInfo? = null,
+
+    var discountAmount: Long? = null,
+
+    var couponCode: String? = null,
+
+    var minimumCost: Long? = 10000L,
+) : BaseTimeEntity() {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,63 +52,9 @@ class CouponCampaign() : BaseTimeEntity() {
     var id: Long? = null
         protected set
 
-    var userId: Long? = null
-        protected set
-
-    @Enumerated(EnumType.STRING)
-    var discountType: DiscountType? = null
-        protected set
-
-    @Enumerated(EnumType.STRING)
-    @ColumnDefault("'ALL'")
-    var applyTarget: ApplyTarget? = null
-        protected set
-
-    var validTerm: Long? = null
-        protected set
-
-    @Embedded
-    var dateTimePeriod: DateTimePeriod? = null
-        protected set
-
-    @Embedded
-    var couponStockInfo: CouponStockInfo? = null
-        protected set
-
-    var discountAmount: Long? = null
-        protected set
-
-    var couponCode: String? = null
-        protected set
-
-    var minimumCost: Long? = 10000L
-        protected set
-
     @OneToMany(mappedBy = "couponCampaign", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
     var issuedCoupons: MutableList<IssuedCoupon> = mutableListOf()
         protected set
-
-    constructor(
-        userId: Long?,
-        discountType: DiscountType?,
-        applyTarget: ApplyTarget?,
-        validTerm: Long?,
-        dateTimePeriod: DateTimePeriod?,
-        couponStockInfo: CouponStockInfo?,
-        discountAmount: Long?,
-        couponCode: String?,
-        minimumCost: Long?,
-    ) : this() {
-        this.userId = userId
-        this.discountType = discountType
-        this.applyTarget = applyTarget
-        this.validTerm = validTerm
-        this.dateTimePeriod = dateTimePeriod
-        this.couponStockInfo = couponStockInfo
-        this.discountAmount = discountAmount
-        this.couponCode = couponCode
-        this.minimumCost = minimumCost
-    }
 
     fun validatePercentageAmount(discountType: DiscountType, discountAmount: Long) {
         if (discountType == DiscountType.PERCENTAGE && discountAmount > 100) {
@@ -102,37 +71,5 @@ class CouponCampaign() : BaseTimeEntity() {
         if (!dateTimePeriod!!.contains(nowTime)) {
             throw NotIssuingCouponPeriodException.EXCEPTION
         }
-    }
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var userId: Long? = null
-        private var discountType: DiscountType? = null
-        private var applyTarget: ApplyTarget? = null
-        private var validTerm: Long? = null
-        private var dateTimePeriod: DateTimePeriod? = null
-        private var couponStockInfo: CouponStockInfo? = null
-        private var discountAmount: Long? = null
-        private var couponCode: String? = null
-        private var minimumCost: Long? = null
-
-        fun userId(userId: Long?) = apply { this.userId = userId }
-        fun discountType(discountType: DiscountType?) = apply { this.discountType = discountType }
-        fun applyTarget(applyTarget: ApplyTarget?) = apply { this.applyTarget = applyTarget }
-        fun validTerm(validTerm: Long?) = apply { this.validTerm = validTerm }
-        fun dateTimePeriod(dateTimePeriod: DateTimePeriod?) = apply { this.dateTimePeriod = dateTimePeriod }
-        fun couponStockInfo(couponStockInfo: CouponStockInfo?) = apply { this.couponStockInfo = couponStockInfo }
-        fun discountAmount(discountAmount: Long?) = apply { this.discountAmount = discountAmount }
-        fun couponCode(couponCode: String?) = apply { this.couponCode = couponCode }
-        fun minimumCost(minimumCost: Long?) = apply { this.minimumCost = minimumCost }
-
-        fun build(): CouponCampaign = CouponCampaign(
-            userId, discountType, applyTarget, validTerm, dateTimePeriod,
-            couponStockInfo, discountAmount, couponCode, minimumCost,
-        )
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/coupon/domain/CouponStockInfo.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/coupon/domain/CouponStockInfo.kt
@@ -4,19 +4,10 @@ import band.gosrock.domain.domains.coupon.exception.NoCouponStockLeftException
 import jakarta.persistence.Embeddable
 
 @Embeddable
-class CouponStockInfo() {
-
-    var issuedAmount: Long? = null
-        protected set
-
-    var remainingAmount: Long? = null
-        protected set
-
-    constructor(issuedAmount: Long?, remainingAmount: Long?) : this() {
-        this.issuedAmount = issuedAmount
-        this.remainingAmount = remainingAmount
-    }
-
+class CouponStockInfo(
+    var issuedAmount: Long? = null,
+    var remainingAmount: Long? = null,
+) {
     fun checkCouponLeft() {
         if (remainingAmount!! < 1) {
             throw NoCouponStockLeftException.EXCEPTION
@@ -26,20 +17,5 @@ class CouponStockInfo() {
     fun decreaseCouponStock() {
         checkCouponLeft()
         this.remainingAmount = remainingAmount!! - 1
-    }
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var issuedAmount: Long? = null
-        private var remainingAmount: Long? = null
-
-        fun issuedAmount(issuedAmount: Long?) = apply { this.issuedAmount = issuedAmount }
-        fun remainingAmount(remainingAmount: Long?) = apply { this.remainingAmount = remainingAmount }
-
-        fun build(): CouponStockInfo = CouponStockInfo(issuedAmount, remainingAmount)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/coupon/domain/IssuedCoupon.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/coupon/domain/IssuedCoupon.kt
@@ -18,15 +18,14 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 
 @Entity(name = "tbl_issued_coupon")
-class IssuedCoupon() : BaseTimeEntity() {
+class IssuedCoupon(
+    var userId: Long? = null,
+) : BaseTimeEntity() {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "issued_coupon_id")
     var id: Long? = null
-        protected set
-
-    var userId: Long? = null
         protected set
 
     var usageStatus: Boolean = false
@@ -37,9 +36,8 @@ class IssuedCoupon() : BaseTimeEntity() {
     var couponCampaign: CouponCampaign? = null
         protected set
 
-    constructor(couponCampaign: CouponCampaign?, userId: Long?) : this() {
+    constructor(couponCampaign: CouponCampaign?, userId: Long?) : this(userId = userId) {
         this.couponCampaign = couponCampaign
-        this.userId = userId
         this.usageStatus = false
     }
 
@@ -91,19 +89,4 @@ class IssuedCoupon() : BaseTimeEntity() {
 
     fun calculateValidTerm(): LocalDateTime =
         createdAtKt().plusDays(this.couponCampaign!!.validTerm!!)
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var couponCampaign: CouponCampaign? = null
-        private var userId: Long? = null
-
-        fun couponCampaign(couponCampaign: CouponCampaign?) = apply { this.couponCampaign = couponCampaign }
-        fun userId(userId: Long?) = apply { this.userId = userId }
-
-        fun build(): IssuedCoupon = IssuedCoupon(couponCampaign, userId)
-    }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/domain/Event.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/domain/Event.kt
@@ -43,7 +43,13 @@ import org.hibernate.annotations.Where
 
 @Where(clause = "status != 'DELETED'")
 @Entity(name = "tbl_event")
-class Event() : BaseTimeEntity() {
+class Event(
+    // 호스트 정보
+    var hostId: Long? = null,
+    name: String? = null,
+    startAt: LocalDateTime? = null,
+    runTime: Long? = null,
+) : BaseTimeEntity() {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -51,12 +57,10 @@ class Event() : BaseTimeEntity() {
     var id: Long? = null
         protected set
 
-    // 호스트 정보
-    var hostId: Long? = null
-        protected set
-
     @Embedded
-    var eventBasic: EventBasic? = null
+    var eventBasic: EventBasic? = if (name != null || startAt != null || runTime != null) {
+        EventBasic(name = name, startAt = startAt, runTime = runTime)
+    } else null
         protected set
 
     @Embedded
@@ -72,10 +76,10 @@ class Event() : BaseTimeEntity() {
     var status: EventStatus = PREPARING
         protected set
 
-    constructor(hostId: Long?, name: String?, startAt: LocalDateTime?, runTime: Long?) : this() {
-        this.hostId = hostId
-        this.eventBasic = EventBasic.builder().name(name).startAt(startAt).runTime(runTime).build()
-        Events.raise(EventCreationEvent.of(hostId, name))
+    init {
+        if (hostId != null && name != null) {
+            Events.raise(EventCreationEvent.of(hostId, name))
+        }
     }
 
     fun getStartAt(): LocalDateTime? = this.eventBasic?.startAt
@@ -223,23 +227,5 @@ class Event() : BaseTimeEntity() {
                 placeAddress = placeAddress ?: currentPlace?.placeAddress,
             )
         }
-    }
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var hostId: Long? = null
-        private var name: String? = null
-        private var startAt: LocalDateTime? = null
-        private var runTime: Long? = null
-
-        fun hostId(hostId: Long?) = apply { this.hostId = hostId }
-        fun name(name: String?) = apply { this.name = name }
-        fun startAt(startAt: LocalDateTime?) = apply { this.startAt = startAt }
-        fun runTime(runTime: Long?) = apply { this.runTime = runTime }
-        fun build() = Event(hostId, name, startAt, runTime)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/domain/EventBasic.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/domain/EventBasic.kt
@@ -5,41 +5,15 @@ import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 
 @Embeddable
-class EventBasic() {
-
+class EventBasic(
     @Column(length = 25)
-    var name: String? = null
-        protected set
+    var name: String? = null,
 
-    var startAt: LocalDateTime? = null
-        protected set
+    var startAt: LocalDateTime? = null,
 
-    var runTime: Long? = null
-        protected set
-
-    constructor(name: String?, startAt: LocalDateTime?, runTime: Long?) : this() {
-        this.name = name
-        this.startAt = startAt
-        this.runTime = runTime
-    }
-
+    var runTime: Long? = null,
+) {
     fun isUpdated(): Boolean = this.name != null && this.startAt != null && this.runTime != null
 
     fun endAt(): LocalDateTime? = if (this.runTime == null) null else this.startAt?.plusMinutes(this.runTime!!)
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var name: String? = null
-        private var startAt: LocalDateTime? = null
-        private var runTime: Long? = null
-
-        fun name(name: String?) = apply { this.name = name }
-        fun startAt(startAt: LocalDateTime?) = apply { this.startAt = startAt }
-        fun runTime(runTime: Long?) = apply { this.runTime = runTime }
-        fun build() = EventBasic(name, startAt, runTime)
-    }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/domain/EventDetail.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/domain/EventDetail.kt
@@ -6,36 +6,16 @@ import jakarta.persistence.Embeddable
 import jakarta.persistence.Embedded
 
 @Embeddable
-class EventDetail() {
-
-    // 포스터 이미지
-    @Embedded
-    var posterImage: ImageVo? = null
-        protected set
+class EventDetail(
+    posterImageKey: String? = null,
 
     // (마크다운) 공연 상세 내용
     @Column(columnDefinition = "TEXT")
-    var content: String? = null
-        protected set
-
-    constructor(posterImageKey: String?, content: String?) : this() {
-        this.posterImage = posterImageKey?.let { ImageVo.valueOf(it) }
-        this.content = content
-    }
+    var content: String? = null,
+) {
+    // 포스터 이미지
+    @Embedded
+    var posterImage: ImageVo? = posterImageKey?.let { ImageVo.valueOf(it) }
 
     fun isUpdated(): Boolean = this.posterImage != null && this.content != null
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var posterImageKey: String? = null
-        private var content: String? = null
-
-        fun posterImageKey(key: String?) = apply { this.posterImageKey = key }
-        fun content(content: String?) = apply { this.content = content }
-        fun build() = EventDetail(posterImageKey, content)
-    }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/domain/EventDetailImage.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/domain/EventDetailImage.kt
@@ -8,38 +8,16 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 
 @Entity(name = "tbl_event_detail_image")
-class EventDetailImage() : BaseTimeEntity() {
+class EventDetailImage(
+    // 이벤트 정보
+    var eventId: Long? = null,
+    // 이미지 주소
+    var imageUrl: String? = null,
+) : BaseTimeEntity() {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "event_detail_image_id")
     var id: Long? = null
         protected set
-
-    // 이벤트 정보
-    var eventId: Long? = null
-        protected set
-
-    // 이미지 주소
-    var imageUrl: String? = null
-        protected set
-
-    constructor(eventId: Long?, imageUrl: String?) : this() {
-        this.eventId = eventId
-        this.imageUrl = imageUrl
-    }
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var eventId: Long? = null
-        private var imageUrl: String? = null
-
-        fun eventId(eventId: Long?) = apply { this.eventId = eventId }
-        fun imageUrl(imageUrl: String?) = apply { this.imageUrl = imageUrl }
-        fun build() = EventDetailImage(eventId, imageUrl)
-    }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/domain/EventPlace.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/domain/EventPlace.kt
@@ -3,54 +3,16 @@ package band.gosrock.domain.domains.event.domain
 import jakarta.persistence.Embeddable
 
 @Embeddable
-class EventPlace() {
-
+class EventPlace(
     // (지도 정보) 위도 - x
-    var latitude: Double? = null
-        protected set
-
+    var latitude: Double? = null,
     // (지도 정보) 경도 - y
-    var longitude: Double? = null
-        protected set
-
+    var longitude: Double? = null,
     // 공연 장소
-    var placeName: String? = null
-        protected set
-
+    var placeName: String? = null,
     // 공연 상세 주소
-    var placeAddress: String? = null
-        protected set
-
-    constructor(
-        latitude: Double?,
-        longitude: Double?,
-        placeName: String?,
-        placeAddress: String?,
-    ) : this() {
-        this.latitude = latitude
-        this.longitude = longitude
-        this.placeName = placeName
-        this.placeAddress = placeAddress
-    }
-
+    var placeAddress: String? = null,
+) {
     fun isUpdated(): Boolean =
         this.latitude != null && this.longitude != null && this.placeName != null && this.placeAddress != null
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var latitude: Double? = null
-        private var longitude: Double? = null
-        private var placeName: String? = null
-        private var placeAddress: String? = null
-
-        fun latitude(latitude: Double?) = apply { this.latitude = latitude }
-        fun longitude(longitude: Double?) = apply { this.longitude = longitude }
-        fun placeName(placeName: String?) = apply { this.placeName = placeName }
-        fun placeAddress(placeAddress: String?) = apply { this.placeAddress = placeAddress }
-        fun build() = EventPlace(latitude, longitude, placeName, placeAddress)
-    }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/example/domain/ExampleEntity.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/example/domain/ExampleEntity.kt
@@ -9,16 +9,11 @@ import jakarta.persistence.Table
 
 @Table(name = "tbl_example")
 @Entity
-class ExampleEntity protected constructor() : BaseTimeEntity() {
+class ExampleEntity(
+    var content: String? = null,
+) : BaseTimeEntity() {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
-
-    var content: String? = null
-        protected set
-
-    constructor(content: String) : this() {
-        this.content = content
-    }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/host/domain/Host.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/host/domain/Host.kt
@@ -28,7 +28,17 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.OrderBy
 
 @Entity(name = "tbl_host")
-class Host() : BaseTimeEntity() {
+class Host(
+    // 마스터 유저 id
+    var masterUserId: Long? = null,
+    // 슬랙 웹훅 url
+    var slackUrl: String? = null,
+    name: String? = null,
+    introduce: String? = null,
+    profileImageKey: String? = null,
+    contactEmail: String? = null,
+    contactNumber: String? = null,
+) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "host_id")
@@ -36,19 +46,17 @@ class Host() : BaseTimeEntity() {
         protected set
 
     @Embedded
-    var profile: HostProfile? = null
-        protected set
-
-    // 마스터 유저 id
-    var masterUserId: Long? = null
+    var profile: HostProfile? = HostProfile(
+        name = name,
+        introduce = introduce,
+        profileImageKey = profileImageKey,
+        contactEmail = contactEmail,
+        contactNumber = contactNumber,
+    )
         protected set
 
     // 파트너 여부
     var partner: Boolean = false
-        protected set
-
-    // 슬랙 웹훅 url
-    var slackUrl: String? = null
         protected set
 
     // 단방향 oneToMany 매핑
@@ -60,26 +68,6 @@ class Host() : BaseTimeEntity() {
     )
     @OrderBy("createdAt DESC")
     val hostUsers: MutableSet<HostUser> = HashSet()
-
-    constructor(
-        name: String?,
-        introduce: String?,
-        profileImageKey: String?,
-        contactEmail: String?,
-        contactNumber: String?,
-        slackUrl: String?,
-        masterUserId: Long?,
-    ) : this() {
-        this.profile = HostProfile.builder()
-            .name(name)
-            .introduce(introduce)
-            .profileImageKey(profileImageKey)
-            .contactEmail(contactEmail)
-            .contactNumber(contactNumber)
-            .build()
-        this.masterUserId = masterUserId
-        this.slackUrl = slackUrl
-    }
 
     fun addHostUsers(hostUserList: Set<HostUser>) {
         hostUserList.forEach { validateHostUserExistence(it) }
@@ -179,28 +167,4 @@ class Host() : BaseTimeEntity() {
 
     fun toHostInfoVo(): HostInfoVo = HostInfoVo.from(this)
     fun toHostProfileVo(): HostProfileVo = HostProfileVo.from(this)
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var name: String? = null
-        private var introduce: String? = null
-        private var profileImageKey: String? = null
-        private var contactEmail: String? = null
-        private var contactNumber: String? = null
-        private var slackUrl: String? = null
-        private var masterUserId: Long? = null
-
-        fun name(name: String?) = apply { this.name = name }
-        fun introduce(introduce: String?) = apply { this.introduce = introduce }
-        fun profileImageKey(key: String?) = apply { this.profileImageKey = key }
-        fun contactEmail(email: String?) = apply { this.contactEmail = email }
-        fun contactNumber(number: String?) = apply { this.contactNumber = number }
-        fun slackUrl(url: String?) = apply { this.slackUrl = url }
-        fun masterUserId(id: Long?) = apply { this.masterUserId = id }
-        fun build() = Host(name, introduce, profileImageKey, contactEmail, contactNumber, slackUrl, masterUserId)
-    }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/host/domain/HostProfile.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/host/domain/HostProfile.kt
@@ -6,43 +6,22 @@ import jakarta.persistence.Embeddable
 import jakarta.persistence.Embedded
 
 @Embeddable
-class HostProfile() {
+class HostProfile(
     // 호스트 이름
     @Column(length = 15)
-    var name: String? = null
-        protected set
-
+    var name: String? = null,
     // 간단 소개
-    var introduce: String? = null
-        protected set
-
-    // 프로필 이미지 url
-    @Embedded
-    var profileImage: ImageVo? = null
-        protected set
-
+    var introduce: String? = null,
+    profileImageKey: String? = null,
     // 대표자 이메일
-    var contactEmail: String? = null
-        protected set
-
+    var contactEmail: String? = null,
     // 대표자 연락처
     @Column(length = 15)
-    var contactNumber: String? = null
-        protected set
-
-    constructor(
-        name: String?,
-        introduce: String?,
-        profileImageKey: String?,
-        contactEmail: String?,
-        contactNumber: String?,
-    ) : this() {
-        this.name = name
-        this.introduce = introduce
-        this.profileImage = ImageVo.valueOf(profileImageKey)
-        this.contactEmail = contactEmail
-        this.contactNumber = contactNumber
-    }
+    var contactNumber: String? = null,
+) {
+    // 프로필 이미지 url
+    @Embedded
+    var profileImage: ImageVo? = ImageVo.valueOf(profileImageKey)
 
     fun updateProfile(hostProfile: HostProfile) {
         this.name = hostProfile.name
@@ -50,25 +29,5 @@ class HostProfile() {
         this.introduce = hostProfile.introduce
         this.contactEmail = hostProfile.contactEmail
         this.contactNumber = hostProfile.contactNumber
-    }
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var name: String? = null
-        private var introduce: String? = null
-        private var profileImageKey: String? = null
-        private var contactEmail: String? = null
-        private var contactNumber: String? = null
-
-        fun name(name: String?) = apply { this.name = name }
-        fun introduce(introduce: String?) = apply { this.introduce = introduce }
-        fun profileImageKey(key: String?) = apply { this.profileImageKey = key }
-        fun contactEmail(email: String?) = apply { this.contactEmail = email }
-        fun contactNumber(number: String?) = apply { this.contactNumber = number }
-        fun build() = HostProfile(name, introduce, profileImageKey, contactEmail, contactNumber)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/host/domain/HostUser.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/host/domain/HostUser.kt
@@ -19,7 +19,15 @@ import jakarta.persistence.UniqueConstraint
 
 @Entity(name = "tbl_host_user")
 @Table(uniqueConstraints = [UniqueConstraint(columnNames = ["host_id", "user_id"])])
-class HostUser() : BaseTimeEntity() {
+class HostUser(
+    // 소속 호스트를 관리중인 유저 아이디
+    @Column(name = "user_id")
+    var userId: Long? = null,
+
+    // 유저의 권한
+    @Enumerated(EnumType.STRING)
+    var role: HostRole = HostRole.GUEST,
+) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "host_user_id")
@@ -32,24 +40,12 @@ class HostUser() : BaseTimeEntity() {
     var host: Host? = null
         protected set
 
-    // 소속 호스트를 관리중인 유저 아이디
-    @Column(name = "user_id")
-    var userId: Long? = null
-        protected set
-
     // 초대 승락 여부
     var active: Boolean = false
         protected set
 
-    // 유저의 권한
-    @Enumerated(EnumType.STRING)
-    var role: HostRole = HostRole.GUEST
-        protected set
-
-    constructor(host: Host, userId: Long?, role: HostRole) : this() {
+    constructor(host: Host, userId: Long?, role: HostRole) : this(userId = userId, role = role) {
         this.host = host
-        this.userId = userId
-        this.role = role
     }
 
     fun setHostRole(role: HostRole) {
@@ -60,21 +56,5 @@ class HostUser() : BaseTimeEntity() {
         if (this.active) throw AlreadyJoinedHostException.EXCEPTION
         this.active = true
         Events.raise(HostUserJoinEvent.of(this.host!!.id, this.userId))
-    }
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var host: Host? = null
-        private var userId: Long? = null
-        private var role: HostRole = HostRole.GUEST
-
-        fun host(host: Host?) = apply { this.host = host }
-        fun userId(userId: Long?) = apply { this.userId = userId }
-        fun role(role: HostRole?) = apply { this.role = role ?: HostRole.GUEST }
-        fun build() = HostUser(host!!, userId, role)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicket.kt
@@ -33,7 +33,23 @@ import jakarta.persistence.PostPersist
 import jakarta.persistence.PrePersist
 
 @Entity(name = "tbl_issued_ticket")
-class IssuedTicket() : BaseTimeEntity() {
+class IssuedTicket(
+    var eventId: Long? = null,
+
+    @Embedded
+    var userInfo: IssuedTicketUserInfoVo? = null,
+
+    var orderUuid: String? = null,
+
+    var orderLineId: Long? = null,
+
+    @Embedded
+    var itemInfo: IssuedTicketItemInfoVo? = null,
+
+    issuedTicketStatus: IssuedTicketStatus? = null,
+
+    initialOptionAnswers: List<IssuedTicketOptionAnswer> = emptyList(),
+) : BaseTimeEntity() {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,24 +60,7 @@ class IssuedTicket() : BaseTimeEntity() {
     var issuedTicketNo: String? = null
         protected set
 
-    var eventId: Long? = null
-        protected set
-
-    @Embedded
-    var userInfo: IssuedTicketUserInfoVo? = null
-        protected set
-
-    @Embedded
-    var itemInfo: IssuedTicketItemInfoVo? = null
-        protected set
-
-    var orderUuid: String? = null
-        protected set
-
     var enteredAt: LocalDateTime? = null
-        protected set
-
-    var orderLineId: Long? = null
         protected set
 
     @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
@@ -74,25 +73,13 @@ class IssuedTicket() : BaseTimeEntity() {
         protected set
 
     @Enumerated(EnumType.STRING)
-    var issuedTicketStatus: IssuedTicketStatus = IssuedTicketStatus.ENTRANCE_INCOMPLETE
+    var issuedTicketStatus: IssuedTicketStatus = issuedTicketStatus ?: IssuedTicketStatus.ENTRANCE_INCOMPLETE
         protected set
 
-    constructor(
-        eventId: Long?,
-        userInfo: IssuedTicketUserInfoVo?,
-        orderUuid: String?,
-        orderLineId: Long?,
-        itemInfo: IssuedTicketItemInfoVo?,
-        issuedTicketStatus: IssuedTicketStatus?,
-        issuedTicketOptionAnswers: List<IssuedTicketOptionAnswer>,
-    ) : this() {
-        this.eventId = eventId
-        this.userInfo = userInfo
-        this.itemInfo = itemInfo
-        this.orderUuid = orderUuid
-        this.orderLineId = orderLineId
-        this.issuedTicketStatus = issuedTicketStatus ?: IssuedTicketStatus.ENTRANCE_INCOMPLETE
-        this.issuedTicketOptionAnswers.addAll(issuedTicketOptionAnswers)
+    init {
+        if (initialOptionAnswers.isNotEmpty()) {
+            this.issuedTicketOptionAnswers.addAll(initialOptionAnswers)
+        }
     }
 
     fun addOptionAnswers(answers: List<IssuedTicketOptionAnswer>) {
@@ -166,15 +153,15 @@ class IssuedTicket() : BaseTimeEntity() {
             orderLineItem: OrderLineItem,
         ): IssuedTicket {
             val orderOptionAnswers = orderLineItem.orderOptionAnswers
-            return builder()
-                .issuedTicketOptionAnswers(orderOptionAnswers.map { IssuedTicketOptionAnswer.from(it) })
-                .itemInfo(IssuedTicketItemInfoVo.from(ticketItem))
-                .orderLineId(orderLineItem.id)
-                .orderUuid(order.uuid)
-                .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
-                .userInfo(IssuedTicketUserInfoVo.from(user))
-                .eventId(eventId)
-                .build()
+            return IssuedTicket(
+                initialOptionAnswers = orderOptionAnswers.map { IssuedTicketOptionAnswer.from(it) },
+                itemInfo = IssuedTicketItemInfoVo.from(ticketItem),
+                orderLineId = orderLineItem.id,
+                orderUuid = order.uuid,
+                issuedTicketStatus = IssuedTicketStatus.ENTRANCE_INCOMPLETE,
+                userInfo = IssuedTicketUserInfoVo.from(user),
+                eventId = eventId,
+            )
         }
 
         @JvmStatic
@@ -188,30 +175,5 @@ class IssuedTicket() : BaseTimeEntity() {
             val quantity = orderLineItem.quantity!!
             return (0 until quantity).map { create(ticketItem, user, order, eventId, orderLineItem) }
         }
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var eventId: Long? = null
-        private var userInfo: IssuedTicketUserInfoVo? = null
-        private var orderUuid: String? = null
-        private var orderLineId: Long? = null
-        private var itemInfo: IssuedTicketItemInfoVo? = null
-        private var issuedTicketStatus: IssuedTicketStatus? = null
-        private var issuedTicketOptionAnswers: List<IssuedTicketOptionAnswer> = emptyList()
-
-        fun eventId(eventId: Long?) = apply { this.eventId = eventId }
-        fun userInfo(userInfo: IssuedTicketUserInfoVo?) = apply { this.userInfo = userInfo }
-        fun orderUuid(orderUuid: String?) = apply { this.orderUuid = orderUuid }
-        fun orderLineId(orderLineId: Long?) = apply { this.orderLineId = orderLineId }
-        fun itemInfo(itemInfo: IssuedTicketItemInfoVo?) = apply { this.itemInfo = itemInfo }
-        fun issuedTicketStatus(issuedTicketStatus: IssuedTicketStatus?) = apply { this.issuedTicketStatus = issuedTicketStatus }
-        fun issuedTicketOptionAnswers(issuedTicketOptionAnswers: List<IssuedTicketOptionAnswer>) = apply { this.issuedTicketOptionAnswers = issuedTicketOptionAnswers }
-
-        fun build(): IssuedTicket = IssuedTicket(
-            eventId, userInfo, orderUuid, orderLineId, itemInfo, issuedTicketStatus, issuedTicketOptionAnswers,
-        )
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketItemInfoVo.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketItemInfoVo.kt
@@ -9,39 +9,19 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 
 @Embeddable
-class IssuedTicketItemInfoVo() {
-
-    var ticketItemId: Long? = null
-        protected set
+class IssuedTicketItemInfoVo(
+    var ticketItemId: Long? = null,
 
     @Enumerated(EnumType.STRING)
-    var ticketType: TicketType? = null
-        protected set
+    var ticketType: TicketType? = null,
 
     @Enumerated(EnumType.STRING)
-    var payType: TicketPayType? = null
-        protected set
+    var payType: TicketPayType? = null,
 
-    var ticketName: String? = null
-        protected set
+    var ticketName: String? = null,
 
-    var price: Money? = null
-        protected set
-
-    constructor(
-        ticketItemId: Long?,
-        ticketType: TicketType?,
-        payType: TicketPayType?,
-        ticketName: String?,
-        price: Money?,
-    ) : this() {
-        this.ticketItemId = ticketItemId
-        this.ticketType = ticketType
-        this.payType = payType
-        this.ticketName = ticketName
-        this.price = price
-    }
-
+    var price: Money? = null,
+) {
     companion object {
         @JvmStatic
         fun from(item: TicketItem): IssuedTicketItemInfoVo = IssuedTicketItemInfoVo(
@@ -51,24 +31,5 @@ class IssuedTicketItemInfoVo() {
             ticketName = item.name,
             price = item.price,
         )
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var ticketItemId: Long? = null
-        private var ticketType: TicketType? = null
-        private var payType: TicketPayType? = null
-        private var ticketName: String? = null
-        private var price: Money? = null
-
-        fun ticketItemId(ticketItemId: Long?) = apply { this.ticketItemId = ticketItemId }
-        fun ticketType(ticketType: TicketType?) = apply { this.ticketType = ticketType }
-        fun payType(payType: TicketPayType?) = apply { this.payType = payType }
-        fun ticketName(ticketName: String?) = apply { this.ticketName = ticketName }
-        fun price(price: Money?) = apply { this.price = price }
-
-        fun build(): IssuedTicketItemInfoVo = IssuedTicketItemInfoVo(ticketItemId, ticketType, payType, ticketName, price)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketOptionAnswer.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketOptionAnswer.kt
@@ -13,28 +13,17 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 
 @Entity(name = "tbl_issued_ticket_option_answer")
-class IssuedTicketOptionAnswer() : BaseTimeEntity() {
+class IssuedTicketOptionAnswer(
+    var optionId: Long? = null,
+    var additionalPrice: Money = Money.ZERO,
+    var answer: String? = null,
+) : BaseTimeEntity() {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "issued_ticket_option_answer_id")
     var id: Long? = null
         protected set
-
-    var optionId: Long? = null
-        protected set
-
-    var additionalPrice: Money = Money.ZERO
-        protected set
-
-    var answer: String? = null
-        protected set
-
-    constructor(optionId: Long?, additionalPrice: Money, answer: String?) : this() {
-        this.optionId = optionId
-        this.additionalPrice = additionalPrice
-        this.answer = answer
-    }
 
     companion object {
         @JvmStatic
@@ -44,32 +33,17 @@ class IssuedTicketOptionAnswer() : BaseTimeEntity() {
                 additionalPrice = orderOptionAnswer.additionalPrice,
                 answer = orderOptionAnswer.answer,
             )
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var optionId: Long? = null
-        private var additionalPrice: Money = Money.ZERO
-        private var answer: String? = null
-
-        fun optionId(optionId: Long?) = apply { this.optionId = optionId }
-        fun additionalPrice(additionalPrice: Money) = apply { this.additionalPrice = additionalPrice }
-        fun answer(answer: String?) = apply { this.answer = answer }
-
-        fun build(): IssuedTicketOptionAnswer = IssuedTicketOptionAnswer(optionId, additionalPrice, answer)
     }
 
     fun toIssuedTicketOptionAnswerVo(): IssuedTicketOptionAnswerVo =
         IssuedTicketOptionAnswerVo.from(this)
 
     fun getOptionAnswerVo(option: Option): OptionAnswerVo =
-        OptionAnswerVo.builder()
-            .questionDescription(option.getQuestionDescription())
-            .optionGroupType(option.getQuestionType())
-            .questionName(option.getQuestionName())
-            .answer(answer)
-            .additionalPrice(option.additionalPrice)
-            .build()
+        OptionAnswerVo(
+            questionDescription = option.getQuestionDescription(),
+            optionGroupType = option.getQuestionType(),
+            questionName = option.getQuestionName(),
+            answer = answer,
+            additionalPrice = option.additionalPrice,
+        )
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketUserInfoVo.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketUserInfoVo.kt
@@ -5,27 +5,12 @@ import band.gosrock.domain.domains.user.domain.User
 import jakarta.persistence.Embeddable
 
 @Embeddable
-class IssuedTicketUserInfoVo() {
-
-    var userId: Long? = null
-        protected set
-
-    var userName: String? = null
-        protected set
-
-    var phoneNumber: PhoneNumberVo? = null
-        protected set
-
-    var email: String? = null
-        protected set
-
-    constructor(userId: Long?, userName: String?, email: String?, phoneNumber: PhoneNumberVo?) : this() {
-        this.userId = userId
-        this.userName = userName
-        this.email = email
-        this.phoneNumber = phoneNumber
-    }
-
+class IssuedTicketUserInfoVo(
+    var userId: Long? = null,
+    var userName: String? = null,
+    var email: String? = null,
+    var phoneNumber: PhoneNumberVo? = null,
+) {
     companion object {
         @JvmStatic
         fun from(user: User): IssuedTicketUserInfoVo = IssuedTicketUserInfoVo(
@@ -34,22 +19,5 @@ class IssuedTicketUserInfoVo() {
             phoneNumber = user.profile?.phoneNumberVo,
             email = user.profile?.email,
         )
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var userId: Long? = null
-        private var userName: String? = null
-        private var email: String? = null
-        private var phoneNumber: PhoneNumberVo? = null
-
-        fun userId(userId: Long?) = apply { this.userId = userId }
-        fun userName(userName: String?) = apply { this.userName = userName }
-        fun email(email: String?) = apply { this.email = email }
-        fun phoneNumber(phoneNumber: PhoneNumberVo?) = apply { this.phoneNumber = phoneNumber }
-
-        fun build(): IssuedTicketUserInfoVo = IssuedTicketUserInfoVo(userId, userName, email, phoneNumber)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/domain/Order.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/domain/Order.kt
@@ -161,30 +161,22 @@ class Order() : BaseTimeEntity() {
         private fun getOrderLineItems(cart: Cart, item: TicketItem): List<OrderLineItem> =
             cart.cartLineItems.map { OrderLineItem.of(it, item) }
 
+        /** 테스트 전용 팩토리 메서드 */
         @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var userId: Long? = null
-        private var orderName: String? = null
-        private var orderLineItems: List<OrderLineItem> = emptyList()
-        private var orderStatus: OrderStatus = OrderStatus.READY
-        private var orderMethod: OrderMethod? = null
-        private var eventId: Long? = null
-        fun userId(userId: Long) = apply { this.userId = userId }
-        fun orderName(orderName: String) = apply { this.orderName = orderName }
-        fun orderLineItems(orderLineItems: List<OrderLineItem>) = apply { this.orderLineItems = orderLineItems }
-        fun orderStatus(orderStatus: OrderStatus) = apply { this.orderStatus = orderStatus }
-        fun orderMethod(orderMethod: OrderMethod) = apply { this.orderMethod = orderMethod }
-        fun eventId(eventId: Long) = apply { this.eventId = eventId }
-        fun build(): Order = Order().apply {
-            this.userId = this@Builder.userId
-            this.orderName = this@Builder.orderName
-            this.orderLineItems.addAll(this@Builder.orderLineItems)
-            this.orderStatus = this@Builder.orderStatus
-            this.orderMethod = this@Builder.orderMethod
-            this.eventId = this@Builder.eventId
+        fun forTest(
+            userId: Long? = null,
+            orderName: String? = null,
+            orderLineItems: List<OrderLineItem> = emptyList(),
+            orderStatus: OrderStatus = OrderStatus.READY,
+            orderMethod: OrderMethod? = null,
+            eventId: Long? = null,
+        ): Order = Order().apply {
+            this.userId = userId
+            this.orderName = orderName
+            this.orderLineItems.addAll(orderLineItems)
+            this.orderStatus = orderStatus
+            this.orderMethod = orderMethod
+            this.eventId = eventId
         }
     }
 

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/domain/OrderLineItem.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/domain/OrderLineItem.kt
@@ -47,21 +47,16 @@ class OrderLineItem() : BaseTimeEntity() {
             }
         }
 
+        /** 테스트 전용 팩토리 메서드 */
         @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var orderOptionAnswer: List<OrderOptionAnswer> = emptyList()
-        private var quantity: Long? = null
-        private var orderItemVo: OrderItemVo? = null
-        fun orderOptionAnswer(orderOptionAnswer: List<OrderOptionAnswer>) = apply { this.orderOptionAnswer = orderOptionAnswer }
-        fun quantity(quantity: Long) = apply { this.quantity = quantity }
-        fun orderItemVo(orderItemVo: OrderItemVo) = apply { this.orderItemVo = orderItemVo }
-        fun build(): OrderLineItem = OrderLineItem().apply {
-            this.orderOptionAnswers.addAll(this@Builder.orderOptionAnswer)
-            this.quantity = this@Builder.quantity
-            this.orderItem = this@Builder.orderItemVo
+        fun forTest(
+            orderOptionAnswer: List<OrderOptionAnswer> = emptyList(),
+            quantity: Long? = null,
+            orderItemVo: OrderItemVo? = null,
+        ): OrderLineItem = OrderLineItem().apply {
+            this.orderOptionAnswers.addAll(orderOptionAnswer)
+            this.quantity = quantity
+            this.orderItem = orderItemVo
         }
     }
 

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/domain/OrderOptionAnswer.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/domain/OrderOptionAnswer.kt
@@ -36,31 +36,14 @@ class OrderOptionAnswer() : BaseTimeEntity() {
             optionId = cartOptionAnswer.optionId
             additionalPrice = cartOptionAnswer.additionalPrice
         }
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var optionId: Long? = null
-        private var additionalPrice: band.gosrock.domain.common.vo.Money = band.gosrock.domain.common.vo.Money.ZERO
-        private var answer: String? = null
-        fun optionId(optionId: Long) = apply { this.optionId = optionId }
-        fun additionalPrice(additionalPrice: band.gosrock.domain.common.vo.Money) = apply { this.additionalPrice = additionalPrice }
-        fun answer(answer: String?) = apply { this.answer = answer }
-        fun build(): OrderOptionAnswer = OrderOptionAnswer().apply {
-            this.optionId = this@Builder.optionId
-            this.additionalPrice = this@Builder.additionalPrice
-            this.answer = this@Builder.answer
-        }
     }
 
     fun getOptionAnswerVo(option: Option): OptionAnswerVo =
-        OptionAnswerVo.builder()
-            .questionDescription(option.getQuestionDescription())
-            .answer(answer)
-            .optionGroupType(option.getQuestionType())
-            .questionName(option.getQuestionName())
-            .additionalPrice(additionalPrice)
-            .build()
+        OptionAnswerVo(
+            questionDescription = option.getQuestionDescription(),
+            answer = answer,
+            optionGroupType = option.getQuestionType(),
+            questionName = option.getQuestionName(),
+            additionalPrice = additionalPrice,
+        )
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/service/WithdrawPaymentService.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/service/WithdrawPaymentService.kt
@@ -16,7 +16,7 @@ class WithdrawPaymentService(private val paymentsCancelClient: PaymentsCancelCli
         return paymentsCancelClient.execute(
             orderUuid,
             paymentKey,
-            CancelPaymentsRequest.builder().cancelReason(reason).build(),
+            CancelPaymentsRequest(cancelReason = reason),
         )
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/settlement/domain/EventSettlement.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/settlement/domain/EventSettlement.kt
@@ -14,99 +14,62 @@ import jakarta.persistence.Id
 
 /** 이벤트 별 정산용 ( 클라이언트 용 ) */
 @Entity(name = "tbl_event_settlement")
-open class EventSettlement protected constructor() : BaseTimeEntity() {
+open class EventSettlement(
+    var eventId: Long? = null,
+
+    // 총 매출 금액
+    @AttributeOverride(name = "amount", column = Column(name = "total_sales_amount"))
+    @Embedded
+    var totalSalesAmount: Money? = null,
+
+    // 두둥티켓 송금 관련
+    @AttributeOverride(name = "amount", column = Column(name = "dudoong_amount"))
+    @Embedded
+    var dudoongAmount: Money? = null,
+
+    // 카드 결제 금액
+    @AttributeOverride(name = "amount", column = Column(name = "payment_amount"))
+    @Embedded
+    var paymentAmount: Money? = null,
+
+    // 쿠폰 금액
+    @AttributeOverride(name = "amount", column = Column(name = "coupon_amount"))
+    @Embedded
+    var couponAmount: Money? = null,
+
+    // 중개 수수료 ( 카드 결제 금액의 % )
+    @AttributeOverride(name = "amount", column = Column(name = "dudoong_fee"))
+    @Embedded
+    var dudoongFee: Money? = null,
+
+    // 결제 대행 수수료
+    @AttributeOverride(name = "amount", column = Column(name = "pg_fee"))
+    @Embedded
+    var pgFee: Money? = null,
+
+    // 결제 대행 수수료 vat
+    @AttributeOverride(name = "amount", column = Column(name = "pg_fee_vat"))
+    @Embedded
+    var pgFeeVat: Money? = null,
+
+    // 최종 정산 금액
+    @AttributeOverride(name = "amount", column = Column(name = "total_amount"))
+    @Embedded
+    var totalAmount: Money? = null,
+
+    // S3 업로드된 키.
+    var eventOrderExcelKey: String? = null,
+
+    // 정산 진행 과정
+    @Enumerated(EnumType.STRING)
+    var eventSettlementStatus: EventSettlementStatus = EventSettlementStatus.READY,
+) : BaseTimeEntity() {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "event_settlement_id")
     var id: Long? = null
         protected set
-
-    var eventId: Long? = null
-        protected set
-
-    // 총 매출 금액
-    @AttributeOverride(name = "amount", column = Column(name = "total_sales_amount"))
-    @Embedded
-    var totalSalesAmount: Money? = null
-        protected set
-
-    // 두둥티켓 송금 관련
-    @AttributeOverride(name = "amount", column = Column(name = "dudoong_amount"))
-    @Embedded
-    var dudoongAmount: Money? = null
-        protected set
-
-    // 카드 결제 금액
-    @AttributeOverride(name = "amount", column = Column(name = "payment_amount"))
-    @Embedded
-    var paymentAmount: Money? = null
-        protected set
-
-    // 쿠폰 금액
-    @AttributeOverride(name = "amount", column = Column(name = "coupon_amount"))
-    @Embedded
-    var couponAmount: Money? = null
-        protected set
-
-    // 중개 수수료 ( 카드 결제 금액의 % )
-    @AttributeOverride(name = "amount", column = Column(name = "dudoong_fee"))
-    @Embedded
-    var dudoongFee: Money? = null
-        protected set
-
-    // 결제 대행 수수료
-    @AttributeOverride(name = "amount", column = Column(name = "pg_fee"))
-    @Embedded
-    var pgFee: Money? = null
-        protected set
-
-    // 결제 대행 수수료 vat
-    @AttributeOverride(name = "amount", column = Column(name = "pg_fee_vat"))
-    @Embedded
-    var pgFeeVat: Money? = null
-        protected set
-
-    // 최종 정산 금액
-    @AttributeOverride(name = "amount", column = Column(name = "total_amount"))
-    @Embedded
-    var totalAmount: Money? = null
-        protected set
-
-    // S3 업로드된 키.
-    var eventOrderExcelKey: String? = null
-        protected set
-
-    // 정산 진행 과정
-    @Enumerated(EnumType.STRING)
-    var eventSettlementStatus: EventSettlementStatus = EventSettlementStatus.READY
-        protected set
-
-    constructor(
-        eventId: Long?,
-        totalSalesAmount: Money?,
-        dudoongAmount: Money?,
-        paymentAmount: Money?,
-        couponAmount: Money?,
-        dudoongFee: Money?,
-        pgFee: Money?,
-        pgFeeVat: Money?,
-        totalAmount: Money?,
-        eventOrderExcelKey: String?,
-        eventSettlementStatus: EventSettlementStatus?,
-    ) : this() {
-        this.eventId = eventId
-        this.totalSalesAmount = totalSalesAmount
-        this.dudoongAmount = dudoongAmount
-        this.paymentAmount = paymentAmount
-        this.couponAmount = couponAmount
-        this.dudoongFee = dudoongFee
-        this.pgFee = pgFee
-        this.pgFeeVat = pgFeeVat
-        this.totalAmount = totalAmount
-        this.eventOrderExcelKey = eventOrderExcelKey
-        if (eventSettlementStatus != null) this.eventSettlementStatus = eventSettlementStatus
-    }
 
     fun updateEventOrderListExcelKey(key: String) {
         this.eventOrderExcelKey = key
@@ -115,62 +78,6 @@ open class EventSettlement protected constructor() : BaseTimeEntity() {
     companion object {
         @JvmStatic
         fun createWithEventId(eventId: Long): EventSettlement =
-            EventSettlement(
-                eventId = eventId,
-                totalSalesAmount = null,
-                dudoongAmount = null,
-                paymentAmount = null,
-                couponAmount = null,
-                dudoongFee = null,
-                pgFee = null,
-                pgFeeVat = null,
-                totalAmount = null,
-                eventOrderExcelKey = null,
-                eventSettlementStatus = null,
-            )
-
-        @JvmStatic
-        fun builder(): Builder = Builder()
-    }
-
-    class Builder {
-        private var eventId: Long? = null
-        private var totalSalesAmount: Money? = null
-        private var dudoongAmount: Money? = null
-        private var paymentAmount: Money? = null
-        private var couponAmount: Money? = null
-        private var dudoongFee: Money? = null
-        private var pgFee: Money? = null
-        private var pgFeeVat: Money? = null
-        private var totalAmount: Money? = null
-        private var eventOrderExcelKey: String? = null
-        private var eventSettlementStatus: EventSettlementStatus? = null
-
-        fun eventId(eventId: Long?) = apply { this.eventId = eventId }
-        fun totalSalesAmount(v: Money?) = apply { this.totalSalesAmount = v }
-        fun dudoongAmount(v: Money?) = apply { this.dudoongAmount = v }
-        fun paymentAmount(v: Money?) = apply { this.paymentAmount = v }
-        fun couponAmount(v: Money?) = apply { this.couponAmount = v }
-        fun dudoongFee(v: Money?) = apply { this.dudoongFee = v }
-        fun pgFee(v: Money?) = apply { this.pgFee = v }
-        fun pgFeeVat(v: Money?) = apply { this.pgFeeVat = v }
-        fun totalAmount(v: Money?) = apply { this.totalAmount = v }
-        fun eventOrderExcelKey(v: String?) = apply { this.eventOrderExcelKey = v }
-        fun eventSettlementStatus(v: EventSettlementStatus?) = apply { this.eventSettlementStatus = v }
-
-        fun build(): EventSettlement =
-            EventSettlement(
-                eventId = eventId,
-                totalSalesAmount = totalSalesAmount,
-                dudoongAmount = dudoongAmount,
-                paymentAmount = paymentAmount,
-                couponAmount = couponAmount,
-                dudoongFee = dudoongFee,
-                pgFee = pgFee,
-                pgFeeVat = pgFeeVat,
-                totalAmount = totalAmount,
-                eventOrderExcelKey = eventOrderExcelKey,
-                eventSettlementStatus = eventSettlementStatus,
-            )
+            EventSettlement(eventId = eventId)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/settlement/domain/SettlementFeeVo.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/settlement/domain/SettlementFeeVo.kt
@@ -8,21 +8,13 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 
 @Embeddable
-class SettlementFeeVo protected constructor() {
-
+class SettlementFeeVo(
     @Enumerated(EnumType.STRING)
-    var type: FeeCode? = null
-        protected set
+    var type: FeeCode? = null,
 
     @Column(name = "fee")
-    var fee: Long? = null
-        protected set
-
-    constructor(type: FeeCode, fee: Long) : this() {
-        this.type = type
-        this.fee = fee
-    }
-
+    var fee: Long? = null,
+) {
     companion object {
         @JvmStatic
         fun from(settlementFeeDto: SettlementFeeDto): SettlementFeeVo =

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/settlement/service/EventSettlementDomainService.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/settlement/service/EventSettlementDomainService.kt
@@ -23,18 +23,18 @@ class EventSettlementDomainService(
         val pgFee = getPgFee(transactionSettlements, totalPaymentAmount)
         val pgFeeVat = getPgFeeVat(pgFee)
 
-        val eventSettlement = EventSettlement.builder()
-            .eventId(eventId)
-            .totalSalesAmount(getTotalSalesAmount(orders))
-            .dudoongAmount(getDudoongTicketSalesAmount(orders))
-            .paymentAmount(totalPaymentAmount)
-            .couponAmount(getPaymentOrderDiscountAmount(orders))
-            .dudoongFee(Money.ZERO)
-            .pgFee(pgFee)
-            .pgFeeVat(pgFeeVat)
-            .totalAmount(getTotalSettlementAmount(totalPaymentAmount, pgFee, pgFeeVat))
-            .eventSettlementStatus(EventSettlementStatus.CALCULATED)
-            .build()
+        val eventSettlement = EventSettlement(
+            eventId = eventId,
+            totalSalesAmount = getTotalSalesAmount(orders),
+            dudoongAmount = getDudoongTicketSalesAmount(orders),
+            paymentAmount = totalPaymentAmount,
+            couponAmount = getPaymentOrderDiscountAmount(orders),
+            dudoongFee = Money.ZERO,
+            pgFee = pgFee,
+            pgFeeVat = pgFeeVat,
+            totalAmount = getTotalSettlementAmount(totalPaymentAmount, pgFee, pgFeeVat),
+            eventSettlementStatus = EventSettlementStatus.CALCULATED,
+        )
 
         // 최종 정산 금액 계산.
         eventSettlementAdaptor.save(eventSettlement)

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/ticket_item/domain/ItemOptionGroup.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/ticket_item/domain/ItemOptionGroup.kt
@@ -13,7 +13,10 @@ import jakarta.persistence.UniqueConstraint
 
 @Table(uniqueConstraints = [UniqueConstraint(columnNames = ["item_id", "option_group_id"])])
 @Entity(name = "tbl_item_option_group")
-class ItemOptionGroup() {
+class ItemOptionGroup(
+    item: TicketItem? = null,
+    optionGroup: OptionGroup? = null,
+) {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,30 +26,11 @@ class ItemOptionGroup() {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_id", updatable = false)
-    var item: TicketItem? = null
+    var item: TicketItem? = item
         protected set
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "option_group_id", updatable = false)
-    var optionGroup: OptionGroup? = null
+    var optionGroup: OptionGroup? = optionGroup
         protected set
-
-    constructor(item: TicketItem?, optionGroup: OptionGroup?) : this() {
-        this.item = item
-        this.optionGroup = optionGroup
-    }
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var item: TicketItem? = null
-        private var optionGroup: OptionGroup? = null
-
-        fun item(item: TicketItem?) = apply { this.item = item }
-        fun optionGroup(optionGroup: OptionGroup?) = apply { this.optionGroup = optionGroup }
-        fun build() = ItemOptionGroup(item, optionGroup)
-    }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/ticket_item/domain/Option.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/ticket_item/domain/Option.kt
@@ -14,7 +14,10 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 
 @Entity(name = "tbl_option")
-class Option() {
+class Option(
+    var answer: String? = null,
+    var additionalPrice: Money? = null,
+) {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,20 +25,12 @@ class Option() {
     var id: Long? = null
         protected set
 
-    var answer: String? = null
-        protected set
-
-    var additionalPrice: Money? = null
-        protected set
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "option_group_id", updatable = false)
     var optionGroup: OptionGroup? = null
         protected set
 
-    constructor(answer: String?, additionalPrice: Money?, optionGroup: OptionGroup?) : this() {
-        this.answer = answer
-        this.additionalPrice = additionalPrice
+    constructor(answer: String?, additionalPrice: Money?, optionGroup: OptionGroup?) : this(answer = answer, additionalPrice = additionalPrice) {
         this.optionGroup = optionGroup
     }
 
@@ -67,19 +62,5 @@ class Option() {
         @JvmStatic
         fun create(answer: String?, additionalPrice: Money?, optionGroup: OptionGroup?): Option =
             Option(answer, additionalPrice, optionGroup)
-
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var answer: String? = null
-        private var additionalPrice: Money? = null
-        private var optionGroup: OptionGroup? = null
-
-        fun answer(answer: String?) = apply { this.answer = answer }
-        fun additionalPrice(price: Money?) = apply { this.additionalPrice = price }
-        fun optionGroup(optionGroup: OptionGroup?) = apply { this.optionGroup = optionGroup }
-        fun build() = Option(answer, additionalPrice, optionGroup)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/ticket_item/domain/OptionGroup.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/ticket_item/domain/OptionGroup.kt
@@ -20,32 +20,24 @@ import jakarta.persistence.OneToMany
 import org.hibernate.annotations.ColumnDefault
 
 @Entity(name = "tbl_option_group")
-class OptionGroup() {
+class OptionGroup(
+    var eventId: Long? = null,
+    // 옵션 그룹 응답 형식
+    @Enumerated(EnumType.STRING)
+    var type: OptionGroupType? = null,
+    // 옵션 그룹 이름
+    var name: String? = null,
+    // 옵션 그룹 설명
+    var description: String? = null,
+    // 필수 응답 여부
+    var isEssential: Boolean? = null,
+    initialOptions: List<Option> = emptyList(),
+) {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "option_group_id")
     var id: Long? = null
-        protected set
-
-    var eventId: Long? = null
-        protected set
-
-    // 옵션 그룹 응답 형식
-    @Enumerated(EnumType.STRING)
-    var type: OptionGroupType? = null
-        protected set
-
-    // 옵션 그룹 이름
-    var name: String? = null
-        protected set
-
-    // 옵션 그룹 설명
-    var description: String? = null
-        protected set
-
-    // 필수 응답 여부
-    var isEssential: Boolean? = null
         protected set
 
     // 상태
@@ -57,21 +49,11 @@ class OptionGroup() {
     @OneToMany(cascade = [CascadeType.ALL], mappedBy = "optionGroup")
     val options: MutableList<Option> = mutableListOf()
 
-    constructor(
-        eventId: Long?,
-        type: OptionGroupType?,
-        name: String?,
-        description: String?,
-        isEssential: Boolean?,
-        options: List<Option>,
-    ) : this() {
-        this.eventId = eventId
-        this.type = type
-        this.name = name
-        this.description = description
-        this.isEssential = isEssential
-        this.options.addAll(options)
-        options.forEach { it.updateOptionGroup(this) }
+    init {
+        if (initialOptions.isNotEmpty()) {
+            this.options.addAll(initialOptions)
+            initialOptions.forEach { it.updateOptionGroup(this) }
+        }
     }
 
     fun validateEventId(eventId: Long) {
@@ -100,27 +82,5 @@ class OptionGroup() {
         // 적용된 옵션은 삭제 불가
         if (this.hasApplication(ticketItems)) throw ForbiddenOptionGroupDeleteException.EXCEPTION
         this.optionGroupStatus = OptionGroupStatus.DELETED
-    }
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var eventId: Long? = null
-        private var type: OptionGroupType? = null
-        private var name: String? = null
-        private var description: String? = null
-        private var isEssential: Boolean? = null
-        private var options: List<Option> = emptyList()
-
-        fun eventId(eventId: Long?) = apply { this.eventId = eventId }
-        fun type(type: OptionGroupType?) = apply { this.type = type }
-        fun name(name: String?) = apply { this.name = name }
-        fun description(description: String?) = apply { this.description = description }
-        fun isEssential(isEssential: Boolean?) = apply { this.isEssential = isEssential }
-        fun options(options: List<Option>) = apply { this.options = options }
-        fun build() = OptionGroup(eventId, type, name, description, isEssential, options)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/ticket_item/domain/TicketItem.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/ticket_item/domain/TicketItem.kt
@@ -34,7 +34,38 @@ import org.hibernate.annotations.ColumnDefault
 import org.springframework.util.StringUtils
 
 @Entity(name = "tbl_ticket_item")
-class TicketItem() : BaseTimeEntity() {
+class TicketItem(
+    // 티켓 지불 타입
+    @Enumerated(EnumType.STRING)
+    var payType: TicketPayType? = null,
+    // 티켓 이름
+    var name: String? = null,
+    // 티켓 설명
+    var description: String? = null,
+    // 티켓 가격
+    var price: Money? = null,
+    // 티켓 재고
+    var quantity: Long? = null,
+    // 티켓 공급량
+    var supplyCount: Long? = null,
+    // 1인당 구매 매수 제한
+    var purchaseLimit: Long? = null,
+    // 티켓 승인 타입
+    @Enumerated(EnumType.STRING)
+    var type: TicketType? = null,
+    bankName: String? = null,
+    accountNumber: String? = null,
+    accountHolder: String? = null,
+    // 재고 공개 여부
+    var isQuantityPublic: Boolean? = null,
+    // 판매 가능 여부
+    var isSellable: Boolean? = null,
+    // 판매 시작 시간
+    var saleStartAt: LocalDateTime? = null,
+    // 판매 종료 시간
+    var saleEndAt: LocalDateTime? = null,
+    var eventId: Long? = null,
+) : BaseTimeEntity() {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,58 +73,10 @@ class TicketItem() : BaseTimeEntity() {
     var id: Long? = null
         protected set
 
-    // 티켓 지불 타입
-    @Enumerated(EnumType.STRING)
-    var payType: TicketPayType? = null
-        protected set
-
-    // 티켓 이름
-    var name: String? = null
-        protected set
-
-    // 티켓 설명
-    var description: String? = null
-        protected set
-
-    // 티켓 가격
-    var price: Money? = null
-        protected set
-
-    // 티켓 재고
-    var quantity: Long? = null
-        protected set
-
-    // 티켓 공급량
-    var supplyCount: Long? = null
-        protected set
-
-    // 1인당 구매 매수 제한
-    var purchaseLimit: Long? = null
-        protected set
-
-    // 티켓 승인 타입
-    @Enumerated(EnumType.STRING)
-    var type: TicketType? = null
-        protected set
-
     @Embedded
-    var accountInfo: AccountInfoVo? = null
-        protected set
-
-    // 재고 공개 여부
-    var isQuantityPublic: Boolean? = null
-        protected set
-
-    // 판매 가능 여부
-    var isSellable: Boolean? = null
-        protected set
-
-    // 판매 시작 시간
-    var saleStartAt: LocalDateTime? = null
-        protected set
-
-    // 판매 종료 시간
-    var saleEndAt: LocalDateTime? = null
+    var accountInfo: AccountInfoVo? = if (payType == TicketPayType.DUDOONG_TICKET)
+        AccountInfoVo.valueOf(bankName, accountNumber, accountHolder)
+    else null
         protected set
 
     // 상태
@@ -102,47 +85,8 @@ class TicketItem() : BaseTimeEntity() {
     var ticketItemStatus: TicketItemStatus = TicketItemStatus.VALID
         protected set
 
-    var eventId: Long? = null
-        protected set
-
     @OneToMany(cascade = [CascadeType.ALL], fetch = FetchType.EAGER, orphanRemoval = true)
     val itemOptionGroups: MutableList<ItemOptionGroup> = mutableListOf()
-
-    constructor(
-        payType: TicketPayType?,
-        name: String?,
-        description: String?,
-        price: Money?,
-        quantity: Long?,
-        supplyCount: Long?,
-        purchaseLimit: Long?,
-        type: TicketType?,
-        bankName: String?,
-        accountNumber: String?,
-        accountHolder: String?,
-        isQuantityPublic: Boolean?,
-        isSellable: Boolean?,
-        saleStartAt: LocalDateTime?,
-        saleEndAt: LocalDateTime?,
-        eventId: Long?,
-    ) : this() {
-        this.payType = payType
-        this.name = name
-        this.description = description
-        this.price = price
-        this.quantity = quantity
-        this.supplyCount = supplyCount
-        this.purchaseLimit = purchaseLimit
-        this.type = type
-        this.accountInfo = if (payType == TicketPayType.DUDOONG_TICKET)
-            AccountInfoVo.valueOf(bankName, accountNumber, accountHolder)
-        else null
-        this.isQuantityPublic = isQuantityPublic
-        this.isSellable = isSellable
-        this.saleStartAt = saleStartAt
-        this.saleEndAt = saleEndAt
-        this.eventId = eventId
-    }
 
     fun addItemOptionGroup(optionGroup: OptionGroup) {
         // 재고 감소된 티켓상품은 옵션적용 변경 불가
@@ -158,7 +102,7 @@ class TicketItem() : BaseTimeEntity() {
         // 중복 체크
         if (hasItemOptionGroup(optionGroup.id!!)) throw DuplicatedItemOptionGroupException.EXCEPTION
 
-        val itemOptionGroup = ItemOptionGroup.builder().item(this).optionGroup(optionGroup).build()
+        val itemOptionGroup = ItemOptionGroup(item = this, optionGroup = optionGroup)
         this.itemOptionGroups.add(itemOptionGroup)
     }
 
@@ -271,51 +215,5 @@ class TicketItem() : BaseTimeEntity() {
         if (price != null) this.price = price
         if (quantity != null) this.quantity = quantity
         if (purchaseLimit != null) this.purchaseLimit = purchaseLimit
-    }
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var payType: TicketPayType? = null
-        private var name: String? = null
-        private var description: String? = null
-        private var price: Money? = null
-        private var quantity: Long? = null
-        private var supplyCount: Long? = null
-        private var purchaseLimit: Long? = null
-        private var type: TicketType? = null
-        private var bankName: String? = null
-        private var accountNumber: String? = null
-        private var accountHolder: String? = null
-        private var isQuantityPublic: Boolean? = null
-        private var isSellable: Boolean? = null
-        private var saleStartAt: LocalDateTime? = null
-        private var saleEndAt: LocalDateTime? = null
-        private var eventId: Long? = null
-
-        fun payType(payType: TicketPayType?) = apply { this.payType = payType }
-        fun name(name: String?) = apply { this.name = name }
-        fun description(description: String?) = apply { this.description = description }
-        fun price(price: Money?) = apply { this.price = price }
-        fun quantity(quantity: Long?) = apply { this.quantity = quantity }
-        fun supplyCount(supplyCount: Long?) = apply { this.supplyCount = supplyCount }
-        fun purchaseLimit(purchaseLimit: Long?) = apply { this.purchaseLimit = purchaseLimit }
-        fun type(type: TicketType?) = apply { this.type = type }
-        fun bankName(bankName: String?) = apply { this.bankName = bankName }
-        fun accountNumber(accountNumber: String?) = apply { this.accountNumber = accountNumber }
-        fun accountHolder(accountHolder: String?) = apply { this.accountHolder = accountHolder }
-        fun isQuantityPublic(isQuantityPublic: Boolean?) = apply { this.isQuantityPublic = isQuantityPublic }
-        fun isSellable(isSellable: Boolean?) = apply { this.isSellable = isSellable }
-        fun saleStartAt(saleStartAt: LocalDateTime?) = apply { this.saleStartAt = saleStartAt }
-        fun saleEndAt(saleEndAt: LocalDateTime?) = apply { this.saleEndAt = saleEndAt }
-        fun eventId(eventId: Long?) = apply { this.eventId = eventId }
-        fun build() = TicketItem(
-            payType, name, description, price, quantity, supplyCount, purchaseLimit, type,
-            bankName, accountNumber, accountHolder, isQuantityPublic, isSellable,
-            saleStartAt, saleEndAt, eventId
-        )
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/user/domain/OauthInfo.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/user/domain/OauthInfo.kt
@@ -7,33 +7,11 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 
 @Embeddable
-class OauthInfo() {
+class OauthInfo(
     @Enumerated(EnumType.STRING)
-    var provider: OauthProvider? = null
-        protected set
-
-    var oid: String? = null
-        protected set
-
-    constructor(provider: OauthProvider, oid: String) : this() {
-        this.provider = provider
-        this.oid = oid
-    }
-
+    var provider: OauthProvider? = null,
+    var oid: String? = null,
+) {
     fun withDrawOauthInfo(): OauthInfo =
         OauthInfo(provider!!, DuDoongStatic.WITHDRAW_PREFIX + LocalDateTime.now() + ":" + oid)
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var provider: OauthProvider? = null
-        private var oid: String = ""
-
-        fun provider(provider: OauthProvider) = apply { this.provider = provider }
-        fun oid(oid: String) = apply { this.oid = oid }
-        fun build() = OauthInfo(provider!!, oid)
-    }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/user/domain/Profile.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/user/domain/Profile.kt
@@ -6,49 +6,22 @@ import jakarta.persistence.Embeddable
 import jakarta.persistence.Embedded
 
 @Embeddable
-class Profile() {
-    var name: String? = null
-        protected set
-    var email: String? = null
-        protected set
+class Profile(
+    var name: String? = null,
+    var email: String? = null,
+    phoneNumber: String? = null,
+    profileImage: String? = null,
+) {
+    @Embedded
+    var phoneNumberVo: PhoneNumberVo? = PhoneNumberVo.valueOf(phoneNumber)
 
     @Embedded
-    var phoneNumberVo: PhoneNumberVo? = null
-        protected set
-
-    @Embedded
-    var profileImage: ImageVo? = null
-        protected set
-
-    constructor(name: String, email: String, phoneNumber: String?, profileImage: String?) : this() {
-        this.name = name
-        this.email = email
-        this.phoneNumberVo = PhoneNumberVo.valueOf(phoneNumber)
-        this.profileImage = ImageVo.valueOf(profileImage)
-    }
+    var profileImage: ImageVo? = ImageVo.valueOf(profileImage)
 
     fun withdraw() {
         this.name = "탈퇴한 유저"
         this.email = null
         this.phoneNumberVo = null
         this.profileImage = null
-    }
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var name: String = ""
-        private var email: String = ""
-        private var phoneNumber: String? = null
-        private var profileImage: String? = null
-
-        fun name(name: String) = apply { this.name = name }
-        fun email(email: String) = apply { this.email = email }
-        fun phoneNumber(phoneNumber: String?) = apply { this.phoneNumber = phoneNumber }
-        fun profileImage(profileImage: String?) = apply { this.profileImage = profileImage }
-        fun build() = Profile(name, email, phoneNumber, profileImage)
     }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/user/domain/RefreshTokenEntity.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/user/domain/RefreshTokenEntity.kt
@@ -14,20 +14,4 @@ class RefreshTokenEntity(
     fun updateTTL(ttl: Long) {
         this.ttl = (this.ttl ?: 0) + ttl
     }
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var id: Long? = null
-        private var refreshToken: String? = null
-        private var ttl: Long? = null
-
-        fun id(id: Long?) = apply { this.id = id }
-        fun refreshToken(refreshToken: String?) = apply { this.refreshToken = refreshToken }
-        fun ttl(ttl: Long?) = apply { this.ttl = ttl }
-        fun build() = RefreshTokenEntity(id, refreshToken, ttl)
-    }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/user/domain/User.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/user/domain/User.kt
@@ -29,19 +29,20 @@ import jakarta.persistence.UniqueConstraint
     name = "tbl_user",
     uniqueConstraints = [UniqueConstraint(columnNames = ["oid", "provider"])],
 )
-class User() : BaseTimeEntity() {
+class User(
+    @Embedded
+    var profile: Profile? = null,
+
+    @Embedded
+    var oauthInfo: OauthInfo? = null,
+
+    // 마케팅 동의 여부
+    var marketingAgree: Boolean = false,
+) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     var id: Long? = null
-        protected set
-
-    @Embedded
-    var profile: Profile? = null
-        protected set
-
-    @Embedded
-    var oauthInfo: OauthInfo? = null
         protected set
 
     @Enumerated(EnumType.STRING)
@@ -56,22 +57,12 @@ class User() : BaseTimeEntity() {
     var receiveMail: Boolean = true
         protected set
 
-    // 마케팅 동의 여부
-    var marketingAgree: Boolean = false
-        protected set
-
     var lastLoginAt: LocalDateTime = LocalDateTime.now()
         protected set
 
-    constructor(profile: Profile, oauthInfo: OauthInfo?, marketingAgree: Boolean) : this() {
-        this.profile = profile
-        this.oauthInfo = oauthInfo
-        this.marketingAgree = marketingAgree
-    }
-
     @PostPersist
     fun registerEvent() {
-        val event = UserRegisterEvent.builder().userId(id).build()
+        val event = UserRegisterEvent(userId = id)
         Events.raise(event)
     }
 
@@ -129,20 +120,4 @@ class User() : BaseTimeEntity() {
     }
 
     fun isDeletedUser(): Boolean = accountState == AccountState.DELETED
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-
-    class Builder {
-        private var profile: Profile? = null
-        private var oauthInfo: OauthInfo? = null
-        private var marketingAgree: Boolean = false
-
-        fun profile(profile: Profile?) = apply { this.profile = profile }
-        fun oauthInfo(oauthInfo: OauthInfo?) = apply { this.oauthInfo = oauthInfo }
-        fun marketingAgree(marketingAgree: Boolean?) = apply { this.marketingAgree = marketingAgree ?: false }
-        fun build() = User(profile!!, oauthInfo, marketingAgree)
-    }
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/user/service/UserDomainService.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/user/service/UserDomainService.kt
@@ -19,11 +19,11 @@ open class UserDomainService(
     @RedissonLock(LockName = "유저등록", identifier = "oid", paramClassType = OauthInfo::class)
     open fun registerUser(profile: Profile, oauthInfo: OauthInfo, marketingAgree: Boolean): User {
         validUserCanRegister(oauthInfo)
-        val newUser = User.builder()
-            .profile(profile)
-            .marketingAgree(marketingAgree)
-            .oauthInfo(oauthInfo)
-            .build()
+        val newUser = User(
+            profile = profile,
+            marketingAgree = marketingAgree,
+            oauthInfo = oauthInfo,
+        )
         userRepository.save(newUser)
         return newUser
     }
@@ -32,11 +32,11 @@ open class UserDomainService(
     @RedissonLock(LockName = "개발용회원가입", identifier = "oid", paramClassType = OauthInfo::class)
     open fun upsertUser(profile: Profile, oauthInfo: OauthInfo): User =
         userRepository.findByOauthInfo(oauthInfo).orElseGet {
-            val newUser = User.builder()
-                .profile(profile)
-                .marketingAgree(true)
-                .oauthInfo(oauthInfo)
-                .build()
+            val newUser = User(
+                profile = profile,
+                marketingAgree = true,
+                oauthInfo = oauthInfo,
+            )
             userRepository.save(newUser)
             newUser
         }

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAopTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/common/aop/redissonLock/RedissonLockAopTest.java
@@ -27,7 +27,7 @@ class RedissonLockAopTest {
     @Test
     public void 커스텀오브젝트에서_클래스타입과_식별자로_키를_가져와야한다()
             throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        ProfileViewDto profileViewDto = ProfileViewDto.builder().id(1000L).build();
+        ProfileViewDto profileViewDto = new ProfileViewDto(1000L, null, null);
         String otherParam = "param";
 
         Object[] testArgs = {profileViewDto, otherParam};
@@ -40,7 +40,7 @@ class RedissonLockAopTest {
 
     @Test
     public void 기본오브젝트에서_식별자로_키를_가져와야한다() {
-        ProfileViewDto profileViewDto = ProfileViewDto.builder().id(1000L).build();
+        ProfileViewDto profileViewDto = new ProfileViewDto(1000L, null, null);
         String keyParamName = "다이내믹키가될값";
 
         Object[] testArgs = {profileViewDto, keyParamName};
@@ -54,7 +54,7 @@ class RedissonLockAopTest {
 
     @Test
     public void 잘못된_인자를_설정하면_오류가_발생해야한다() {
-        ProfileViewDto profileViewDto = ProfileViewDto.builder().id(1000L).build();
+        ProfileViewDto profileViewDto = new ProfileViewDto(1000L, null, null);
         // 키값
         String keyParamName = "다른값";
         // 실제 인자로 넘겨질 값들

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/cart/domain/CartLineItemTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/cart/domain/CartLineItemTest.java
@@ -33,21 +33,13 @@ class CartLineItemTest {
         given(hasPriceItem.getPrice()).willReturn(itemPrice);
 
         hasPriceCartLineItem =
-                CartLineItem.builder()
-                        .quantity(itemQuantity)
-                        .cartOptionAnswers(List.of(cartOptionAnswer))
-                        .item(hasPriceItem)
-                        .build();
+                CartLineItem.of(hasPriceItem, itemQuantity, List.of(cartOptionAnswer));
 
         given(freeItem.getId()).willReturn(1L);
         given(freeItem.getPrice()).willReturn(Money.ZERO);
 
         freeCartLineItem =
-                CartLineItem.builder()
-                        .quantity(itemQuantity)
-                        .cartOptionAnswers(List.of(cartOptionAnswer))
-                        .item(freeItem)
-                        .build();
+                CartLineItem.of(freeItem, itemQuantity, List.of(cartOptionAnswer));
     }
 
     @Test

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/cart/domain/CartOptionAnswerTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/cart/domain/CartOptionAnswerTest.java
@@ -28,7 +28,7 @@ class CartOptionAnswerTest {
         given(option.getId()).willReturn(optionId);
         given(option.getAdditionalPrice()).willReturn(W3000);
 
-        cartOptionAnswer = CartOptionAnswer.builder().answer(answer).option(option).build();
+        cartOptionAnswer = CartOptionAnswer.of(option, answer);
     }
 
     @Test
@@ -41,13 +41,7 @@ class CartOptionAnswerTest {
         given(option.getQuestionType()).willReturn(trueFalse);
         given(option.getQuestionName()).willReturn(questionName);
         OptionAnswerVo build =
-                OptionAnswerVo.builder()
-                        .answer(answer)
-                        .optionGroupType(trueFalse)
-                        .questionDescription(questionDescription)
-                        .questionName(questionName)
-                        .additionalPrice(W3000)
-                        .build();
+                new OptionAnswerVo(trueFalse, questionName, questionDescription, answer, W3000);
         // when
         OptionAnswerVo optionAnswerVo = cartOptionAnswer.getOptionAnswerVo(option);
         assertEquals(optionAnswerVo, build);

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/cart/domain/CartTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/cart/domain/CartTest.java
@@ -28,12 +28,9 @@ class CartTest {
     @BeforeEach
     void setUp() {
         hasPriceCart =
-                Cart.builder()
-                        .cartLineItems(List.of(cartLineItem1, cartLineItem2))
-                        .userId(1L)
-                        .build();
+                Cart.forTest(1L, List.of(cartLineItem1, cartLineItem2));
 
-        freeCart = Cart.builder().cartLineItems(List.of(cartLineItem2)).userId(1L).build();
+        freeCart = Cart.forTest(1L, List.of(cartLineItem2));
     }
 
     @Test
@@ -97,7 +94,7 @@ class CartTest {
         // given
         willDoNothing().given(cartValidator).validCanCreate(any());
         List<CartLineItem> cartLineItems = List.of(cartLineItem1);
-        Cart buildCart = Cart.builder().userId(1L).cartLineItems(cartLineItems).build();
+        Cart buildCart = Cart.forTest(1L, cartLineItems);
         buildCart.updateCartName("장바구니이름");
         // when
         Cart cart = Cart.of(cartLineItems, "장바구니이름", 1L, cartValidator);
@@ -129,7 +126,7 @@ class CartTest {
     @Test
     public void 카트_카트라인_한개조회시_없으면_에러발생() {
         // given
-        Cart emptyLineCart = Cart.builder().cartLineItems(List.of()).build();
+        Cart emptyLineCart = Cart.forTest(null, List.of());
         // when
         // then
         assertThrows(CartLineItemNotFoundException.class, emptyLineCart::getCartLineItem);

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/coupon/domain/CouponCampaignTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/coupon/domain/CouponCampaignTest.java
@@ -23,13 +23,9 @@ public class CouponCampaignTest {
                 new DateTimePeriod(nowTime.minusDays(2), nowTime.minusDays(1));
 
         CouponStockInfo couponStockInfo =
-                CouponStockInfo.builder().issuedAmount(3L).remainingAmount(1L).build();
+                new CouponStockInfo(3L, 1L);
         couponCampaign =
-                CouponCampaign.builder()
-                        .discountType(DiscountType.PERCENTAGE)
-                        .couponStockInfo(couponStockInfo)
-                        .dateTimePeriod(dateTimePeriod)
-                        .build();
+                new CouponCampaign(null, DiscountType.PERCENTAGE, null, null, dateTimePeriod, couponStockInfo, null, null, null);
     }
 
     @Test

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/coupon/domain/CouponStockInfoTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/coupon/domain/CouponStockInfoTest.java
@@ -18,16 +18,16 @@ public class CouponStockInfoTest {
     @BeforeEach
     void setUp() {
         zeroCouponStockInfo =
-                CouponStockInfo.builder().remainingAmount(0L).issuedAmount(3L).build();
+                new CouponStockInfo(3L, 0L);
         leftCouponStockInfo =
-                CouponStockInfo.builder().remainingAmount(1L).issuedAmount(3L).build();
+                new CouponStockInfo(3L, 1L);
     }
 
     @Test
     public void 쿠폰_남은_재고_없음() {
         // given
         zeroCouponStockInfo =
-                CouponStockInfo.builder().remainingAmount(0L).issuedAmount(3L).build();
+                new CouponStockInfo(3L, 0L);
         // when, then
         assertThrows(
                 NoCouponStockLeftException.class, () -> zeroCouponStockInfo.decreaseCouponStock());
@@ -37,7 +37,7 @@ public class CouponStockInfoTest {
     public void 쿠폰_남은_재고_있음() {
         // given
         leftCouponStockInfo =
-                CouponStockInfo.builder().remainingAmount(1L).issuedAmount(3L).build();
+                new CouponStockInfo(3L, 1L);
         // when
         leftCouponStockInfo.decreaseCouponStock();
         // then

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/coupon/domain/IssuedCouponTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/coupon/domain/IssuedCouponTest.java
@@ -26,7 +26,7 @@ class IssuedCouponTest {
 
     @BeforeEach
     void setUp() {
-        issuedCoupon = IssuedCoupon.builder().userId(userId).couponCampaign(couponCampaign).build();
+        issuedCoupon = new IssuedCoupon(couponCampaign, userId);
     }
 
     @Test

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/event/EventTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/event/EventTest.java
@@ -27,7 +27,7 @@ public class EventTest {
 
     @BeforeEach
     void setup() {
-        event = Event.builder().build();
+        event = new Event();
     }
 
     @Test
@@ -56,7 +56,7 @@ public class EventTest {
     void endAt_가져오기_테스트() {
         // given
         final EventBasic eventBasic =
-                EventBasic.builder().startAt(startAt).runTime(runTime).build();
+                new EventBasic(null, startAt, runTime);
         event.updateEventBasic(eventBasic);
         // when
         final LocalDateTime expectedEndAt = startAt.plusMinutes(runTime);
@@ -79,7 +79,7 @@ public class EventTest {
     public void eventBasic_업데이트_테스트() {
         // given
         EventBasic eventBasic =
-                EventBasic.builder().name("test event").startAt(startAt).runTime(runTime).build();
+                new EventBasic("test event", startAt, runTime);
         // when
         event.updateEventBasic(eventBasic);
         // then

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostProfileTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostProfileTest.java
@@ -17,20 +17,14 @@ public class HostProfileTest {
 
     @BeforeEach
     void setup() {
-        hostProfile = HostProfile.builder().build();
+        hostProfile = new HostProfile();
     }
 
     @Test
     void 호스트_프로필_업데이트_테스트() {
         // given
         final HostProfile newHostProfile =
-                HostProfile.builder()
-                        .name("테스트")
-                        .contactEmail("22@cc.com")
-                        .contactNumber("010-0000-0000")
-                        .introduce("123")
-                        .profileImageKey("key")
-                        .build();
+                new HostProfile("테스트", "123", "key", "22@cc.com", "010-0000-0000");
         // when
         hostProfile.updateProfile(newHostProfile);
         // then

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostTest.java
@@ -28,7 +28,7 @@ public class HostTest {
 
     @BeforeEach
     void setup() {
-        host = Host.builder().masterUserId(1L).build();
+        host = new Host(1L, null, null, null, null, null, null);
     }
 
     @Test

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostUserTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/domain/HostUserTest.java
@@ -21,7 +21,7 @@ public class HostUserTest {
 
     @BeforeEach
     void setup() {
-        hostUser = HostUser.builder().host(host).role(MASTER).build();
+        hostUser = new HostUser(host, null, MASTER);
     }
 
     @Test

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/service/HostServiceConcurrencyFailureTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/service/HostServiceConcurrencyFailureTest.java
@@ -38,7 +38,7 @@ public class HostServiceConcurrencyFailureTest {
 
     @BeforeEach
     void setup() {
-        host = Host.builder().build();
+        host = new Host();
         ReflectionTestUtils.setField(host, "id", 1L);
         given(hostUser.getUserId()).willReturn(9L);
         given(hostRepository.save(any(Host.class))).willReturn(host);

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/service/HostServiceConcurrencyTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/host/service/HostServiceConcurrencyTest.java
@@ -36,7 +36,7 @@ public class HostServiceConcurrencyTest {
 
     @BeforeEach
     void setup() {
-        host = Host.builder().build();
+        host = new Host();
         ReflectionTestUtils.setField(host, "id", 1L);
         given(hostUser.getUserId()).willReturn(9L);
         given(hostRepository.save(any(Host.class))).willReturn(host);

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketItemInfoVoTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketItemInfoVoTest.java
@@ -31,37 +31,14 @@ public class IssuedTicketItemInfoVoTest {
     @BeforeEach
     void setUp() {
         itemInfoVo =
-                IssuedTicketItemInfoVo.builder()
-                        .ticketItemId(1L)
-                        .ticketType(ticketType)
-                        .payType(payType)
-                        .ticketName("testTicket")
-                        .price(w3000)
-                        .build();
+                new IssuedTicketItemInfoVo(1L, ticketType, payType, "testTicket", w3000);
     }
 
     @Test
     public void 티켓_아이템_정보를_발급티켓_아이템_인포로_정상적으로_변환_테스트() {
         // given
         TicketItem newTicketItem =
-                TicketItem.builder()
-                        .payType(TicketPayType.DUDOONG_TICKET)
-                        .name("testTicket")
-                        .description("test")
-                        .price(w3000)
-                        .quantity(1L)
-                        .supplyCount(1L)
-                        .purchaseLimit(1L)
-                        .type(ticketType)
-                        .bankName("test")
-                        .accountHolder("test")
-                        .accountNumber("test")
-                        .isQuantityPublic(true)
-                        .isSellable(true)
-                        .saleStartAt(startAt)
-                        .saleEndAt(endAt)
-                        .eventId(1L)
-                        .build();
+                new TicketItem(TicketPayType.DUDOONG_TICKET, "testTicket", "test", w3000, 1L, 1L, 1L, ticketType, "test", "test", "test", true, true, startAt, endAt, 1L);
 
         // when
         IssuedTicketItemInfoVo itemInfoVoForTest = IssuedTicketItemInfoVo.from(newTicketItem);

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketOptionAnswerTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketOptionAnswerTest.java
@@ -32,7 +32,7 @@ public class IssuedTicketOptionAnswerTest {
         given(option.getAdditionalPrice()).willReturn(W3000);
 
         issuedTicketOptionAnswer =
-                IssuedTicketOptionAnswer.builder().optionId(optionId).answer(answer).build();
+                new IssuedTicketOptionAnswer(optionId, Money.ZERO, answer);
     }
 
     @Test
@@ -47,13 +47,7 @@ public class IssuedTicketOptionAnswerTest {
         given(option.getQuestionType()).willReturn(optionGroupType);
 
         OptionAnswerVo optionAnswerVoForTest =
-                OptionAnswerVo.builder()
-                        .answer(answer)
-                        .additionalPrice(W3000)
-                        .optionGroupType(optionGroupType)
-                        .questionDescription(questionDescription)
-                        .questionName(questionName)
-                        .build();
+                new OptionAnswerVo(optionGroupType, questionName, questionDescription, answer, W3000);
 
         OptionAnswerVo optionAnswerVo = issuedTicketOptionAnswer.getOptionAnswerVo(option);
 

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketTest.java
@@ -40,40 +40,13 @@ public class IssuedTicketTest {
     @BeforeEach
     void setUp() {
         issuedTicket =
-                IssuedTicket.builder()
-                        .issuedTicketOptionAnswers(
-                                List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1))
-                        .itemInfo(itemInfoVo)
-                        .userInfo(userInfoVo)
-                        .eventId(1L)
-                        .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
-                        .orderLineId(1L)
-                        .orderUuid(orderUuid)
-                        .build();
+                new IssuedTicket(1L, userInfoVo, orderUuid, 1L, itemInfoVo, IssuedTicketStatus.ENTRANCE_INCOMPLETE, List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1));
 
         canceledIssuedTicket =
-                IssuedTicket.builder()
-                        .issuedTicketOptionAnswers(
-                                List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1))
-                        .itemInfo(itemInfoVo)
-                        .userInfo(userInfoVo)
-                        .eventId(1L)
-                        .issuedTicketStatus(IssuedTicketStatus.CANCELED)
-                        .orderLineId(1L)
-                        .orderUuid(orderUuid)
-                        .build();
+                new IssuedTicket(1L, userInfoVo, orderUuid, 1L, itemInfoVo, IssuedTicketStatus.CANCELED, List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1));
 
         entranceIssuedTicket =
-                IssuedTicket.builder()
-                        .issuedTicketOptionAnswers(
-                                List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1))
-                        .itemInfo(itemInfoVo)
-                        .userInfo(userInfoVo)
-                        .eventId(1L)
-                        .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_COMPLETED)
-                        .orderLineId(1L)
-                        .orderUuid(orderUuid)
-                        .build();
+                new IssuedTicket(1L, userInfoVo, orderUuid, 1L, itemInfoVo, IssuedTicketStatus.ENTRANCE_COMPLETED, List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1));
     }
 
     @Test

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketUserInfoVoTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/domain/IssuedTicketUserInfoVoTest.java
@@ -27,19 +27,9 @@ public class IssuedTicketUserInfoVoTest {
     @BeforeEach
     void setUp() {
         userInfoVo =
-                IssuedTicketUserInfoVo.builder()
-                        .userId(1L)
-                        .userName("test")
-                        .phoneNumber(phoneNumberVo)
-                        .email("test@test.com")
-                        .build();
+                new IssuedTicketUserInfoVo(1L, "test", "test@test.com", phoneNumberVo);
         profile =
-                Profile.builder()
-                        .profileImage("test")
-                        .phoneNumber("010-1234-5678")
-                        .name("test")
-                        .email("test@test.com")
-                        .build();
+                new Profile("test", "test@test.com", "010-1234-5678", "test");
     }
 
     @Test

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainServiceTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/issuedTicket/service/IssuedTicketDomainServiceTest.java
@@ -87,46 +87,19 @@ public class IssuedTicketDomainServiceTest {
         // Todo: orderLineItem 생성
 
         issuedTicket =
-                IssuedTicket.builder()
-                        .issuedTicketOptionAnswers(
-                                List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1))
-                        .itemInfo(itemInfoVo)
-                        .userInfo(userInfoVo)
-                        .eventId(1L)
-                        .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
-                        .orderLineId(1L)
-                        .orderUuid(orderUuid)
-                        .build();
+                new IssuedTicket(1L, userInfoVo, orderUuid, 1L, itemInfoVo, IssuedTicketStatus.ENTRANCE_INCOMPLETE, List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1));
 
         issuedTicket.createUUID();
         issuedTickets.add(issuedTicket);
 
         issuedTicket1 =
-                IssuedTicket.builder()
-                        .issuedTicketOptionAnswers(
-                                List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1))
-                        .itemInfo(itemInfoVo)
-                        .userInfo(userInfoVo)
-                        .eventId(1L)
-                        .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
-                        .orderLineId(1L)
-                        .orderUuid(orderUuid)
-                        .build();
+                new IssuedTicket(1L, userInfoVo, orderUuid, 1L, itemInfoVo, IssuedTicketStatus.ENTRANCE_INCOMPLETE, List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1));
 
         issuedTicket1.createUUID();
         issuedTickets.add(issuedTicket1);
 
         issuedTicket2 =
-                IssuedTicket.builder()
-                        .issuedTicketOptionAnswers(
-                                List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1))
-                        .itemInfo(itemInfoVo1)
-                        .userInfo(userInfoVo)
-                        .eventId(1L)
-                        .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
-                        .orderLineId(1L)
-                        .orderUuid(orderUuid)
-                        .build();
+                new IssuedTicket(1L, userInfoVo, orderUuid, 1L, itemInfoVo1, IssuedTicketStatus.ENTRANCE_INCOMPLETE, List.of(issuedTicketOptionAnswer, issuedTicketOptionAnswer1));
 
         issuedTicket2.createUUID();
 

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/OrderLineItemTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/OrderLineItemTest.java
@@ -35,11 +35,7 @@ class OrderLineItemTest {
     void setUp() {
 
         orderLineItem =
-                OrderLineItem.builder()
-                        .orderOptionAnswer(List.of(orderOptionAnswer1, orderOptionAnswer2))
-                        .quantity(quantity)
-                        .orderItemVo(orderItem)
-                        .build();
+                OrderLineItem.forTest(List.of(orderOptionAnswer1, orderOptionAnswer2), quantity, orderItem);
     }
 
     @Test
@@ -114,11 +110,7 @@ class OrderLineItemTest {
         given(orderItem.getPrice()).willReturn(Money.ZERO);
 
         orderLineItem =
-                OrderLineItem.builder()
-                        .orderOptionAnswer(List.of(orderOptionAnswer1, orderOptionAnswer2))
-                        .quantity(quantity)
-                        .orderItemVo(orderItem)
-                        .build();
+                OrderLineItem.forTest(List.of(orderOptionAnswer1, orderOptionAnswer2), quantity, orderItem);
 
         given(orderOptionAnswer1.getAdditionalPrice()).willReturn(Money.ZERO);
         given(orderOptionAnswer2.getAdditionalPrice()).willReturn(Money.ZERO);

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/OrderOptionAnswerTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/OrderOptionAnswerTest.java
@@ -29,20 +29,15 @@ class OrderOptionAnswerTest {
 
     @BeforeEach
     void setUp() {
-        orderOptionAnswer =
-                OrderOptionAnswer.builder()
-                        .answer(answer)
-                        .optionId(optionId)
-                        .additionalPrice(W3000)
-                        .build();
+        given(cartOptionAnswer.getAnswer()).willReturn(answer);
+        given(cartOptionAnswer.getOptionId()).willReturn(optionId);
+        given(cartOptionAnswer.getAdditionalPrice()).willReturn(W3000);
+        orderOptionAnswer = OrderOptionAnswer.from(cartOptionAnswer);
     }
 
     @Test
     void 주문옵션답변_정적팩터리_생성자_검증() {
-        // given
-        given(cartOptionAnswer.getAnswer()).willReturn(answer);
-        given(cartOptionAnswer.getOptionId()).willReturn(optionId);
-        given(cartOptionAnswer.getAdditionalPrice()).willReturn(W3000);
+        // given - already set up in @BeforeEach
         // when
         OrderOptionAnswer fromFactory = OrderOptionAnswer.from(cartOptionAnswer);
 
@@ -61,13 +56,7 @@ class OrderOptionAnswerTest {
         given(option.getQuestionType()).willReturn(trueFalse);
         given(option.getQuestionName()).willReturn(questionName);
         OptionAnswerVo build =
-                OptionAnswerVo.builder()
-                        .answer(answer)
-                        .optionGroupType(trueFalse)
-                        .questionDescription(questionDescription)
-                        .questionName(questionName)
-                        .additionalPrice(W3000)
-                        .build();
+                new OptionAnswerVo(trueFalse, questionName, questionDescription, answer, W3000);
         // when
         OptionAnswerVo optionAnswerVo = orderOptionAnswer.getOptionAnswerVo(option);
         assertEquals(optionAnswerVo, build);

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/OrderTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/domain/OrderTest.java
@@ -28,21 +28,9 @@ class OrderTest {
     @BeforeEach
     void setUp() {
         notHaveCouponOrder =
-                Order.builder()
-                        .userId(1L)
-                        .orderName("주문이름")
-                        .orderLineItems(List.of(orderLineItem1, orderLineItem2))
-                        .orderStatus(OrderStatus.PENDING_APPROVE)
-                        .orderMethod(OrderMethod.APPROVAL)
-                        .build();
+                Order.forTest(1L, "주문이름", List.of(orderLineItem1, orderLineItem2), OrderStatus.PENDING_APPROVE, OrderMethod.APPROVAL, null);
         couponOrder =
-                Order.builder()
-                        .userId(1L)
-                        .orderName("주문이름")
-                        .orderLineItems(List.of(orderLineItem1, orderLineItem2))
-                        .orderStatus(OrderStatus.PENDING_APPROVE)
-                        .orderMethod(OrderMethod.APPROVAL)
-                        .build();
+                Order.forTest(1L, "주문이름", List.of(orderLineItem1, orderLineItem2), OrderStatus.PENDING_APPROVE, OrderMethod.APPROVAL, null);
         couponOrder.attachCoupon(orderCouponVo);
     }
 

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyFailTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyFailTest.java
@@ -45,12 +45,7 @@ class OrderApproveServiceConcurrencyFailTest {
     void setUp() {
         given(orderLineItem.getTotalOrderLinePrice()).willReturn(Money.ZERO);
         order =
-                Order.builder()
-                        .orderMethod(OrderMethod.APPROVAL)
-                        .orderStatus(OrderStatus.PENDING_APPROVE)
-                        .orderLineItems(List.of(orderLineItem))
-                        .userId(1L)
-                        .build();
+                Order.forTest(1L, null, List.of(orderLineItem), OrderStatus.PENDING_APPROVE, OrderMethod.APPROVAL, null);
         order.addUUID();
         willDoNothing().given(orderValidator).validCanDone(any());
         willDoNothing().given(orderValidator).validUserNotDeleted(any());

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/OrderApproveServiceConcurrencyTest.java
@@ -46,12 +46,7 @@ class OrderApproveServiceConcurrencyTest {
     void setUp() {
         given(orderLineItem.getTotalOrderLinePrice()).willReturn(Money.ZERO);
         order =
-                Order.builder()
-                        .orderMethod(OrderMethod.APPROVAL)
-                        .orderStatus(OrderStatus.PENDING_APPROVE)
-                        .orderLineItems(List.of(orderLineItem))
-                        .userId(1L)
-                        .build();
+                Order.forTest(1L, null, List.of(orderLineItem), OrderStatus.PENDING_APPROVE, OrderMethod.APPROVAL, null);
         order.addUUID();
         willDoNothing().given(orderValidator).validCanDone(any());
         willDoNothing().given(orderValidator).validUserNotDeleted(any());

--- a/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/WithdrawOrderServiceTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domain/domains/order/service/WithdrawOrderServiceTest.java
@@ -41,12 +41,7 @@ class WithdrawOrderServiceTest {
     @BeforeEach
     void setUp() {
         order =
-                Order.builder()
-                        .userId(userId)
-                        .orderStatus(OrderStatus.CONFIRM)
-                        .orderMethod(OrderMethod.PAYMENT)
-                        .orderLineItems(List.of(orderLineItem))
-                        .build();
+                Order.forTest(userId, null, List.of(orderLineItem), OrderStatus.CONFIRM, OrderMethod.PAYMENT, null);
         order.addUUID();
         given(orderAdaptor.findByOrderUuid(any())).willReturn(order);
         given(orderLineItem.getTotalOrderLinePrice()).willReturn(Money.ZERO);

--- a/DuDoong-Domain/src/test/java/band/gosrock/domains/user/domain/OauthInfoTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domains/user/domain/OauthInfoTest.java
@@ -15,7 +15,7 @@ class OauthInfoTest {
         String testOid = "test";
         String withDrawOid = DuDoongStatic.WITHDRAW_PREFIX + testOid;
         OauthInfo oauthInfo =
-                OauthInfo.builder().oid(testOid).provider(OauthProvider.KAKAO).build();
+                new OauthInfo(OauthProvider.KAKAO, testOid);
 
         // when
         OauthInfo withDrawOauthInfo = oauthInfo.withDrawOauthInfo();

--- a/DuDoong-Domain/src/test/java/band/gosrock/domains/user/domain/UserTest.java
+++ b/DuDoong-Domain/src/test/java/band/gosrock/domains/user/domain/UserTest.java
@@ -12,9 +12,9 @@ class UserTest {
     public void 유저프로필변경테스트() {
 
         // given
-        Profile profile = Profile.builder().email("t@naver.com").name("곽팔두").build();
-        User user = User.builder().profile(profile).build();
-        Profile newProfile = Profile.builder().email("a@naver.com").name("홍길동").build();
+        Profile profile = new Profile("곽팔두", "t@naver.com", null, null);
+        User user = new User(profile, null, false);
+        Profile newProfile = new Profile("홍길동", "a@naver.com", null, null);
         // when
         user.changeProfile(newProfile);
         // then

--- a/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/domains/event/EventStatusTransitionTest.kt
+++ b/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/domains/event/EventStatusTransitionTest.kt
@@ -31,18 +31,18 @@ class EventStatusTransitionTest {
 
     @BeforeEach
     fun setUp() {
-        event = Event.builder().build()
+        event = Event()
     }
 
     // ---- hasEventBasic ----
 
     @Test
     fun `name과 startAt과 runTime이 모두 있으면 hasEventBasic이 true다`() {
-        val basic = EventBasic.builder()
-            .name("공연명")
-            .startAt(LocalDateTime.now().plusDays(1))
-            .runTime(90L)
-            .build()
+        val basic = EventBasic(
+            name = "공연명",
+            startAt = LocalDateTime.now().plusDays(1),
+            runTime = 90L,
+        )
         event.updateEventBasic(basic)
         assertTrue(event.hasEventBasic())
     }
@@ -55,10 +55,10 @@ class EventStatusTransitionTest {
 
     @Test
     fun `name이 없으면 hasEventBasic이 false다`() {
-        val basic = EventBasic.builder()
-            .startAt(LocalDateTime.now().plusDays(1))
-            .runTime(90L)
-            .build()
+        val basic = EventBasic(
+            startAt = LocalDateTime.now().plusDays(1),
+            runTime = 90L,
+        )
         event.updateEventBasic(basic)
         assertFalse(event.hasEventBasic())
     }
@@ -67,22 +67,22 @@ class EventStatusTransitionTest {
 
     @Test
     fun `startAt이 미래이면 isTimeBeforeStartAt이 true다`() {
-        val basic = EventBasic.builder()
-            .name("공연명")
-            .startAt(LocalDateTime.now().plusDays(1))
-            .runTime(90L)
-            .build()
+        val basic = EventBasic(
+            name = "공연명",
+            startAt = LocalDateTime.now().plusDays(1),
+            runTime = 90L,
+        )
         event.updateEventBasic(basic)
         assertTrue(event.isTimeBeforeStartAt())
     }
 
     @Test
     fun `startAt이 과거이면 isTimeBeforeStartAt이 false다`() {
-        val basic = EventBasic.builder()
-            .name("공연명")
-            .startAt(LocalDateTime.now().minusMinutes(1))
-            .runTime(90L)
-            .build()
+        val basic = EventBasic(
+            name = "공연명",
+            startAt = LocalDateTime.now().minusMinutes(1),
+            runTime = 90L,
+        )
         event.updateEventBasic(basic)
         assertFalse(event.isTimeBeforeStartAt())
     }
@@ -91,11 +91,11 @@ class EventStatusTransitionTest {
 
     @Test
     fun `startAt이 과거이면 validateTicketingTime이 예외를 던진다`() {
-        val basic = EventBasic.builder()
-            .name("공연명")
-            .startAt(LocalDateTime.now().minusMinutes(1))
-            .runTime(90L)
-            .build()
+        val basic = EventBasic(
+            name = "공연명",
+            startAt = LocalDateTime.now().minusMinutes(1),
+            runTime = 90L,
+        )
         event.updateEventBasic(basic)
         assertThrows(EventTicketingTimeIsPassedException::class.java) {
             event.validateTicketingTime()
@@ -104,11 +104,11 @@ class EventStatusTransitionTest {
 
     @Test
     fun `startAt이 미래이면 validateTicketingTime이 예외를 던지지 않는다`() {
-        val basic = EventBasic.builder()
-            .name("공연명")
-            .startAt(LocalDateTime.now().plusHours(1))
-            .runTime(90L)
-            .build()
+        val basic = EventBasic(
+            name = "공연명",
+            startAt = LocalDateTime.now().plusHours(1),
+            runTime = 90L,
+        )
         event.updateEventBasic(basic)
         event.validateTicketingTime() // no exception
     }
@@ -131,11 +131,11 @@ class EventStatusTransitionTest {
 
     @Test
     fun `미래 startAt이 있는 이벤트는 open 상태로 변경된다`() {
-        val basic = EventBasic.builder()
-            .name("공연명")
-            .startAt(LocalDateTime.now().plusMinutes(10))
-            .runTime(90L)
-            .build()
+        val basic = EventBasic(
+            name = "공연명",
+            startAt = LocalDateTime.now().plusMinutes(10),
+            runTime = 90L,
+        )
         event.updateEventBasic(basic)
         event.open()
         assertEquals(EventStatus.OPEN, event.status)
@@ -143,11 +143,11 @@ class EventStatusTransitionTest {
 
     @Test
     fun `이미 OPEN 상태에서 open을 호출하면 AlreadyOpenStatusException이 발생한다`() {
-        val basic = EventBasic.builder()
-            .name("공연명")
-            .startAt(LocalDateTime.now().plusMinutes(10))
-            .runTime(90L)
-            .build()
+        val basic = EventBasic(
+            name = "공연명",
+            startAt = LocalDateTime.now().plusMinutes(10),
+            runTime = 90L,
+        )
         event.updateEventBasic(basic)
         event.open()
         assertThrows(AlreadyOpenStatusException::class.java) {
@@ -157,11 +157,11 @@ class EventStatusTransitionTest {
 
     @Test
     fun `과거 startAt이 있는 이벤트는 open을 호출하면 EventOpenTimeExpiredException이 발생한다`() {
-        val basic = EventBasic.builder()
-            .name("공연명")
-            .startAt(LocalDateTime.now().minusMinutes(1))
-            .runTime(90L)
-            .build()
+        val basic = EventBasic(
+            name = "공연명",
+            startAt = LocalDateTime.now().minusMinutes(1),
+            runTime = 90L,
+        )
         event.updateEventBasic(basic)
         assertThrows(EventOpenTimeExpiredException::class.java) {
             event.open()
@@ -270,11 +270,11 @@ class EventStatusTransitionTest {
 
     @Test
     fun `eventBasic이 있으면 getEventName이 이름을 반환한다`() {
-        val basic = EventBasic.builder()
-            .name("두둥 공연")
-            .startAt(LocalDateTime.now().plusDays(1))
-            .runTime(60L)
-            .build()
+        val basic = EventBasic(
+            name = "두둥 공연",
+            startAt = LocalDateTime.now().plusDays(1),
+            runTime = 60L,
+        )
         event.updateEventBasic(basic)
         assertEquals("두둥 공연", event.getEventName())
     }

--- a/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/domains/issuedTicket/IssuedTicketStatusTransitionTest.kt
+++ b/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/domains/issuedTicket/IssuedTicketStatusTransitionTest.kt
@@ -33,15 +33,15 @@ class IssuedTicketStatusTransitionTest {
 
     @BeforeEach
     fun setUp() {
-        issuedTicket = IssuedTicket.builder()
-            .eventId(1L)
-            .userInfo(userInfo)
-            .itemInfo(itemInfo)
-            .orderUuid("test-uuid")
-            .orderLineId(10L)
-            .issuedTicketStatus(IssuedTicketStatus.ENTRANCE_INCOMPLETE)
-            .issuedTicketOptionAnswers(emptyList())
-            .build()
+        issuedTicket = IssuedTicket(
+            eventId = 1L,
+            userInfo = userInfo,
+            itemInfo = itemInfo,
+            orderUuid = "test-uuid",
+            orderLineId = 10L,
+            issuedTicketStatus = IssuedTicketStatus.ENTRANCE_INCOMPLETE,
+            initialOptionAnswers = emptyList(),
+        )
     }
 
     // ---- 기본 상태 ----

--- a/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/domains/order/OrderPaymentCalculationTest.kt
+++ b/DuDoong-Domain/src/test/kotlin/band/gosrock/domain/domains/order/OrderPaymentCalculationTest.kt
@@ -33,23 +33,23 @@ class OrderPaymentCalculationTest {
 
     @BeforeEach
     fun setUp() {
-        noCouponOrder = Order.builder()
-            .userId(1L)
-            .orderName("쿠폰없는주문")
-            .orderLineItems(listOf(lineItem1, lineItem2))
-            .orderStatus(OrderStatus.PENDING_PAYMENT)
-            .orderMethod(OrderMethod.PAYMENT)
-            .eventId(100L)
-            .build()
+        noCouponOrder = Order.forTest(
+            userId = 1L,
+            orderName = "쿠폰없는주문",
+            orderLineItems = listOf(lineItem1, lineItem2),
+            orderStatus = OrderStatus.PENDING_PAYMENT,
+            orderMethod = OrderMethod.PAYMENT,
+            eventId = 100L,
+        )
 
-        couponOrder = Order.builder()
-            .userId(1L)
-            .orderName("쿠폰있는주문")
-            .orderLineItems(listOf(lineItem1, lineItem2))
-            .orderStatus(OrderStatus.PENDING_PAYMENT)
-            .orderMethod(OrderMethod.PAYMENT)
-            .eventId(100L)
-            .build()
+        couponOrder = Order.forTest(
+            userId = 1L,
+            orderName = "쿠폰있는주문",
+            orderLineItems = listOf(lineItem1, lineItem2),
+            orderStatus = OrderStatus.PENDING_PAYMENT,
+            orderMethod = OrderMethod.PAYMENT,
+            eventId = 100L,
+        )
         couponOrder.attachCoupon(orderCouponVo)
     }
 
@@ -150,14 +150,14 @@ class OrderPaymentCalculationTest {
 
     @Test
     fun `결제금액이 0원이고 APPROVAL 방식이면 isDudoongTicketOrder가 false다`() {
-        val approvalOrder = Order.builder()
-            .userId(1L)
-            .orderName("승인주문")
-            .orderLineItems(listOf(lineItem1, lineItem2))
-            .orderStatus(OrderStatus.PENDING_APPROVE)
-            .orderMethod(OrderMethod.APPROVAL)
-            .eventId(100L)
-            .build()
+        val approvalOrder = Order.forTest(
+            userId = 1L,
+            orderName = "승인주문",
+            orderLineItems = listOf(lineItem1, lineItem2),
+            orderStatus = OrderStatus.PENDING_APPROVE,
+            orderMethod = OrderMethod.APPROVAL,
+            eventId = 100L,
+        )
 
         given(lineItem1.getTotalOrderLinePrice()).willReturn(Money.ZERO)
         given(lineItem2.getTotalOrderLinePrice()).willReturn(Money.ZERO)

--- a/DuDoong-Infrastructure/src/main/kotlin/band/gosrock/infrastructure/config/ses/RawEmailAttachmentDto.kt
+++ b/DuDoong-Infrastructure/src/main/kotlin/band/gosrock/infrastructure/config/ses/RawEmailAttachmentDto.kt
@@ -11,20 +11,4 @@ class RawEmailAttachmentDto(
     val fileBytes: ByteArray,
     /** 사용자가 이메일을 받았을 때 뜰 첨부파일이름. ex : 이벤트_정산서.pdf */
     val fileName: String,
-) {
-    class Builder {
-        private var type: String = ""
-        private var fileBytes: ByteArray = byteArrayOf()
-        private var fileName: String = ""
-
-        fun type(type: String) = apply { this.type = type }
-        fun fileBytes(fileBytes: ByteArray) = apply { this.fileBytes = fileBytes }
-        fun fileName(fileName: String) = apply { this.fileName = fileName }
-        fun build() = RawEmailAttachmentDto(type, fileBytes, fileName)
-    }
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
-}
+)

--- a/DuDoong-Infrastructure/src/main/kotlin/band/gosrock/infrastructure/config/ses/SendRawEmailDto.kt
+++ b/DuDoong-Infrastructure/src/main/kotlin/band/gosrock/infrastructure/config/ses/SendRawEmailDto.kt
@@ -12,20 +12,4 @@ class SendRawEmailDto(
     fun addEmailAttachments(rawEmailAttachment: RawEmailAttachmentDto) {
         rawEmailAttachments.add(rawEmailAttachment)
     }
-
-    class Builder {
-        private var recipient: String = ""
-        private var subject: String = ""
-        private var bodyHtml: String = ""
-
-        fun recipient(recipient: String) = apply { this.recipient = recipient }
-        fun subject(subject: String) = apply { this.subject = subject }
-        fun bodyHtml(bodyHtml: String) = apply { this.bodyHtml = bodyHtml }
-        fun build() = SendRawEmailDto(recipient, subject, bodyHtml)
-    }
-
-    companion object {
-        @JvmStatic
-        fun builder() = Builder()
-    }
 }

--- a/DuDoong-Infrastructure/src/main/kotlin/band/gosrock/infrastructure/outer/api/tossPayments/dto/request/CancelPaymentsRequest.kt
+++ b/DuDoong-Infrastructure/src/main/kotlin/band/gosrock/infrastructure/outer/api/tossPayments/dto/request/CancelPaymentsRequest.kt
@@ -1,14 +1,4 @@
 package band.gosrock.infrastructure.outer.api.tossPayments.dto.request
 
 // 부분 취소 안합니다. 전체 금액 취소입니다.
-data class CancelPaymentsRequest(val cancelReason: String? = null) {
-    class Builder {
-        private var cancelReason: String? = null
-        fun cancelReason(v: String?) = apply { cancelReason = v }
-        fun build() = CancelPaymentsRequest(cancelReason)
-    }
-
-    companion object {
-        @JvmStatic fun builder() = Builder()
-    }
-}
+data class CancelPaymentsRequest(val cancelReason: String? = null)

--- a/DuDoong-Infrastructure/src/main/kotlin/band/gosrock/infrastructure/outer/api/tossPayments/dto/request/ConfirmPaymentsRequest.kt
+++ b/DuDoong-Infrastructure/src/main/kotlin/band/gosrock/infrastructure/outer/api/tossPayments/dto/request/ConfirmPaymentsRequest.kt
@@ -4,18 +4,4 @@ data class ConfirmPaymentsRequest(
     val paymentKey: String? = null,
     val orderId: String? = null,
     val amount: Long? = null,
-) {
-    class Builder {
-        private var paymentKey: String? = null
-        private var orderId: String? = null
-        private var amount: Long? = null
-        fun paymentKey(v: String?) = apply { paymentKey = v }
-        fun orderId(v: String?) = apply { orderId = v }
-        fun amount(v: Long?) = apply { amount = v }
-        fun build() = ConfirmPaymentsRequest(paymentKey, orderId, amount)
-    }
-
-    companion object {
-        @JvmStatic fun builder() = Builder()
-    }
-}
+)

--- a/DuDoong-Infrastructure/src/main/kotlin/band/gosrock/infrastructure/outer/api/tossPayments/dto/request/CreatePaymentsRequest.kt
+++ b/DuDoong-Infrastructure/src/main/kotlin/band/gosrock/infrastructure/outer/api/tossPayments/dto/request/CreatePaymentsRequest.kt
@@ -7,24 +7,4 @@ data class CreatePaymentsRequest(
     val orderName: String? = null,
     val successUrl: String? = null,
     val failUrl: String? = null,
-) {
-    class Builder {
-        private var method: String? = null
-        private var amount: Long? = null
-        private var orderId: String? = null
-        private var orderName: String? = null
-        private var successUrl: String? = null
-        private var failUrl: String? = null
-        fun method(v: String?) = apply { method = v }
-        fun amount(v: Long?) = apply { amount = v }
-        fun orderId(v: String?) = apply { orderId = v }
-        fun orderName(v: String?) = apply { orderName = v }
-        fun successUrl(v: String?) = apply { successUrl = v }
-        fun failUrl(v: String?) = apply { failUrl = v }
-        fun build() = CreatePaymentsRequest(method, amount, orderId, orderName, successUrl, failUrl)
-    }
-
-    companion object {
-        @JvmStatic fun builder() = Builder()
-    }
-}
+)

--- a/DuDoong-Infrastructure/src/test/java/band/gosrock/infrastructure/outer/api/tossPayments/client/PaymentsCancelClientTest.java
+++ b/DuDoong-Infrastructure/src/test/java/band/gosrock/infrastructure/outer/api/tossPayments/client/PaymentsCancelClientTest.java
@@ -33,7 +33,7 @@ class PaymentsCancelClientTest {
     private static final String IDEMPOTENCY_KEY = "idempotency-key";
     private static final String PAYMENT_KEY = "1234";
     private static final CancelPaymentsRequest REQUEST =
-            CancelPaymentsRequest.builder().cancelReason("test").build();
+            new CancelPaymentsRequest("test");
     @Autowired private PaymentsCancelClient paymentsCancelClient;
 
     @Test


### PR DESCRIPTION
## Summary

103파일, +656 -2011 lines (**1355줄 삭제**)

### 보조 생성자 제거 (21개 클래스)
- `constructor(...) : this() { this.x = x }` → 주생성자 기본값
- JPA noArg 플러그인이 기본 생성자 자동 생성
- 대상: Domain VO, Embeddable, Entity 전체

### Builder 패턴 제거 (35+ 클래스)
- `companion fun builder()` + `inner class Builder` 제거
- 호출부: `.builder().field(value).build()` → `ClassName(field = value)`
- Domain 이벤트 6개, VO 5개, 엔티티 20+개, Infrastructure DTO 5개

### Java 테스트 업데이트
- 26+ Java 테스트에서 `.builder()` → 직접 생성자 또는 `forTest()`
- `Order`, `OrderLineItem`, `Cart`에 `forTest()` 팩토리 메서드 추가 (Java에서 Kotlin default params 사용 불가)

### 제외 (외부 라이브러리)
- Slack SDK `MarkdownTextObject.builder()` — 유지
- JJWT `Jwts.builder()` — 유지
- QueryDSL `PathBuilder` — 유지

### 테스트
- [x] 유닛 테스트 251 passed
- [x] E2E 148 passed, 4 skipped, 0 failed

## 관련 이슈

close #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)