### PR TITLE
feat: 환불 전용 API (호스트 + 어드민)

### DIFF
--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminRefundController.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/controller/AdminRefundController.kt
@@ -1,0 +1,58 @@
+package band.gosrock.admin.controller
+
+import band.gosrock.admin.model.dto.response.AdminRefundResponse
+import band.gosrock.admin.service.AdminCompleteRefundUseCase
+import band.gosrock.admin.service.AdminGetRefundDetailUseCase
+import band.gosrock.admin.service.AdminGetRefundsUseCase
+import band.gosrock.common.annotation.CurrentUserId
+import band.gosrock.domain.domains.order.domain.RefundStatus
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/internal-api/v1/refunds")
+@SecurityRequirement(name = "admin-token")
+@Tag(name = "Admin")
+class AdminRefundController(
+    private val adminGetRefundsUseCase: AdminGetRefundsUseCase,
+    private val adminGetRefundDetailUseCase: AdminGetRefundDetailUseCase,
+    private val adminCompleteRefundUseCase: AdminCompleteRefundUseCase,
+) {
+
+    @Operation(summary = "전체 환불 목록을 조회합니다.")
+    @GetMapping
+    fun getRefunds(
+        @CurrentUserId userId: Long,
+        @RequestParam(required = false) refundStatus: RefundStatus?,
+        @RequestParam(required = false) eventId: Long?,
+        @RequestParam(required = false) keyword: String?,
+        @PageableDefault(size = 20) pageable: Pageable,
+    ): Page<AdminRefundResponse> =
+        adminGetRefundsUseCase.execute(userId, refundStatus, eventId, keyword, pageable)
+
+    @Operation(summary = "환불 상세 정보를 조회합니다.")
+    @GetMapping("/{orderUuid}")
+    fun getRefundDetail(
+        @CurrentUserId userId: Long,
+        @PathVariable orderUuid: String,
+    ): AdminRefundResponse =
+        adminGetRefundDetailUseCase.execute(userId, orderUuid)
+
+    @Operation(summary = "환불을 확인 처리합니다. (REFUND_COMPLETED)")
+    @PatchMapping("/{orderUuid}/complete")
+    fun completeRefund(
+        @CurrentUserId userId: Long,
+        @PathVariable orderUuid: String,
+    ): AdminRefundResponse =
+        adminCompleteRefundUseCase.execute(userId, orderUuid)
+}

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/model/dto/response/AdminRefundResponse.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/model/dto/response/AdminRefundResponse.kt
@@ -1,0 +1,40 @@
+package band.gosrock.admin.model.dto.response
+
+import band.gosrock.domain.domains.order.domain.Order
+import band.gosrock.domain.domains.order.domain.RefundStatus
+import java.time.LocalDateTime
+
+data class AdminRefundResponse(
+    val orderId: String?,
+    val orderNo: String?,
+    val userName: String?,
+    val eventName: String?,
+    val eventId: Long?,
+    val ticketName: String?,
+    val totalAmount: Long,
+    val cancelReason: String?,
+    val refundStatus: RefundStatus,
+    val refundStatusChangedAt: LocalDateTime?,
+    val withDrawAt: LocalDateTime?,
+    val createdAt: LocalDateTime?,
+    val userId: Long?,
+) {
+    companion object {
+        fun of(order: Order, userName: String?, eventName: String?): AdminRefundResponse =
+            AdminRefundResponse(
+                orderId = order.uuid,
+                orderNo = order.orderNo,
+                userName = userName,
+                eventName = eventName,
+                eventId = order.eventId,
+                ticketName = order.orderName,
+                totalAmount = order.getTotalPaymentPrice().longValue(),
+                cancelReason = order.cancelReason,
+                refundStatus = order.refundStatus,
+                refundStatusChangedAt = order.refundStatusChangedAt,
+                withDrawAt = order.withDrawAt,
+                createdAt = order.createdAt,
+                userId = order.userId,
+            )
+    }
+}

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/service/AdminCompleteRefundUseCase.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/service/AdminCompleteRefundUseCase.kt
@@ -1,0 +1,32 @@
+package band.gosrock.admin.service
+
+import band.gosrock.admin.model.dto.response.AdminRefundResponse
+import band.gosrock.common.annotation.UseCase
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class AdminCompleteRefundUseCase(
+    private val orderAdaptor: OrderAdaptor,
+    private val userAdaptor: UserAdaptor,
+    private val eventAdaptor: EventAdaptor,
+    private val adminAuthValidator: AdminAuthValidator,
+) {
+
+    @Transactional
+    fun execute(userId: Long, orderUuid: String): AdminRefundResponse {
+        adminAuthValidator.validateAdminOrAbove(userId)
+        val order = orderAdaptor.findByOrderUuid(orderUuid)
+        order.completeRefund()
+
+        val userName = order.userId?.let {
+            runCatching { userAdaptor.queryUser(it).profile?.name }.getOrNull()
+        }
+        val eventName = order.eventId?.let {
+            runCatching { eventAdaptor.findById(it).eventBasic?.name }.getOrNull()
+        }
+        return AdminRefundResponse.of(order, userName, eventName)
+    }
+}

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/service/AdminGetRefundDetailUseCase.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/service/AdminGetRefundDetailUseCase.kt
@@ -1,0 +1,30 @@
+package band.gosrock.admin.service
+
+import band.gosrock.admin.model.dto.response.AdminRefundResponse
+import band.gosrock.common.annotation.UseCase
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+@Transactional(readOnly = true)
+class AdminGetRefundDetailUseCase(
+    private val orderAdaptor: OrderAdaptor,
+    private val userAdaptor: UserAdaptor,
+    private val eventAdaptor: EventAdaptor,
+    private val adminAuthValidator: AdminAuthValidator,
+) {
+
+    fun execute(userId: Long, orderUuid: String): AdminRefundResponse {
+        adminAuthValidator.validateAdminOrAbove(userId)
+        val order = orderAdaptor.findByOrderUuid(orderUuid)
+        val userName = order.userId?.let {
+            runCatching { userAdaptor.queryUser(it).profile?.name }.getOrNull()
+        }
+        val eventName = order.eventId?.let {
+            runCatching { eventAdaptor.findById(it).eventBasic?.name }.getOrNull()
+        }
+        return AdminRefundResponse.of(order, userName, eventName)
+    }
+}

