### PR TITLE
feat: 어드민 API 응답 필드 보강

### DIFF
--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/model/dto/response/AdminCommentResponse.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/model/dto/response/AdminCommentResponse.kt
@@ -11,6 +11,8 @@ data class AdminCommentResponse(
     val content: String?,
     val commentStatus: CommentStatus?,
     val createdAt: LocalDateTime?,
+    val userId: Long?,
+    val eventId: Long?,
 ) {
     companion object {
         fun of(comment: Comment, eventName: String?): AdminCommentResponse =
@@ -21,6 +23,8 @@ data class AdminCommentResponse(
                 content = comment.content,
                 commentStatus = comment.commentStatus,
                 createdAt = comment.createdAt,
+                userId = comment.user?.id,
+                eventId = comment.eventId,
             )
     }
 }

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/model/dto/response/AdminEventResponse.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/model/dto/response/AdminEventResponse.kt
@@ -18,6 +18,10 @@ data class AdminEventResponse(
     val content: String? = null,
     val placeName: String? = null,
     val placeAddress: String? = null,
+    val hostId: Long? = null,
+    val posterImageKey: String? = null,
+    val latitude: Double? = null,
+    val longitude: Double? = null,
 ) {
     companion object {
         fun of(event: Event, hostName: String?): AdminEventResponse =
@@ -29,6 +33,10 @@ data class AdminEventResponse(
                 startAt = event.eventBasic?.startAt,
                 runTime = event.eventBasic?.runTime,
                 createdAt = event.createdAt,
+                hostId = event.hostId,
+                posterImageKey = event.eventDetail?.posterImage?.imageKey,
+                latitude = event.eventPlace?.latitude,
+                longitude = event.eventPlace?.longitude,
             )
 
         fun ofDetail(
@@ -52,6 +60,10 @@ data class AdminEventResponse(
                 content = event.eventDetail?.content,
                 placeName = event.eventPlace?.placeName,
                 placeAddress = event.eventPlace?.placeAddress,
+                hostId = event.hostId,
+                posterImageKey = event.eventDetail?.posterImage?.imageKey,
+                latitude = event.eventPlace?.latitude,
+                longitude = event.eventPlace?.longitude,
             )
     }
 }

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/model/dto/response/AdminHostDetailResponse.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/model/dto/response/AdminHostDetailResponse.kt
@@ -14,6 +14,7 @@ data class AdminHostDetailResponse(
     val masterUserId: Long?,
     val createdAt: LocalDateTime?,
     val memberCount: Int,
+    val slackUrl: String?,
 ) {
     companion object {
         fun from(host: Host): AdminHostDetailResponse =
@@ -28,6 +29,7 @@ data class AdminHostDetailResponse(
                 masterUserId = host.masterUserId,
                 createdAt = host.createdAt,
                 memberCount = host.hostUsers.size,
+                slackUrl = host.slackUrl,
             )
     }
 }

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/model/dto/response/AdminOrderResponse.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/model/dto/response/AdminOrderResponse.kt
@@ -12,6 +12,17 @@ data class AdminOrderResponse(
     val totalAmount: Long,
     val orderStatus: OrderStatus,
     val createdAt: LocalDateTime?,
+    val orderNo: String?,
+    val orderMethod: String?,
+    val userId: Long?,
+    val eventId: Long?,
+    val approvedAt: LocalDateTime?,
+    val withDrawAt: LocalDateTime?,
+    val paymentMethod: String?,
+    val receiptUrl: String?,
+    val supplyAmount: String?,
+    val discountAmount: String?,
+    val couponName: String?,
 ) {
     companion object {
         fun of(order: Order, userName: String?, eventName: String?): AdminOrderResponse =
@@ -23,6 +34,17 @@ data class AdminOrderResponse(
                 totalAmount = order.getTotalPaymentPrice().longValue(),
                 orderStatus = order.orderStatus,
                 createdAt = order.createdAt,
+                orderNo = order.orderNo,
+                orderMethod = order.orderMethod?.name,
+                userId = order.userId,
+                eventId = order.eventId,
+                approvedAt = order.approvedAt,
+                withDrawAt = order.withDrawAt,
+                paymentMethod = order.pgPaymentInfo.paymentMethod.name,
+                receiptUrl = order.pgPaymentInfo.receiptUrl,
+                supplyAmount = order.totalPaymentInfo?.supplyAmount?.toString(),
+                discountAmount = order.totalPaymentInfo?.discountAmount?.toString(),
+                couponName = order.orderCouponVo.name,
             )
     }
 }

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/model/dto/response/AdminUserDetailResponse.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/model/dto/response/AdminUserDetailResponse.kt
@@ -17,6 +17,8 @@ data class AdminUserDetailResponse(
     val phoneNumber: String?,
     val marketingAgree: Boolean,
     val oauthProvider: OauthProvider?,
+    val lastLoginAt: LocalDateTime?,
+    val receiveMail: Boolean,
 ) {
     companion object {
         fun from(user: User): AdminUserDetailResponse =
@@ -31,6 +33,8 @@ data class AdminUserDetailResponse(
                 phoneNumber = user.profile?.phoneNumberVo?.phoneNumber,
                 marketingAgree = user.marketingAgree,
                 oauthProvider = user.oauthInfo?.provider,
+                lastLoginAt = user.lastLoginAt,
+                receiveMail = user.receiveMail,
             )
     }
 }


### PR DESCRIPTION
## Summary

5개 Admin DTO에 총 20개 필드 추가.

| DTO | 추가 필드 |
|-----|----------|
| AdminUserDetailResponse | `lastLoginAt`, `receiveMail` |
| AdminHostDetailResponse | `slackUrl` |
| AdminOrderResponse | `orderNo`, `orderMethod`, `userId`, `eventId`, `approvedAt`, `withDrawAt`, `paymentMethod`, `receiptUrl`, `supplyAmount`, `discountAmount`, `couponName` (11개) |
| AdminEventResponse | `hostId`, `posterImageKey`, `latitude`, `longitude` |
| AdminCommentResponse | `userId`, `eventId` |

### 테스트
- [x] 유닛 테스트 통과
- [x] E2E 148 passed, 4 skipped

## 관련 이슈

close #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)