### PR TITLE
fix: 인증 API Set-Cookie domain 격리

### DIFF
--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/helper/CookieHelper.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/helper/CookieHelper.kt
@@ -3,13 +3,15 @@ package band.gosrock.api.auth.service.helper
 import band.gosrock.api.auth.model.dto.response.TokenAndUserResponse
 import band.gosrock.common.annotation.Helper
 import band.gosrock.common.helper.SpringEnvironmentHelper
+import band.gosrock.common.properties.CookieProperties
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseCookie
 
 @Helper
 class CookieHelper(
-    private val springEnvironmentHelper: SpringEnvironmentHelper
+    private val springEnvironmentHelper: SpringEnvironmentHelper,
+    private val cookieProperties: CookieProperties,
 ) {
 
     fun getAccessTokenName(): String = "accessToken"
@@ -48,8 +50,8 @@ class CookieHelper(
     }
 
     private fun buildCookie(name: String, value: String, maxAge: Long): ResponseCookie {
-        val isProdOrStaging = springEnvironmentHelper.isProdAndStagingProfile()
         val sameSite = if (springEnvironmentHelper.isProdProfile()) "Strict" else "None"
+        val domain = cookieProperties.domain
 
         return ResponseCookie.from(name, value)
             .path("/")
@@ -57,8 +59,8 @@ class CookieHelper(
             .sameSite(sameSite)
             .secure(true)
             .apply {
-                if (isProdOrStaging) {
-                    domain(".dudoong.com")
+                if (domain.isNotBlank()) {
+                    domain(domain)
                 }
             }
             .build()

--- a/DuDoong-Common/src/main/kotlin/band/gosrock/common/config/ConfigurationPropertiesConfig.kt
+++ b/DuDoong-Common/src/main/kotlin/band/gosrock/common/config/ConfigurationPropertiesConfig.kt
@@ -1,5 +1,6 @@
 package band.gosrock.common.config
 
+import band.gosrock.common.properties.CookieProperties
 import band.gosrock.common.properties.JwtProperties
 import band.gosrock.common.properties.OauthProperties
 import band.gosrock.common.properties.TossPaymentsProperties
@@ -10,6 +11,7 @@ import org.springframework.context.annotation.Configuration
     JwtProperties::class,
     OauthProperties::class,
     TossPaymentsProperties::class,
+    CookieProperties::class,
 )
 @Configuration
 class ConfigurationPropertiesConfig

--- a/DuDoong-Common/src/main/kotlin/band/gosrock/common/properties/CookieProperties.kt
+++ b/DuDoong-Common/src/main/kotlin/band/gosrock/common/properties/CookieProperties.kt
@@ -1,0 +1,8 @@
+package band.gosrock.common.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "app.cookie")
+data class CookieProperties(
+    val domain: String,
+)

--- a/DuDoong-Common/src/main/resources/application-common.yml
+++ b/DuDoong-Common/src/main/resources/application-common.yml
@@ -4,6 +4,10 @@ auth:
     access-exp: ${JWT_ACCESS_EXP:3600}
     refresh-exp: ${JWT_REFRESH_EXP:3600}
 
+app:
+  cookie:
+    domain: ${COOKIE_DOMAIN:}
+
 oauth:
   kakao:
     base-url: ${KAKAO_BASE_URL}


### PR DESCRIPTION
## Summary

- `CookieHelper`의 domain을 하드코딩에서 **환경변수(`COOKIE_DOMAIN`)로 전환**
- `CookieProperties` 설정 클래스 신규 생성 (기존 `JwtProperties` 패턴 따름)
- `application-common.yml`에 `app.cookie.domain` 속성 추가

### 환경별 설정

| 환경 | `COOKIE_DOMAIN` | 효과 |
|------|----------------|------|
| Production | `.dudoong.com` | 라이브 전용 쿠키 |
| Staging | `staging.dudoong.com` | 스테이징 전용 쿠키 |
| Local | (비워둠) | domain 미설정 (localhost) |

### 변경 파일

- `CookieProperties.kt` — 신규: cookie domain 설정 클래스
- `ConfigurationPropertiesConfig.kt` — `CookieProperties` 등록
- `application-common.yml` — `app.cookie.domain: ${COOKIE_DOMAIN:}` 추가
- `CookieHelper.kt` — domain을 config에서 주입받도록 변경

### 기존 동작 유지
- 응답 body의 토큰은 그대로 유지 (프론트 전환 기간 호환)
- 인증 API 4개(login, register, refresh, logout) 모두 `CookieHelper` 사용 중이라 컨트롤러 변경 없음

close #682

## Test plan

- [ ] `./gradlew :DuDoong-Api:build` 빌드 통과 확인
- [ ] `COOKIE_DOMAIN=.dudoong.com`으로 로그인 시 Set-Cookie에 `Domain=.dudoong.com` 포함 확인
- [ ] `COOKIE_DOMAIN` 미설정 시 Domain 속성 없이 쿠키 생성 확인
- [ ] 스테이징 로그인 후 라이브 접속 시 쿠키 충돌 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)