--- a/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/service/AdminGetRefundsUseCase.kt
+++ b/DuDoong-Admin/src/main/kotlin/band/gosrock/admin/service/AdminGetRefundsUseCase.kt
@@ -1,0 +1,44 @@
+package band.gosrock.admin.service
+
+import band.gosrock.admin.model.dto.response.AdminRefundResponse
+import band.gosrock.common.annotation.UseCase
+import band.gosrock.domain.domains.event.repository.EventRepository
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor
+import band.gosrock.domain.domains.order.domain.RefundStatus
+import band.gosrock.domain.domains.user.repository.UserRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+@Transactional(readOnly = true)
+class AdminGetRefundsUseCase(
+    private val orderAdaptor: OrderAdaptor,
+    private val userRepository: UserRepository,
+    private val eventRepository: EventRepository,
+    private val adminAuthValidator: AdminAuthValidator,
+) {
+
+    fun execute(
+        userId: Long,
+        refundStatus: RefundStatus?,
+        eventId: Long?,
+        keyword: String?,
+        pageable: Pageable,
+    ): Page<AdminRefundResponse> {
+        adminAuthValidator.validateAdminOrAbove(userId)
+        val orderPage = orderAdaptor.findRefunds(eventId, refundStatus, keyword, pageable)
+
+        val userIds = orderPage.content.mapNotNull { it.userId }
+        val eventIds = orderPage.content.mapNotNull { it.eventId }
+
+        val userMap = userRepository.findAllByIdIn(userIds).associateBy { it.id }
+        val eventMap = eventRepository.findAllByIdIn(eventIds).associateBy { it.id }
+
+        return orderPage.map { order ->
+            val userName = order.userId?.let { userMap[it]?.profile?.name }
+            val eventName = order.eventId?.let { eventMap[it]?.eventBasic?.name }
+            AdminRefundResponse.of(order, userName, eventName)
+        }
+    }
+}

