### PR TITLE
feat: 어드민 엑셀 다운로드 고도화 (주문 상세 + 발급 티켓 옵션)

### DIFF
--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminEventController.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminEventController.kt
@@ -10,6 +10,7 @@ import band.gosrock.admin.model.dto.response.AdminTicketItemResponse
 import band.gosrock.admin.service.AdminAdjustTicketStockUseCase
 import band.gosrock.admin.service.AdminDeleteEventUseCase
 import band.gosrock.admin.service.AdminExcelService
+import band.gosrock.admin.service.AdminExportIssuedTicketsUseCase
 import band.gosrock.admin.service.AdminGetEventDetailUseCase
 import band.gosrock.admin.service.AdminGetEventsUseCase
 import band.gosrock.admin.service.AdminGetIssuedTicketsUseCase
@@ -51,6 +52,7 @@ class AdminEventController(
     private val adminUpdateEventUseCase: AdminUpdateEventUseCase,
     private val adminGetIssuedTicketsUseCase: AdminGetIssuedTicketsUseCase,
     private val adminExcelService: AdminExcelService,
+    private val adminExportIssuedTicketsUseCase: AdminExportIssuedTicketsUseCase,
     private val adminGetTicketItemsUseCase: AdminGetTicketItemsUseCase,
     private val adminUpdateTicketItemUseCase: AdminUpdateTicketItemUseCase,
     private val adminAdjustTicketStockUseCase: AdminAdjustTicketStockUseCase,
@@ -143,11 +145,10 @@ class AdminEventController(
             .body(bytes)
     }
 
-    @Operation(summary = "이벤트별 발급 티켓 목록을 엑셀로 다운로드합니다.")
+    @Operation(summary = "이벤트별 발급 티켓 목록을 엑셀로 다운로드합니다. (옵션 응답 동적 컬럼 포함)")
     @GetMapping("/{eventId}/issued-tickets/export")
     fun exportIssuedTickets(@CurrentUserId userId: Long, @PathVariable eventId: Long): ResponseEntity<ByteArray> {
-        val tickets = adminGetIssuedTicketsUseCase.executeAll(userId, eventId)
-        val bytes = adminExcelService.generateIssuedTicketsExcel(tickets)
+        val bytes = adminExportIssuedTicketsUseCase.execute(userId, eventId)
         return ResponseEntity.ok()
             .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=issued-tickets-${eventId}.xlsx")
             .contentType(MediaType.APPLICATION_OCTET_STREAM)

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/service/AdminExcelService.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/service/AdminExcelService.kt
@@ -5,6 +5,8 @@ import band.gosrock.admin.model.dto.response.AdminIssuedTicketResponse
 import band.gosrock.admin.model.dto.response.AdminOrderResponse
 import band.gosrock.admin.model.dto.response.AdminTicketItemResponse
 import band.gosrock.admin.model.dto.response.AdminUserResponse
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket
+import band.gosrock.domain.domains.ticket_item.domain.Option
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.springframework.stereotype.Service
 import java.io.ByteArrayOutputStream
@@ -16,18 +18,28 @@ class AdminExcelService {
         val workbook = XSSFWorkbook()
         val sheet = workbook.createSheet("주문 목록")
         val headerRow = sheet.createRow(0)
-        listOf("주문번호", "사용자", "이벤트", "티켓", "금액", "상태", "주문일").forEachIndexed { i, h ->
-            headerRow.createCell(i).setCellValue(h)
-        }
+        val headers = listOf(
+            "주문번호", "주문번호(읽기용)", "사용자", "이벤트", "티켓", "금액", "상태",
+            "주문방식", "결제수단", "승인일시", "취소일시", "할인금액", "쿠폰명", "주문일",
+        )
+        headers.forEachIndexed { i, h -> headerRow.createCell(i).setCellValue(h) }
         orders.forEachIndexed { idx, order ->
             val row = sheet.createRow(idx + 1)
-            row.createCell(0).setCellValue(order.orderId ?: "")
-            row.createCell(1).setCellValue(order.userName ?: "")
-            row.createCell(2).setCellValue(order.eventName ?: "")
-            row.createCell(3).setCellValue(order.ticketName ?: "")
-            row.createCell(4).setCellValue(order.totalAmount.toDouble())
-            row.createCell(5).setCellValue(order.orderStatus.toString())
-            row.createCell(6).setCellValue(order.createdAt?.toString() ?: "")
+            var col = 0
+            row.createCell(col++).setCellValue(order.orderId ?: "")
+            row.createCell(col++).setCellValue(order.orderNo ?: "")
+            row.createCell(col++).setCellValue(order.userName ?: "")
+            row.createCell(col++).setCellValue(order.eventName ?: "")
+            row.createCell(col++).setCellValue(order.ticketName ?: "")
+            row.createCell(col++).setCellValue(order.totalAmount.toDouble())
+            row.createCell(col++).setCellValue(order.orderStatus.toString())
+            row.createCell(col++).setCellValue(order.orderMethod ?: "")
+            row.createCell(col++).setCellValue(order.paymentMethod ?: "")
+            row.createCell(col++).setCellValue(order.approvedAt?.toString() ?: "")
+            row.createCell(col++).setCellValue(order.withDrawAt?.toString() ?: "")
+            row.createCell(col++).setCellValue(order.discountAmount ?: "")
+            row.createCell(col++).setCellValue(order.couponName ?: "")
+            row.createCell(col++).setCellValue(order.createdAt?.toString() ?: "")
         }
         return toByteArray(workbook)
     }
@@ -93,20 +105,58 @@ class AdminExcelService {
     }
 
     fun generateIssuedTicketsExcel(tickets: List<AdminIssuedTicketResponse>): ByteArray {
+        return generateIssuedTicketsExcelWithOptions(tickets, emptyList(), emptyList())
+    }
+
+    /**
+     * 발급 티켓 엑셀에 옵션 응답을 동적 컬럼으로 포함하여 생성합니다.
+     *
+     * @param tickets 발급 티켓 응답 목록
+     * @param options 이벤트에 등록된 옵션 목록 (동적 컬럼 헤더용)
+     * @param issuedTickets 발급 티켓 엔티티 목록 (옵션 응답 데이터 접근용)
+     */
+    fun generateIssuedTicketsExcelWithOptions(
+        tickets: List<AdminIssuedTicketResponse>,
+        options: List<Option>,
+        issuedTickets: List<IssuedTicket>,
+    ): ByteArray {
         val workbook = XSSFWorkbook()
         val sheet = workbook.createSheet("발급 티켓 목록")
         val headerRow = sheet.createRow(0)
-        listOf("티켓번호", "유저명", "티켓종류", "주문번호", "입장여부", "발급일").forEachIndexed { i, h ->
-            headerRow.createCell(i).setCellValue(h)
+
+        // 기본 헤더
+        val baseHeaders = listOf("티켓번호", "유저명", "티켓종류", "주문번호", "입장여부", "발급일")
+        baseHeaders.forEachIndexed { i, h -> headerRow.createCell(i).setCellValue(h) }
+
+        // 옵션 동적 헤더
+        val optionHeaders = options.map { it.getQuestionName() ?: "옵션(${it.id})" }
+        optionHeaders.forEachIndexed { i, h ->
+            headerRow.createCell(baseHeaders.size + i).setCellValue(h)
         }
+
+        // IssuedTicket id -> IssuedTicket 맵 (옵션 응답 조회용)
+        val ticketEntityMap = issuedTickets.associateBy { it.id }
+
         tickets.forEachIndexed { idx, ticket ->
             val row = sheet.createRow(idx + 1)
-            row.createCell(0).setCellValue(ticket.issuedTicketNo ?: "")
-            row.createCell(1).setCellValue(ticket.userName ?: "")
-            row.createCell(2).setCellValue(ticket.ticketName ?: "")
-            row.createCell(3).setCellValue(ticket.orderUuid ?: "")
-            row.createCell(4).setCellValue(if (ticket.enteredAt != null) "입장" else "미입장")
-            row.createCell(5).setCellValue(ticket.createdAt?.toString() ?: "")
+            var col = 0
+            row.createCell(col++).setCellValue(ticket.issuedTicketNo ?: "")
+            row.createCell(col++).setCellValue(ticket.userName ?: "")
+            row.createCell(col++).setCellValue(ticket.ticketName ?: "")
+            row.createCell(col++).setCellValue(ticket.orderUuid ?: "")
+            row.createCell(col++).setCellValue(if (ticket.enteredAt != null) "입장" else "미입장")
+            row.createCell(col++).setCellValue(ticket.createdAt?.toString() ?: "")
+
+            // 옵션 응답 채우기
+            if (options.isNotEmpty()) {
+                val entity = ticketEntityMap[ticket.id]
+                val answerMap = entity?.issuedTicketOptionAnswers
+                    ?.associateBy { it.optionId } ?: emptyMap()
+                options.forEach { option ->
+                    val answer = answerMap[option.id]?.answer ?: ""
+                    row.createCell(col++).setCellValue(answer)
+                }
+            }
         }
         return toByteArray(workbook)
     }

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/service/AdminExportIssuedTicketsUseCase.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/service/AdminExportIssuedTicketsUseCase.kt
@@ -1,0 +1,38 @@
+package band.gosrock.admin.service
+
+import band.gosrock.common.annotation.UseCase
+import band.gosrock.domain.domains.issuedTicket.repository.IssuedTicketRepository
+import band.gosrock.domain.domains.ticket_item.adaptor.OptionGroupAdaptor
+import band.gosrock.domain.domains.ticket_item.domain.Option
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+@Transactional(readOnly = true)
+class AdminExportIssuedTicketsUseCase(
+    private val issuedTicketRepository: IssuedTicketRepository,
+    private val optionGroupAdaptor: OptionGroupAdaptor,
+    private val adminExcelService: AdminExcelService,
+    private val adminAuthValidator: AdminAuthValidator,
+    private val adminGetIssuedTicketsUseCase: AdminGetIssuedTicketsUseCase,
+) {
+
+    fun execute(userId: Long, eventId: Long): ByteArray {
+        adminAuthValidator.validateAdminOrAbove(userId)
+
+        // 발급 티켓 엔티티 조회
+        val issuedTickets = issuedTicketRepository.findAllByEventId(eventId)
+
+        // 발급 티켓 응답 DTO 변환
+        val ticketResponses = adminGetIssuedTicketsUseCase.executeAll(userId, eventId)
+
+        // 이벤트의 옵션 그룹 → 옵션 목록 조회
+        val optionGroups = optionGroupAdaptor.findAllByEventId(eventId)
+        val options: List<Option> = optionGroups.flatMap { it.options }
+
+        return adminExcelService.generateIssuedTicketsExcelWithOptions(
+            tickets = ticketResponses,
+            options = options,
+            issuedTickets = issuedTickets,
+        )
+    }
+}

--- a/DuDoong-Admin/src/test/kotlin/band/gosrock/admin/service/AdminExcelServiceTest.kt
+++ b/DuDoong-Admin/src/test/kotlin/band/gosrock/admin/service/AdminExcelServiceTest.kt
@@ -1,0 +1,276 @@
+package band.gosrock.admin.service
+
+import band.gosrock.admin.model.dto.response.AdminIssuedTicketResponse
+import band.gosrock.admin.model.dto.response.AdminOrderResponse
+import band.gosrock.domain.common.vo.Money
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicket
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketOptionAnswer
+import band.gosrock.domain.domains.issuedTicket.domain.IssuedTicketStatus
+import band.gosrock.domain.domains.order.domain.OrderStatus
+import band.gosrock.domain.domains.ticket_item.domain.Option
+import band.gosrock.domain.domains.ticket_item.domain.OptionGroup
+import band.gosrock.domain.domains.ticket_item.domain.OptionGroupType
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.util.ReflectionTestUtils
+import java.io.ByteArrayInputStream
+import java.time.LocalDateTime
+
+@DisplayName("AdminExcelService")
+class AdminExcelServiceTest {
+
+    private lateinit var adminExcelService: AdminExcelService
+
+    @BeforeEach
+    fun setUp() {
+        adminExcelService = AdminExcelService()
+    }
+
+    @Nested
+    @DisplayName("generateOrdersExcel")
+    inner class GenerateOrdersExcelTest {
+
+        @Test
+        @DisplayName("주문 엑셀 헤더 컬럼이 올바르게 생성된다")
+        fun headerColumnsAreCorrect() {
+            val bytes = adminExcelService.generateOrdersExcel(emptyList())
+            val workbook = XSSFWorkbook(ByteArrayInputStream(bytes))
+            val sheet = workbook.getSheetAt(0)
+            val headerRow = sheet.getRow(0)
+
+            val expectedHeaders = listOf(
+                "주문번호", "주문번호(읽기용)", "사용자", "이벤트", "티켓", "금액", "상태",
+                "주문방식", "결제수단", "승인일시", "취소일시", "할인금액", "쿠폰명", "주문일",
+            )
+            expectedHeaders.forEachIndexed { i, expected ->
+                assertEquals(expected, headerRow.getCell(i).stringCellValue, "헤더[$i]")
+            }
+            assertEquals(expectedHeaders.size, headerRow.lastCellNum.toInt())
+            workbook.close()
+        }
+
+        @Test
+        @DisplayName("주문 데이터 행이 올바르게 생성된다")
+        fun dataRowsAreCorrect() {
+            val now = LocalDateTime.of(2026, 3, 22, 10, 0)
+            val orders = listOf(
+                AdminOrderResponse(
+                    orderId = "uuid-1",
+                    orderNo = "R100001",
+                    userName = "테스트유저",
+                    eventName = "테스트이벤트",
+                    ticketName = "일반 티켓",
+                    totalAmount = 10000L,
+                    orderStatus = OrderStatus.CONFIRM,
+                    createdAt = now,
+                    orderMethod = "PAYMENT",
+                    userId = 1L,
+                    eventId = 1L,
+                    approvedAt = now.plusMinutes(5),
+                    withDrawAt = null,
+                    paymentMethod = "CARD",
+                    receiptUrl = "https://example.com/receipt",
+                    supplyAmount = "10000",
+                    discountAmount = "1000",
+                    couponName = "첫주문쿠폰",
+                ),
+            )
+
+            val bytes = adminExcelService.generateOrdersExcel(orders)
+            val workbook = XSSFWorkbook(ByteArrayInputStream(bytes))
+            val sheet = workbook.getSheetAt(0)
+            val dataRow = sheet.getRow(1)
+
+            assertEquals("uuid-1", dataRow.getCell(0).stringCellValue)
+            assertEquals("R100001", dataRow.getCell(1).stringCellValue)
+            assertEquals("테스트유저", dataRow.getCell(2).stringCellValue)
+            assertEquals("테스트이벤트", dataRow.getCell(3).stringCellValue)
+            assertEquals("일반 티켓", dataRow.getCell(4).stringCellValue)
+            assertEquals(10000.0, dataRow.getCell(5).numericCellValue)
+            assertEquals("CONFIRM", dataRow.getCell(6).stringCellValue)
+            assertEquals("PAYMENT", dataRow.getCell(7).stringCellValue)
+            assertEquals("CARD", dataRow.getCell(8).stringCellValue)
+            assertEquals(now.plusMinutes(5).toString(), dataRow.getCell(9).stringCellValue)
+            assertEquals("", dataRow.getCell(10).stringCellValue) // withDrawAt null
+            assertEquals("1000", dataRow.getCell(11).stringCellValue)
+            assertEquals("첫주문쿠폰", dataRow.getCell(12).stringCellValue)
+            assertEquals(now.toString(), dataRow.getCell(13).stringCellValue)
+            workbook.close()
+        }
+    }
+
+    @Nested
+    @DisplayName("generateIssuedTicketsExcel")
+    inner class GenerateIssuedTicketsExcelTest {
+
+        @Test
+        @DisplayName("기본 발급 티켓 엑셀 헤더가 올바르게 생성된다")
+        fun basicHeaderColumnsAreCorrect() {
+            val bytes = adminExcelService.generateIssuedTicketsExcel(emptyList())
+            val workbook = XSSFWorkbook(ByteArrayInputStream(bytes))
+            val sheet = workbook.getSheetAt(0)
+            val headerRow = sheet.getRow(0)
+
+            val expectedHeaders = listOf("티켓번호", "유저명", "티켓종류", "주문번호", "입장여부", "발급일")
+            expectedHeaders.forEachIndexed { i, expected ->
+                assertEquals(expected, headerRow.getCell(i).stringCellValue, "헤더[$i]")
+            }
+            assertEquals(expectedHeaders.size, headerRow.lastCellNum.toInt())
+            workbook.close()
+        }
+    }
+
+    @Nested
+    @DisplayName("generateIssuedTicketsExcelWithOptions")
+    inner class GenerateIssuedTicketsExcelWithOptionsTest {
+
+        @Test
+        @DisplayName("옵션 동적 컬럼이 헤더에 추가된다")
+        fun optionDynamicHeadersAreAdded() {
+            val optionGroup = createOptionGroup(1L, "이름 수집용", OptionGroupType.SUBJECTIVE)
+            val option1 = createOption(10L, "참석자 이름", optionGroup)
+            val option2 = createOption(11L, "연락처", optionGroup)
+
+            val bytes = adminExcelService.generateIssuedTicketsExcelWithOptions(
+                tickets = emptyList(),
+                options = listOf(option1, option2),
+                issuedTickets = emptyList(),
+            )
+            val workbook = XSSFWorkbook(ByteArrayInputStream(bytes))
+            val sheet = workbook.getSheetAt(0)
+            val headerRow = sheet.getRow(0)
+
+            // 기본 6 컬럼 + 옵션 2 컬럼
+            assertEquals(8, headerRow.lastCellNum.toInt())
+            assertEquals("참석자 이름", headerRow.getCell(6).stringCellValue)
+            assertEquals("연락처", headerRow.getCell(7).stringCellValue)
+            workbook.close()
+        }
+
+        @Test
+        @DisplayName("옵션 응답이 올바르게 매핑된다")
+        fun optionAnswersAreMapped() {
+            val optionGroup = createOptionGroup(1L, "참석자 정보", OptionGroupType.SUBJECTIVE)
+            val option1 = createOption(10L, "참석자 이름", optionGroup)
+            val option2 = createOption(11L, "연락처", optionGroup)
+
+            val now = LocalDateTime.of(2026, 3, 22, 10, 0)
+
+            // IssuedTicket 엔티티 생성 (옵션 응답 포함)
+            val answer1 = IssuedTicketOptionAnswer(optionId = 10L, answer = "홍길동")
+            val answer2 = IssuedTicketOptionAnswer(optionId = 11L, answer = "010-1234-5678")
+            val issuedTicket = createIssuedTicket(100L, listOf(answer1, answer2))
+
+            val ticketResponse = AdminIssuedTicketResponse(
+                id = 100L,
+                issuedTicketNo = "T100001",
+                userName = "테스트유저",
+                ticketName = "일반 티켓",
+                orderUuid = "order-uuid-1",
+                enteredAt = null,
+                status = IssuedTicketStatus.ENTRANCE_INCOMPLETE,
+                createdAt = now,
+            )
+
+            val bytes = adminExcelService.generateIssuedTicketsExcelWithOptions(
+                tickets = listOf(ticketResponse),
+                options = listOf(option1, option2),
+                issuedTickets = listOf(issuedTicket),
+            )
+            val workbook = XSSFWorkbook(ByteArrayInputStream(bytes))
+            val sheet = workbook.getSheetAt(0)
+            val dataRow = sheet.getRow(1)
+
+            // 기본 컬럼 확인
+            assertEquals("T100001", dataRow.getCell(0).stringCellValue)
+            assertEquals("테스트유저", dataRow.getCell(1).stringCellValue)
+            assertEquals("일반 티켓", dataRow.getCell(2).stringCellValue)
+            assertEquals("order-uuid-1", dataRow.getCell(3).stringCellValue)
+            assertEquals("미입장", dataRow.getCell(4).stringCellValue)
+
+            // 옵션 응답 컬럼 확인
+            assertEquals("홍길동", dataRow.getCell(6).stringCellValue)
+            assertEquals("010-1234-5678", dataRow.getCell(7).stringCellValue)
+            workbook.close()
+        }
+
+        @Test
+        @DisplayName("옵션 응답이 없는 경우 빈 문자열로 채워진다")
+        fun missingOptionAnswersAreFilled() {
+            val optionGroup = createOptionGroup(1L, "참석자 정보", OptionGroupType.SUBJECTIVE)
+            val option1 = createOption(10L, "참석자 이름", optionGroup)
+            val option2 = createOption(11L, "연락처", optionGroup)
+
+            val now = LocalDateTime.of(2026, 3, 22, 10, 0)
+
+            // 옵션 응답이 하나만 있는 경우
+            val answer1 = IssuedTicketOptionAnswer(optionId = 10L, answer = "홍길동")
+            val issuedTicket = createIssuedTicket(100L, listOf(answer1))
+
+            val ticketResponse = AdminIssuedTicketResponse(
+                id = 100L,
+                issuedTicketNo = "T100001",
+                userName = "테스트유저",
+                ticketName = "일반 티켓",
+                orderUuid = "order-uuid-1",
+                enteredAt = null,
+                status = IssuedTicketStatus.ENTRANCE_INCOMPLETE,
+                createdAt = now,
+            )
+
+            val bytes = adminExcelService.generateIssuedTicketsExcelWithOptions(
+                tickets = listOf(ticketResponse),
+                options = listOf(option1, option2),
+                issuedTickets = listOf(issuedTicket),
+            )
+            val workbook = XSSFWorkbook(ByteArrayInputStream(bytes))
+            val sheet = workbook.getSheetAt(0)
+            val dataRow = sheet.getRow(1)
+
+            assertEquals("홍길동", dataRow.getCell(6).stringCellValue)
+            assertEquals("", dataRow.getCell(7).stringCellValue) // 응답 없음
+            workbook.close()
+        }
+    }
+
+    // --- Helper Methods ---
+
+    private fun createOptionGroup(id: Long, name: String, type: OptionGroupType): OptionGroup {
+        val optionGroup = OptionGroup(
+            eventId = 1L,
+            type = type,
+            name = name,
+            description = "설명",
+            isEssential = true,
+        )
+        ReflectionTestUtils.setField(optionGroup, "id", id)
+        return optionGroup
+    }
+
+    private fun createOption(id: Long, questionName: String, optionGroup: OptionGroup): Option {
+        val og = OptionGroup(
+            eventId = 1L,
+            type = optionGroup.type,
+            name = questionName,
+            description = optionGroup.description,
+            isEssential = optionGroup.isEssential,
+        )
+        ReflectionTestUtils.setField(og, "id", optionGroup.id)
+        val option = Option(answer = "", additionalPrice = Money.ZERO, optionGroup = og)
+        ReflectionTestUtils.setField(option, "id", id)
+        return option
+    }
+
+    private fun createIssuedTicket(id: Long, optionAnswers: List<IssuedTicketOptionAnswer>): IssuedTicket {
+        val ticket = IssuedTicket(
+            eventId = 1L,
+            initialOptionAnswers = optionAnswers,
+        )
+        ReflectionTestUtils.setField(ticket, "id", id)
+        return ticket
+    }
+}


### PR DESCRIPTION
## Summary

### 주문 엑셀 (+7 컬럼)
주문번호, 주문방식, 결제수단, 승인일시, 취소일시, 할인금액, 쿠폰명

### 발급 티켓 엑셀 (옵션 동적 컬럼)
이벤트의 OptionGroup → Option 목록 조회 후 동적 헤더 생성. IssuedTicketOptionAnswer에서 optionId 매칭.

### 테스트
- [x] AdminExcelServiceTest 6개 (주문 헤더/데이터, 티켓 옵션 동적 컬럼)
- [x] 전체 빌드 + 테스트 통과

close #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)