--- a/DuDoong-Admin/src/test/kotlin/band/gosrock/admin/service/AdminCompleteRefundUseCaseTest.kt
+++ b/DuDoong-Admin/src/test/kotlin/band/gosrock/admin/service/AdminCompleteRefundUseCaseTest.kt
@@ -1,0 +1,64 @@
+package band.gosrock.admin.service
+
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor
+import band.gosrock.domain.domains.order.domain.Order
+import band.gosrock.domain.domains.order.domain.OrderMethod
+import band.gosrock.domain.domains.order.domain.OrderStatus
+import band.gosrock.domain.domains.order.domain.RefundStatus
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("AdminCompleteRefundUseCase")
+class AdminCompleteRefundUseCaseTest {
+
+    @Mock
+    private lateinit var orderAdaptor: OrderAdaptor
+
+    @Mock
+    private lateinit var userAdaptor: UserAdaptor
+
+    @Mock
+    private lateinit var eventAdaptor: EventAdaptor
+
+    @Mock
+    private lateinit var adminAuthValidator: AdminAuthValidator
+
+    @InjectMocks
+    private lateinit var adminCompleteRefundUseCase: AdminCompleteRefundUseCase
+
+    @Test
+    @DisplayName("어드민 환불 확인 시 refundStatus가 REFUND_COMPLETED로 변경된다")
+    fun completeRefund() {
+        // given
+        val order = Order.forTest(
+            userId = 1L,
+            orderName = "테스트주문",
+            orderStatus = OrderStatus.CANCELED,
+            orderMethod = OrderMethod.PAYMENT,
+            eventId = 100L,
+            cancelReason = "단순 변심",
+            refundStatus = RefundStatus.REFUND_REQUESTED,
+        )
+        given(orderAdaptor.findByOrderUuid("test-uuid")).willReturn(order)
+
+        // when
+        val response = adminCompleteRefundUseCase.execute(1L, "test-uuid")
+
+        // then
+        assertEquals(RefundStatus.REFUND_COMPLETED, response.refundStatus)
+        assertEquals(RefundStatus.REFUND_COMPLETED, order.refundStatus)
+        assertNotNull(order.refundStatusChangedAt)
+        assertNotNull(response.userId)
+        assertEquals(1L, response.userId)
+    }
+}

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/refund/controller/RefundController.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/refund/controller/RefundController.kt
@@ -1,0 +1,57 @@
+package band.gosrock.api.refund.controller
+
+import band.gosrock.api.common.page.PageResponse
+import band.gosrock.api.refund.dto.response.RefundResponse
+import band.gosrock.api.refund.service.CompleteRefundUseCase
+import band.gosrock.api.refund.service.GetRefundsUseCase
+import band.gosrock.common.annotation.CurrentUserId
+import band.gosrock.domain.domains.order.domain.RefundStatus
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.data.domain.Pageable
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@SecurityRequirement(name = "access-token")
+@Tag(name = "7-1. [환불관리]")
+@RestController
+@RequestMapping("/api/v1/events/{eventId}/refunds")
+class RefundController(
+    private val getRefundsUseCase: GetRefundsUseCase,
+    private val completeRefundUseCase: CompleteRefundUseCase,
+) {
+
+    @Operation(summary = "환불 목록 조회")
+    @GetMapping
+    fun getRefunds(
+        @CurrentUserId userId: Long,
+        @PathVariable eventId: Long,
+        @RequestParam(required = false) refundStatus: RefundStatus?,
+        @ParameterObject pageable: Pageable,
+    ): PageResponse<RefundResponse> =
+        getRefundsUseCase.execute(userId, eventId, refundStatus, pageable)
+
+    @Operation(summary = "환불 상세 조회")
+    @GetMapping("/{orderUuid}")
+    fun getRefundDetail(
+        @CurrentUserId userId: Long,
+        @PathVariable eventId: Long,
+        @PathVariable orderUuid: String,
+    ): RefundResponse =
+        getRefundsUseCase.getDetail(userId, eventId, orderUuid)
+
+    @Operation(summary = "환불 확인 처리 (REFUND_COMPLETED)")
+    @PatchMapping("/{orderUuid}/complete")
+    fun completeRefund(
+        @CurrentUserId userId: Long,
+        @PathVariable eventId: Long,
+        @PathVariable orderUuid: String,
+    ): RefundResponse =
+        completeRefundUseCase.execute(userId, eventId, orderUuid)
+}

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/refund/dto/response/RefundResponse.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/refund/dto/response/RefundResponse.kt
@@ -1,0 +1,38 @@
+package band.gosrock.api.refund.dto.response
+
+import band.gosrock.domain.domains.order.domain.Order
+import band.gosrock.domain.domains.order.domain.RefundStatus
+import java.time.LocalDateTime
+
+data class RefundResponse(
+    val orderId: String?,
+    val orderNo: String?,
+    val userName: String?,
+    val eventName: String?,
+    val eventId: Long?,
+    val ticketName: String?,
+    val totalAmount: Long,
+    val cancelReason: String?,
+    val refundStatus: RefundStatus,
+    val refundStatusChangedAt: LocalDateTime?,
+    val withDrawAt: LocalDateTime?,
+    val createdAt: LocalDateTime?,
+) {
+    companion object {
+        fun of(order: Order, userName: String?, eventName: String?): RefundResponse =
+            RefundResponse(
+                orderId = order.uuid,
+                orderNo = order.orderNo,
+                userName = userName,
+                eventName = eventName,
+                eventId = order.eventId,
+                ticketName = order.orderName,
+                totalAmount = order.getTotalPaymentPrice().longValue(),
+                cancelReason = order.cancelReason,
+                refundStatus = order.refundStatus,
+                refundStatusChangedAt = order.refundStatusChangedAt,
+                withDrawAt = order.withDrawAt,
+                createdAt = order.createdAt,
+            )
+    }
+}

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/refund/service/CompleteRefundUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/refund/service/CompleteRefundUseCase.kt
@@ -1,0 +1,34 @@
+package band.gosrock.api.refund.service
+
+import band.gosrock.api.common.aop.hostRole.FindHostFrom.EVENT_ID
+import band.gosrock.api.common.aop.hostRole.HostQualification.MANAGER
+import band.gosrock.api.common.aop.hostRole.HostRolesAllowed
+import band.gosrock.api.refund.dto.response.RefundResponse
+import band.gosrock.common.annotation.UseCase
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+class CompleteRefundUseCase(
+    private val orderAdaptor: OrderAdaptor,
+    private val userAdaptor: UserAdaptor,
+    private val eventAdaptor: EventAdaptor,
+) {
+
+    @Transactional
+    @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID, applyTransaction = false)
+    fun execute(userId: Long, eventId: Long, orderUuid: String): RefundResponse {
+        val order = orderAdaptor.findByOrderUuid(orderUuid)
+        order.completeRefund()
+
+        val userName = order.userId?.let {
+            runCatching { userAdaptor.queryUser(it).profile?.name }.getOrNull()
+        }
+        val eventName = order.eventId?.let {
+            runCatching { eventAdaptor.findById(it).eventBasic?.name }.getOrNull()
+        }
+        return RefundResponse.of(order, userName, eventName)
+    }
+}

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/refund/service/GetRefundsUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/refund/service/GetRefundsUseCase.kt
@@ -1,0 +1,55 @@
+package band.gosrock.api.refund.service
+
+import band.gosrock.api.common.aop.hostRole.FindHostFrom.EVENT_ID
+import band.gosrock.api.common.aop.hostRole.HostQualification.GUEST
+import band.gosrock.api.common.aop.hostRole.HostRolesAllowed
+import band.gosrock.api.common.page.PageResponse
+import band.gosrock.api.refund.dto.response.RefundResponse
+import band.gosrock.common.annotation.UseCase
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor
+import band.gosrock.domain.domains.order.domain.RefundStatus
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor
+import org.springframework.data.domain.Pageable
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+@Transactional(readOnly = true)
+class GetRefundsUseCase(
+    private val orderAdaptor: OrderAdaptor,
+    private val userAdaptor: UserAdaptor,
+    private val eventAdaptor: EventAdaptor,
+) {
+
+    @HostRolesAllowed(role = GUEST, findHostFrom = EVENT_ID)
+    fun execute(
+        userId: Long,
+        eventId: Long,
+        refundStatus: RefundStatus?,
+        pageable: Pageable,
+    ): PageResponse<RefundResponse> {
+        val orderPage = orderAdaptor.findRefunds(eventId, refundStatus, null, pageable)
+
+        val userIds = orderPage.content.mapNotNull { it.userId }
+        val userMap = userAdaptor.findUserByIdIn(userIds).associateBy { it.id }
+
+        val eventName = runCatching { eventAdaptor.findById(eventId).eventBasic?.name }.getOrNull()
+
+        return PageResponse.of(orderPage.map { order ->
+            val userName = order.userId?.let { userMap[it]?.profile?.name }
+            RefundResponse.of(order, userName, eventName)
+        })
+    }
+
+    @HostRolesAllowed(role = GUEST, findHostFrom = EVENT_ID)
+    fun getDetail(userId: Long, eventId: Long, orderUuid: String): RefundResponse {
+        val order = orderAdaptor.findByOrderUuid(orderUuid)
+        val userName = order.userId?.let {
+            runCatching { userAdaptor.queryUser(it).profile?.name }.getOrNull()
+        }
+        val eventName = order.eventId?.let {
+            runCatching { eventAdaptor.findById(it).eventBasic?.name }.getOrNull()
+        }
+        return RefundResponse.of(order, userName, eventName)
+    }
+}

--- a/DuDoong-Api/src/test/kotlin/band/gosrock/api/refund/service/CompleteRefundUseCaseTest.kt
+++ b/DuDoong-Api/src/test/kotlin/band/gosrock/api/refund/service/CompleteRefundUseCaseTest.kt
@@ -1,0 +1,59 @@
+package band.gosrock.api.refund.service
+
+import band.gosrock.domain.domains.event.adaptor.EventAdaptor
+import band.gosrock.domain.domains.order.adaptor.OrderAdaptor
+import band.gosrock.domain.domains.order.domain.Order
+import band.gosrock.domain.domains.order.domain.OrderMethod
+import band.gosrock.domain.domains.order.domain.OrderStatus
+import band.gosrock.domain.domains.order.domain.RefundStatus
+import band.gosrock.domain.domains.user.adaptor.UserAdaptor
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+@DisplayName("CompleteRefundUseCase")
+class CompleteRefundUseCaseTest {
+
+    @Mock
+    private lateinit var orderAdaptor: OrderAdaptor
+
+    @Mock
+    private lateinit var userAdaptor: UserAdaptor
+
+    @Mock
+    private lateinit var eventAdaptor: EventAdaptor
+
+    @InjectMocks
+    private lateinit var completeRefundUseCase: CompleteRefundUseCase
+
+    @Test
+    @DisplayName("환불 확인 시 refundStatus가 REFUND_COMPLETED로 변경된다")
+    fun completeRefund() {
+        // given
+        val order = Order.forTest(
+            userId = 1L,
+            orderName = "테스트주문",
+            orderStatus = OrderStatus.CANCELED,
+            orderMethod = OrderMethod.PAYMENT,
+            eventId = 100L,
+            cancelReason = "단순 변심",
+            refundStatus = RefundStatus.REFUND_REQUESTED,
+        )
+        given(orderAdaptor.findByOrderUuid("test-uuid")).willReturn(order)
+
+        // when
+        val response = completeRefundUseCase.execute(1L, 100L, "test-uuid")
+
+        // then
+        assertEquals(RefundStatus.REFUND_COMPLETED, response.refundStatus)
+        assertEquals(RefundStatus.REFUND_COMPLETED, order.refundStatus)
+        assertNotNull(order.refundStatusChangedAt)
+    }
+}

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/adaptor/OrderAdaptor.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/adaptor/OrderAdaptor.kt
@@ -3,6 +3,7 @@ package band.gosrock.domain.domains.order.adaptor
 import band.gosrock.common.annotation.Adaptor
 import band.gosrock.domain.domains.order.domain.Order
 import band.gosrock.domain.domains.order.domain.OrderStatus
+import band.gosrock.domain.domains.order.domain.RefundStatus
 import band.gosrock.domain.domains.order.exception.OrderNotFoundException
 import band.gosrock.domain.domains.order.repository.OrderRepository
 import band.gosrock.domain.domains.order.repository.condition.FindEventOrdersCondition
@@ -43,4 +44,7 @@ class OrderAdaptor(private val orderRepository: OrderRepository) {
 
     fun findByEventIdAndOrderStatusAndUserId(eventId: Long, userId: Long, orderStatus: OrderStatus): List<Order> =
         orderRepository.findByEventIdAndUserIdAndOrderStatus(eventId, userId, orderStatus)
+
+    fun findRefunds(eventId: Long?, refundStatus: RefundStatus?, keyword: String?, pageable: Pageable): Page<Order> =
+        orderRepository.findRefunds(eventId, refundStatus, keyword, pageable)
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/repository/OrderCustomRepository.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/repository/OrderCustomRepository.kt
@@ -1,6 +1,7 @@
 package band.gosrock.domain.domains.order.repository
 
 import band.gosrock.domain.domains.order.domain.Order
+import band.gosrock.domain.domains.order.domain.RefundStatus
 import band.gosrock.domain.domains.order.repository.condition.FindEventOrdersCondition
 import band.gosrock.domain.domains.order.repository.condition.FindMyPageOrderCondition
 import java.util.Optional
@@ -13,4 +14,5 @@ interface OrderCustomRepository {
     fun findMyOrders(condition: FindMyPageOrderCondition, pageable: Pageable): Slice<Order>
     fun findEventOrders(condition: FindEventOrdersCondition, pageable: Pageable): Page<Order>
     fun findRecentOrder(userId: Long): Optional<Order>
+    fun findRefunds(eventId: Long?, refundStatus: RefundStatus?, keyword: String?, pageable: Pageable): Page<Order>
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/repository/OrderCustomRepositoryImpl.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/repository/OrderCustomRepositoryImpl.kt
@@ -5,6 +5,7 @@ import band.gosrock.domain.domains.event.domain.QEvent.event
 import band.gosrock.domain.domains.order.domain.Order
 import band.gosrock.domain.domains.order.domain.OrderStatus
 import band.gosrock.domain.domains.order.domain.QOrder.order
+import band.gosrock.domain.domains.order.domain.RefundStatus
 import band.gosrock.domain.domains.order.domain.QOrderLineItem.orderLineItem
 import band.gosrock.domain.domains.order.repository.condition.FindEventOrdersCondition
 import band.gosrock.domain.domains.order.repository.condition.FindMyPageOrderCondition
@@ -110,6 +111,39 @@ class OrderCustomRepositoryImpl(
 
     private fun eqEventId(eventId: Long?): BooleanExpression? =
         if (eventId == null) null else order.eventId.eq(eventId)
+
+    override fun findRefunds(eventId: Long?, refundStatus: RefundStatus?, keyword: String?, pageable: Pageable): Page<Order> {
+        val orders = queryFactory
+            .selectFrom(order)
+            .where(
+                order.refundStatus.ne(RefundStatus.NONE),
+                eqEventId(eventId),
+                eqRefundStatus(refundStatus),
+                containsOrderNo(keyword),
+            )
+            .orderBy(order.id.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        val countQuery: JPAQuery<Long> = queryFactory
+            .select(order.count())
+            .from(order)
+            .where(
+                order.refundStatus.ne(RefundStatus.NONE),
+                eqEventId(eventId),
+                eqRefundStatus(refundStatus),
+                containsOrderNo(keyword),
+            )
+
+        return PageableExecutionUtils.getPage(orders, pageable) { countQuery.fetchOne() ?: 0L }
+    }
+
+    private fun eqRefundStatus(refundStatus: RefundStatus?): BooleanExpression? =
+        if (refundStatus == null) null else order.refundStatus.eq(refundStatus)
+
+    private fun containsOrderNo(keyword: String?): BooleanExpression? =
+        if (keyword.isNullOrBlank()) null else order.orderNo.containsIgnoreCase(keyword)
 
     private fun openingState(isShowing: Boolean?): BooleanExpression {
         val eventEndAtTemplate: DateTemplate<LocalDateTime> = Expressions.dateTemplate(

--- a/e2e-tests/test_38_refund_api.py
+++ b/e2e-tests/test_38_refund_api.py
@@ -1,0 +1,195 @@
+"""
+환불 전용 API E2E 테스트.
+호스트용 환불 조회/확인 API와 어드민용 환불 API를 검증합니다.
+"""
+import pytest
+import requests
+
+from conftest import assert_status, get_data
+
+
+def _create_and_refund_order(base_url, auth_headers, state) -> str:
+    """
+    환불 API 테스트 전용: 주문 생성 -> 무료 결제 -> 환불 요청 후 order_uuid 반환.
+    """
+    assert state.ticket_item_id, "ticket_item_id가 없습니다. test_04를 먼저 실행하세요."
+
+    # 1) 장바구니 생성
+    cart_resp = requests.post(
+        f"{base_url}/v1/carts",
+        json={"items": [{"itemId": state.ticket_item_id, "quantity": 1, "options": []}]},
+        headers=auth_headers,
+    )
+    assert cart_resp.status_code in (200, 201), f"장바구니 생성 실패: {cart_resp.text[:200]}"
+    cart_id = get_data(cart_resp)["cartId"]
+
+    # 2) 주문 생성
+    order_resp = requests.post(
+        f"{base_url}/v1/orders/",
+        json={"couponId": None, "cartId": cart_id},
+        headers=auth_headers,
+    )
+    assert order_resp.status_code in (200, 201), f"주문 생성 실패: {order_resp.text[:200]}"
+    order_uuid = get_data(order_resp)["orderId"]
+
+    # 3) 무료 결제 완료
+    free_resp = requests.post(
+        f"{base_url}/v1/orders/{order_uuid}/free",
+        headers=auth_headers,
+    )
+    assert free_resp.status_code == 200, f"무료 결제 실패: {free_resp.text[:200]}"
+
+    # 4) 환불 요청
+    refund_resp = requests.post(
+        f"{base_url}/v1/orders/{order_uuid}/refund",
+        headers=auth_headers,
+    )
+    assert refund_resp.status_code == 200, f"환불 요청 실패: {refund_resp.text[:200]}"
+
+    return order_uuid
+
+
+# ==================== 호스트용 환불 API ====================
+
+
+class TestHostRefundApi:
+    """호스트용 환불 API (/api/v1/events/{eventId}/refunds) 테스트"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, base_url, auth_headers, state):
+        self.base_url = base_url
+        self.auth_headers = auth_headers
+        self.state = state
+
+    def test_refund_list(self):
+        """환불 목록 조회 API가 정상 응답한다."""
+        assert self.state.event_id, "event_id가 없습니다."
+
+        # 환불 대상 주문 생성
+        order_uuid = _create_and_refund_order(
+            self.base_url, self.auth_headers, self.state
+        )
+        self.state.refund_api_order_uuid = order_uuid
+
+        url = f"{self.base_url}/v1/events/{self.state.event_id}/refunds"
+        print(f"\n[test_refund_list] GET {url}")
+        resp = requests.get(url, headers=self.auth_headers)
+        print(f"[test_refund_list] status={resp.status_code}, body={resp.text[:400]}")
+
+        assert_status(resp, 200)
+        data = get_data(resp)
+        assert "content" in data, f"응답에 content 필드 없음: {data}"
+        assert len(data["content"]) > 0, "환불 목록이 비어있습니다."
+
+    def test_refund_list_with_status_filter(self):
+        """환불 목록 조회 시 refundStatus 필터가 동작한다."""
+        url = f"{self.base_url}/v1/events/{self.state.event_id}/refunds"
+        resp = requests.get(
+            url,
+            params={"refundStatus": "REFUND_REQUESTED"},
+            headers=self.auth_headers,
+        )
+        assert_status(resp, 200)
+        data = get_data(resp)
+        for item in data.get("content", []):
+            assert item["refundStatus"] == "REFUND_REQUESTED"
+
+    def test_refund_detail(self):
+        """환불 상세 조회 API가 정상 응답한다."""
+        order_uuid = getattr(self.state, "refund_api_order_uuid", None)
+        if not order_uuid:
+            pytest.skip("환불 주문이 없습니다.")
+
+        url = f"{self.base_url}/v1/events/{self.state.event_id}/refunds/{order_uuid}"
+        print(f"\n[test_refund_detail] GET {url}")
+        resp = requests.get(url, headers=self.auth_headers)
+        print(f"[test_refund_detail] status={resp.status_code}, body={resp.text[:400]}")
+
+        assert_status(resp, 200)
+        data = get_data(resp)
+        assert data["orderId"] == order_uuid
+        assert data["refundStatus"] == "REFUND_REQUESTED"
+
+    def test_complete_refund(self):
+        """환불 확인 API가 정상 동작한다."""
+        order_uuid = getattr(self.state, "refund_api_order_uuid", None)
+        if not order_uuid:
+            pytest.skip("환불 주문이 없습니다.")
+
+        url = f"{self.base_url}/v1/events/{self.state.event_id}/refunds/{order_uuid}/complete"
+        print(f"\n[test_complete_refund] PATCH {url}")
+        resp = requests.patch(url, headers=self.auth_headers)
+        print(f"[test_complete_refund] status={resp.status_code}, body={resp.text[:400]}")
+
+        assert_status(resp, 200)
+        data = get_data(resp)
+        assert data["orderId"] == order_uuid
+        assert data["refundStatus"] == "REFUND_COMPLETED"
+
+
+# ==================== 어드민용 환불 API ====================
+
+
+class TestAdminRefundApi:
+    """어드민용 환불 API (/internal-api/v1/refunds) 테스트"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, base_url, auth_headers, state):
+        self.base_url = base_url
+        self.auth_headers = auth_headers
+        self.state = state
+        # internal-api base url
+        self.admin_base = self.base_url.replace("/api", "")
+
+    def test_admin_refund_list(self):
+        """어드민 환불 목록 조회가 정상 응답한다."""
+        url = f"{self.admin_base}/internal-api/v1/refunds"
+        print(f"\n[test_admin_refund_list] GET {url}")
+        resp = requests.get(url, headers=self.auth_headers)
+        print(f"[test_admin_refund_list] status={resp.status_code}, body={resp.text[:400]}")
+
+        # ADMIN 권한이 없으면 403이 정상
+        if resp.status_code == 403:
+            pytest.skip("ADMIN 권한이 없어 스킵합니다.")
+
+        assert_status(resp, 200)
+        data = get_data(resp)
+        assert "content" in data, f"응답에 content 필드 없음: {data}"
+
+    def test_admin_refund_detail(self):
+        """어드민 환불 상세 조회가 정상 응답한다."""
+        order_uuid = getattr(self.state, "refund_api_order_uuid", None)
+        if not order_uuid:
+            pytest.skip("환불 주문이 없습니다.")
+
+        url = f"{self.admin_base}/internal-api/v1/refunds/{order_uuid}"
+        resp = requests.get(url, headers=self.auth_headers)
+
+        if resp.status_code == 403:
+            pytest.skip("ADMIN 권한이 없어 스킵합니다.")
+
+        assert_status(resp, 200)
+        data = get_data(resp)
+        assert data["orderId"] == order_uuid
+        assert "userId" in data, "어드민 응답에 userId 필드가 없습니다."
+
+    def test_admin_complete_refund(self):
+        """어드민 환불 확인 API가 정상 동작한다."""
+        # 새로운 환불 대상 주문 생성
+        order_uuid = _create_and_refund_order(
+            self.base_url, self.auth_headers, self.state
+        )
+
+        url = f"{self.admin_base}/internal-api/v1/refunds/{order_uuid}/complete"
+        print(f"\n[test_admin_complete_refund] PATCH {url}")
+        resp = requests.patch(url, headers=self.auth_headers)
+        print(f"[test_admin_complete_refund] status={resp.status_code}, body={resp.text[:400]}")
+
+        if resp.status_code == 403:
+            pytest.skip("ADMIN 권한이 없어 스킵합니다.")
+
+        assert_status(resp, 200)
+        data = get_data(resp)
+        assert data["orderId"] == order_uuid
+        assert data["refundStatus"] == "REFUND_COMPLETED"
+        assert "userId" in data


### PR DESCRIPTION
## Summary

환불 관리를 주문과 분리된 전용 API로 구현.

### 호스트용
- `GET /api/v1/events/{eventId}/refunds` — 목록 (refundStatus 필터)
- `PATCH .../refunds/{uuid}/complete` — 환불 확인

### 어드민용
- `GET /internal-api/v1/refunds` — 전체 목록 (refundStatus/eventId/keyword 필터)
- `PATCH .../refunds/{uuid}/complete` — 환불 확인

### 테스트
- [x] CompleteRefundUseCase + AdminCompleteRefundUseCase 유닛
- [x] E2E test_38
- [x] 빌드 통과

close #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)