### PR TITLE
feat: MDC traceId 도입 — nginx X-Trace-Id 연계 요청별 로그 그룹핑 (#688)

### DIFF
--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/LoginUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/LoginUseCase.kt
@@ -5,6 +5,7 @@ import band.gosrock.api.auth.service.helper.KakaoOauthHelper
 import band.gosrock.api.auth.service.helper.TokenGenerateHelper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.user.service.UserDomainService
+import org.slf4j.LoggerFactory
 
 @UseCase
 class LoginUseCase(
@@ -12,10 +13,13 @@ class LoginUseCase(
     private val userDomainService: UserDomainService,
     private val tokenGenerateHelper: TokenGenerateHelper
 ) {
+    private val log = LoggerFactory.getLogger(LoginUseCase::class.java)
 
     fun execute(idToken: String): TokenAndUserResponse {
+        log.info("[LoginUseCase][execute] 로그인 시도")
         val oauthInfo = kakaoOauthHelper.getOauthInfoByIdToken(idToken)
         val user = userDomainService.loginUser(oauthInfo)
+        log.info("[LoginUseCase][execute] 로그인 성공 userId={}", user.id)
         return tokenGenerateHelper.execute(user)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/RefreshUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/RefreshUseCase.kt
@@ -7,6 +7,7 @@ import band.gosrock.common.jwt.JwtTokenProvider
 import band.gosrock.domain.domains.user.adaptor.RefreshTokenAdaptor
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor
 import band.gosrock.domain.domains.user.service.UserDomainService
+import org.slf4j.LoggerFactory
 
 @UseCase
 class RefreshUseCase(
@@ -16,10 +17,12 @@ class RefreshUseCase(
     private val refreshTokenAdaptor: RefreshTokenAdaptor,
     private val tokenGenerateHelper: TokenGenerateHelper
 ) {
+    private val log = LoggerFactory.getLogger(RefreshUseCase::class.java)
 
     fun execute(refreshToken: String): TokenAndUserResponse {
         val savedRefreshTokenEntity = refreshTokenAdaptor.queryRefreshToken(refreshToken)
         val refreshUserId = jwtTokenProvider.parseRefreshToken(savedRefreshTokenEntity.refreshToken!!)
+        log.info("[RefreshUseCase][execute] 토큰 갱신 userId={}", refreshUserId)
         val user = userAdaptor.queryUser(refreshUserId)
         // 리프레쉬 시에도 last로그인 정보 업데이트
         userDomainService.loginUser(user.oauthInfo!!)

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/RegisterUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/RegisterUseCase.kt
@@ -9,6 +9,7 @@ import band.gosrock.api.auth.service.helper.KakaoOauthHelper
 import band.gosrock.api.auth.service.helper.TokenGenerateHelper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.user.service.UserDomainService
+import org.slf4j.LoggerFactory
 
 @UseCase
 class RegisterUseCase(
@@ -16,6 +17,7 @@ class RegisterUseCase(
     private val userDomainService: UserDomainService,
     private val tokenGenerateHelper: TokenGenerateHelper
 ) {
+    private val log = LoggerFactory.getLogger(RegisterUseCase::class.java)
 
     fun getKaKaoOauthLinkTest(): OauthLoginLinkResponse =
         OauthLoginLinkResponse(kakaoOauthHelper.getKaKaoOauthLinkTest())
@@ -42,12 +44,14 @@ class RegisterUseCase(
         idToken: String,
         registerUserRequest: RegisterRequest
     ): TokenAndUserResponse {
+        log.info("[RegisterUseCase][registerUserByOCIDToken] 회원가입")
         val oauthInfo = kakaoOauthHelper.getOauthInfoByIdToken(idToken)
         val user = userDomainService.registerUser(
             registerUserRequest.toProfile(),
             oauthInfo,
             registerUserRequest.marketingAgree
         )
+        log.info("[RegisterUseCase][registerUserByOCIDToken] 회원가입 완료 userId={}", user.id)
         return tokenGenerateHelper.execute(user)
     }
 

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/WithDrawUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/auth/service/WithDrawUseCase.kt
@@ -5,6 +5,7 @@ import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.user.adaptor.RefreshTokenAdaptor
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor
 import band.gosrock.domain.domains.user.service.UserDomainService
+import org.slf4j.LoggerFactory
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
@@ -14,9 +15,11 @@ class WithDrawUseCase(
     private val userAdaptor: UserAdaptor,
     private val kakaoOauthHelper: KakaoOauthHelper
 ) {
+    private val log = LoggerFactory.getLogger(WithDrawUseCase::class.java)
 
     @Transactional
     fun execute(userId: Long) {
+        log.info("[WithDrawUseCase][execute] 회원 탈퇴 userId={}", userId)
         refreshTokenAdaptor.deleteByUserId(userId)
         val user = userAdaptor.queryUser(userId)
         val oid = user.oauthInfo!!.oid!!

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/MdcFilter.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/MdcFilter.kt
@@ -3,26 +3,66 @@ package band.gosrock.api.config
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.util.ContentCachingRequestWrapper
 import java.util.UUID
 
 @Component
 class MdcFilter : OncePerRequestFilter() {
+
+    private val log = LoggerFactory.getLogger(MdcFilter::class.java)
+
+    companion object {
+        private const val MAX_BODY_LOG_SIZE = 2048
+        private val EXCLUDED_PATHS = listOf("/api/v1/auth", "/api/v1/payment")
+    }
+
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         filterChain: FilterChain,
     ) {
+        val wrappedRequest = ContentCachingRequestWrapper(request, MAX_BODY_LOG_SIZE)
         try {
             val traceId = request.getHeader("X-Trace-Id")
                 ?: UUID.randomUUID().toString().replace("-", "").substring(0, 8)
             MDC.put("traceId", traceId)
             response.setHeader("X-Trace-Id", traceId)
-            filterChain.doFilter(request, response)
+            filterChain.doFilter(wrappedRequest, response)
         } finally {
+            logRequest(wrappedRequest, response)
             MDC.clear()
         }
+    }
+
+    private fun logRequest(request: ContentCachingRequestWrapper, response: HttpServletResponse) {
+        val uri = request.requestURI
+        val method = request.method
+        val status = response.status
+
+        val body = if (shouldLogBody(uri, method)) {
+            val content = request.contentAsByteArray
+            if (content.isNotEmpty()) {
+                String(content, Charsets.UTF_8).take(MAX_BODY_LOG_SIZE)
+            } else {
+                null
+            }
+        } else {
+            "[FILTERED]"
+        }
+
+        if (body != null) {
+            log.info("{} {} {} body={}", method, uri, status, body)
+        } else {
+            log.info("{} {} {}", method, uri, status)
+        }
+    }
+
+    private fun shouldLogBody(uri: String, method: String): Boolean {
+        if (method == "GET") return false
+        return EXCLUDED_PATHS.none { uri.startsWith(it) }
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/MdcFilter.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/MdcFilter.kt
@@ -1,0 +1,28 @@
+package band.gosrock.api.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+@Component
+class MdcFilter : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        try {
+            val traceId = request.getHeader("X-Trace-Id")
+                ?: UUID.randomUUID().toString().replace("-", "").substring(0, 8)
+            MDC.put("traceId", traceId)
+            response.setHeader("X-Trace-Id", traceId)
+            filterChain.doFilter(request, response)
+        } finally {
+            MDC.clear()
+        }
+    }
+}

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/ServletFilterConfig.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/ServletFilterConfig.kt
@@ -13,7 +13,16 @@ import org.springframework.web.servlet.resource.ResourceUrlEncodingFilter
 class ServletFilterConfig(
     private val httpContentCacheFilter: HttpContentCacheFilter,
     private val forwardedHeaderFilter: ForwardedHeaderFilter,
+    private val mdcFilter: MdcFilter,
 ) : WebMvcConfigurer {
+
+    @Bean
+    fun setMdcFilterOrder(): FilterRegistrationBean<MdcFilter> {
+        val registrationBean = FilterRegistrationBean<MdcFilter>()
+        registrationBean.filter = mdcFilter
+        registrationBean.order = Int.MIN_VALUE
+        return registrationBean
+    }
 
     @Bean
     fun setResourceUrlEncodingFilter(): FilterRegistrationBean<ResourceUrlEncodingFilter> {

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/service/CreateEventUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/service/CreateEventUseCase.kt
@@ -6,6 +6,7 @@ import band.gosrock.api.event.model.mapper.EventMapper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.event.service.EventService
 import band.gosrock.domain.domains.host.service.HostService
+import org.slf4j.LoggerFactory
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
@@ -14,8 +15,11 @@ class CreateEventUseCase(
     private val eventService: EventService,
     private val eventMapper: EventMapper
 ) {
+    private val log = LoggerFactory.getLogger(CreateEventUseCase::class.java)
+
     @Transactional
     fun execute(userId: Long, createEventRequest: CreateEventRequest): EventResponse {
+        log.info("[CreateEventUseCase][execute] 이벤트 생성 userId={} hostId={}", userId, createEventRequest.hostId)
         // 슈퍼 호스트 이상만 공연 생성 가능
         hostService.validateManagerHostUser(createEventRequest.hostId!!, userId)
         val event = eventMapper.toEntity(createEventRequest)

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/service/OpenEventUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/service/OpenEventUseCase.kt
@@ -7,6 +7,7 @@ import band.gosrock.api.event.model.dto.response.EventResponse
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor
 import band.gosrock.domain.domains.event.service.EventService
+import org.slf4j.LoggerFactory
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
@@ -14,9 +15,12 @@ class OpenEventUseCase(
     private val eventService: EventService,
     private val eventAdaptor: EventAdaptor
 ) {
+    private val log = LoggerFactory.getLogger(OpenEventUseCase::class.java)
+
     @Transactional
     @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID)
     fun execute(userId: Long, eventId: Long): EventResponse {
+        log.info("[OpenEventUseCase][execute] 이벤트 오픈 userId={} eventId={}", userId, eventId)
         val event = eventAdaptor.findById(eventId)
         return EventResponse.of(eventService.openEvent(event))
     }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/service/UpdateEventStatusUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/service/UpdateEventStatusUseCase.kt
@@ -8,6 +8,7 @@ import band.gosrock.api.event.model.dto.response.EventResponse
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor
 import band.gosrock.domain.domains.event.service.EventService
+import org.slf4j.LoggerFactory
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
@@ -15,9 +16,12 @@ class UpdateEventStatusUseCase(
     private val eventService: EventService,
     private val eventAdaptor: EventAdaptor
 ) {
+    private val log = LoggerFactory.getLogger(UpdateEventStatusUseCase::class.java)
+
     @Transactional
     @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID)
     fun execute(userId: Long, eventId: Long, updateEventStatusRequest: UpdateEventStatusRequest): EventResponse {
+        log.info("[UpdateEventStatusUseCase][execute] 이벤트 상태 변경 userId={} eventId={} status={}", userId, eventId, updateEventStatusRequest.status)
         val event = eventAdaptor.findById(eventId)
         val status = updateEventStatusRequest.status!!
         return EventResponse.of(eventService.updateEventStatus(event, status))

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/service/CreateHostUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/host/service/CreateHostUseCase.kt
@@ -6,6 +6,7 @@ import band.gosrock.api.host.model.mapper.HostMapper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.host.service.HostService
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor
+import org.slf4j.LoggerFactory
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
@@ -14,8 +15,11 @@ class CreateHostUseCase(
     private val hostService: HostService,
     private val hostMapper: HostMapper,
 ) {
+    private val log = LoggerFactory.getLogger(CreateHostUseCase::class.java)
+
     @Transactional
     fun execute(userId: Long, createHostRequest: CreateHostRequest): HostResponse {
+        log.info("[CreateHostUseCase][execute] 호스트 생성 userId={}", userId)
         // 존재하는 유저인지 검증
         userAdaptor.queryUser(userId)
         // 호스트 생성

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/issuedTicket/service/EntranceIssuedTicketUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/issuedTicket/service/EntranceIssuedTicketUseCase.kt
@@ -6,16 +6,19 @@ import band.gosrock.api.common.aop.hostRole.HostRolesAllowed
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.common.vo.IssuedTicketInfoVo
 import band.gosrock.domain.domains.issuedTicket.service.IssuedTicketDomainService
+import org.slf4j.LoggerFactory
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 class EntranceIssuedTicketUseCase(
     private val issuedTicketDomainService: IssuedTicketDomainService,
 ) {
+    private val log = LoggerFactory.getLogger(EntranceIssuedTicketUseCase::class.java)
 
     @Transactional
     @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID)
     fun execute(userId: Long, eventId: Long, uuid: String): IssuedTicketInfoVo {
+        log.info("[EntranceIssuedTicketUseCase][execute] QR 입장 처리 userId={} eventId={} ticketUuid={}", userId, eventId, uuid)
         return issuedTicketDomainService.processingEntranceIssuedTicket(eventId, uuid)
     }
 }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/ApproveOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/ApproveOrderUseCase.kt
@@ -7,14 +7,18 @@ import band.gosrock.api.order.model.dto.response.OrderResponse
 import band.gosrock.api.order.model.mapper.OrderMapper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.order.service.OrderApproveService
+import org.slf4j.LoggerFactory
 
 @UseCase
 class ApproveOrderUseCase(
     private val orderApproveService: OrderApproveService,
     private val orderMapper: OrderMapper,
 ) {
+    private val log = LoggerFactory.getLogger(ApproveOrderUseCase::class.java)
+
     @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID, applyTransaction = false)
     fun execute(userId: Long, eventId: Long, orderUuid: String): OrderResponse {
+        log.info("[ApproveOrderUseCase][execute] 주문 승인 userId={} eventId={} orderUuid={}", userId, eventId, orderUuid)
         val confirmOrderUuid = orderApproveService.execute(orderUuid)
         return orderMapper.toOrderResponse(confirmOrderUuid)
     }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/CancelOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/CancelOrderUseCase.kt
@@ -7,14 +7,18 @@ import band.gosrock.api.order.model.dto.response.OrderResponse
 import band.gosrock.api.order.model.mapper.OrderMapper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.order.service.WithdrawOrderService
+import org.slf4j.LoggerFactory
 
 @UseCase
 class CancelOrderUseCase(
     private val withdrawOrderService: WithdrawOrderService,
     private val orderMapper: OrderMapper,
 ) {
+    private val log = LoggerFactory.getLogger(CancelOrderUseCase::class.java)
+
     @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID, applyTransaction = false)
     fun execute(userId: Long, eventId: Long, orderUuid: String, reason: String? = null): OrderResponse {
+        log.info("[CancelOrderUseCase][execute] 주문 취소 userId={} eventId={} orderUuid={} reason={}", userId, eventId, orderUuid, reason)
         withdrawOrderService.cancelOrder(orderUuid, reason)
         return orderMapper.toOrderResponse(orderUuid)
     }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/ConfirmOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/ConfirmOrderUseCase.kt
@@ -6,13 +6,17 @@ import band.gosrock.api.order.model.mapper.OrderMapper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.order.service.OrderConfirmService
 import band.gosrock.infrastructure.outer.api.tossPayments.dto.request.ConfirmPaymentsRequest
+import org.slf4j.LoggerFactory
 
 @UseCase
 class ConfirmOrderUseCase(
     private val orderConfirmService: OrderConfirmService,
     private val orderMapper: OrderMapper,
 ) {
+    private val log = LoggerFactory.getLogger(ConfirmOrderUseCase::class.java)
+
     fun execute(userId: Long, orderUuid: String, confirmOrderRequest: ConfirmOrderRequest): OrderResponse {
+        log.info("[ConfirmOrderUseCase][execute] 결제 확인 userId={} orderUuid={} amount={}", userId, orderUuid, confirmOrderRequest.amount)
         val confirmPaymentsRequest = ConfirmPaymentsRequest(
             paymentKey = confirmOrderRequest.paymentKey,
             amount = confirmOrderRequest.amount,

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/CreateOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/CreateOrderUseCase.kt
@@ -5,13 +5,17 @@ import band.gosrock.api.order.model.dto.response.CreateOrderResponse
 import band.gosrock.api.order.model.mapper.OrderMapper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.order.service.CreateOrderService
+import org.slf4j.LoggerFactory
 
 @UseCase
 class CreateOrderUseCase(
     private val createOrderService: CreateOrderService,
     private val orderMapper: OrderMapper,
 ) {
+    private val log = LoggerFactory.getLogger(CreateOrderUseCase::class.java)
+
     fun execute(userId: Long, createOrderRequest: CreateOrderRequest): CreateOrderResponse {
+        log.info("[CreateOrderUseCase][execute] 주문 생성 userId={} cartId={} couponId={}", userId, createOrderRequest.cartId, createOrderRequest.couponId)
         val couponId = createOrderRequest.couponId
         val cartId = createOrderRequest.cartId!!
         return if (couponId == null) {

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/CreateTossOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/CreateTossOrderUseCase.kt
@@ -5,6 +5,7 @@ import band.gosrock.domain.domains.order.adaptor.OrderAdaptor
 import band.gosrock.infrastructure.outer.api.tossPayments.client.PaymentsCreateClient
 import band.gosrock.infrastructure.outer.api.tossPayments.dto.request.CreatePaymentsRequest
 import band.gosrock.infrastructure.outer.api.tossPayments.dto.response.PaymentsResponse
+import org.slf4j.LoggerFactory
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
@@ -13,7 +14,10 @@ class CreateTossOrderUseCase(
     private val paymentsCreateClient: PaymentsCreateClient,
     private val orderAdaptor: OrderAdaptor,
 ) {
+    private val log = LoggerFactory.getLogger(CreateTossOrderUseCase::class.java)
+
     fun execute(orderUuid: String): PaymentsResponse {
+        log.info("[CreateTossOrderUseCase][execute] Toss 결제 생성 orderUuid={}", orderUuid)
         val order = orderAdaptor.findByOrderUuid(orderUuid)
         val createPaymentsRequest = CreatePaymentsRequest(
             method = "카드",

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/FreeOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/FreeOrderUseCase.kt
@@ -4,13 +4,17 @@ import band.gosrock.api.order.model.dto.response.OrderResponse
 import band.gosrock.api.order.model.mapper.OrderMapper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.order.service.FreeOrderService
+import org.slf4j.LoggerFactory
 
 @UseCase
 class FreeOrderUseCase(
     private val freeOrderService: FreeOrderService,
     private val orderMapper: OrderMapper,
 ) {
+    private val log = LoggerFactory.getLogger(FreeOrderUseCase::class.java)
+
     fun execute(userId: Long, orderUuid: String): OrderResponse {
+        log.info("[FreeOrderUseCase][execute] 무료 주문 확정 userId={} orderUuid={}", userId, orderUuid)
         val confirmOrderUuid = freeOrderService.execute(orderUuid, userId)
         return orderMapper.toOrderResponse(confirmOrderUuid)
     }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/RefundOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/RefundOrderUseCase.kt
@@ -4,6 +4,7 @@ import band.gosrock.api.order.model.dto.response.OrderResponse
 import band.gosrock.api.order.model.mapper.OrderMapper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.order.service.WithdrawOrderService
+import org.slf4j.LoggerFactory
 
 /** 환불을 위함 환불이라 함은, 사용자가 직접 구매한 물품을 취소시킴 */
 @UseCase
@@ -11,7 +12,10 @@ class RefundOrderUseCase(
     private val withdrawOrderService: WithdrawOrderService,
     private val orderMapper: OrderMapper,
 ) {
+    private val log = LoggerFactory.getLogger(RefundOrderUseCase::class.java)
+
     fun execute(userId: Long, orderUuid: String, reason: String? = null): OrderResponse {
+        log.info("[RefundOrderUseCase][execute] 환불 요청 userId={} orderUuid={} reason={}", userId, orderUuid, reason)
         withdrawOrderService.refundOrder(orderUuid, userId, reason)
         return orderMapper.toOrderResponse(orderUuid)
     }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/RefuseOrderUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/order/service/RefuseOrderUseCase.kt
@@ -7,14 +7,18 @@ import band.gosrock.api.order.model.dto.response.OrderResponse
 import band.gosrock.api.order.model.mapper.OrderMapper
 import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.order.service.WithdrawOrderService
+import org.slf4j.LoggerFactory
 
 @UseCase
 class RefuseOrderUseCase(
     private val withdrawOrderService: WithdrawOrderService,
     private val orderMapper: OrderMapper,
 ) {
+    private val log = LoggerFactory.getLogger(RefuseOrderUseCase::class.java)
+
     @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID, applyTransaction = false)
     fun execute(userId: Long, eventId: Long, orderUuid: String, reason: String? = null): OrderResponse {
+        log.info("[RefuseOrderUseCase][execute] 주문 거부 userId={} eventId={} orderUuid={} reason={}", userId, eventId, orderUuid, reason)
         withdrawOrderService.refuseOrder(orderUuid, reason)
         return orderMapper.toOrderResponse(orderUuid)
     }

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/refund/service/CompleteRefundUseCase.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/refund/service/CompleteRefundUseCase.kt
@@ -8,6 +8,7 @@ import band.gosrock.common.annotation.UseCase
 import band.gosrock.domain.domains.event.adaptor.EventAdaptor
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor
 import band.gosrock.domain.domains.user.adaptor.UserAdaptor
+import org.slf4j.LoggerFactory
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
@@ -16,10 +17,12 @@ class CompleteRefundUseCase(
     private val userAdaptor: UserAdaptor,
     private val eventAdaptor: EventAdaptor,
 ) {
+    private val log = LoggerFactory.getLogger(CompleteRefundUseCase::class.java)
 
     @Transactional
     @HostRolesAllowed(role = MANAGER, findHostFrom = EVENT_ID, applyTransaction = false)
     fun execute(userId: Long, eventId: Long, orderUuid: String): RefundResponse {
+        log.info("[CompleteRefundUseCase][execute] 환불 완료 처리 userId={} eventId={} orderUuid={}", userId, eventId, orderUuid)
         val order = orderAdaptor.findByOrderUuid(orderUuid)
         order.completeRefund()
 

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/slack/sender/SlackInternalErrorSender.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/slack/sender/SlackInternalErrorSender.kt
@@ -9,6 +9,7 @@ import com.slack.api.model.block.composition.BlockCompositions.plainText
 import com.slack.api.model.block.composition.MarkdownTextObject
 import band.gosrock.infrastructure.config.slack.SlackErrorNotificationProvider
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.stereotype.Component
 import org.springframework.web.util.ContentCachingRequestWrapper
 import java.io.IOException
@@ -35,9 +36,14 @@ class SlackInternalErrorSender(
         )
         layoutBlocks.add(divider())
 
+        val traceId = MDC.get("traceId") ?: "no-trace"
+
         val errorUserIdMarkdown = MarkdownTextObject.builder().text("* User Id :*\n$userId").build()
         val errorUserIpMarkdown = MarkdownTextObject.builder().text("* User IP :*\n$errorUserIP").build()
         layoutBlocks.add(section { it.fields(listOf(errorUserIdMarkdown, errorUserIpMarkdown)) })
+
+        val traceIdMarkdown = MarkdownTextObject.builder().text("* Trace ID :*\n`$traceId`").build()
+        layoutBlocks.add(section { it.fields(listOf(traceIdMarkdown)) })
 
         val methodMarkdown = MarkdownTextObject.builder().text("* Request Addr :*\n$method : $url").build()
         val bodyMarkdown = MarkdownTextObject.builder().text("* Request Body :*\n$body").build()

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/slack/sender/SlackThrottleErrorSender.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/slack/sender/SlackThrottleErrorSender.kt
@@ -9,6 +9,7 @@ import com.slack.api.model.block.composition.BlockCompositions.plainText
 import com.slack.api.model.block.composition.MarkdownTextObject
 import band.gosrock.infrastructure.config.slack.SlackErrorNotificationProvider
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.stereotype.Component
 import org.springframework.web.util.ContentCachingRequestWrapper
 import java.io.IOException
@@ -33,9 +34,14 @@ class SlackThrottleErrorSender(
         )
         layoutBlocks.add(divider())
 
+        val traceId = MDC.get("traceId") ?: "no-trace"
+
         val errorUserIdMarkdown = MarkdownTextObject.builder().text("* User Id :*\n$userId").build()
         val errorUserIpMarkdown = MarkdownTextObject.builder().text("* User IP :*\n$errorUserIP").build()
         layoutBlocks.add(section { it.fields(listOf(errorUserIdMarkdown, errorUserIpMarkdown)) })
+
+        val traceIdMarkdown = MarkdownTextObject.builder().text("* Trace ID :*\n`$traceId`").build()
+        layoutBlocks.add(section { it.fields(listOf(traceIdMarkdown)) })
 
         val methodMarkdown = MarkdownTextObject.builder().text("* Request Addr :*\n$method : $url").build()
         val bodyMarkdown = MarkdownTextObject.builder().text("* Request Body :*\n$body").build()

--- a/DuDoong-Api/src/main/resources/application.yml
+++ b/DuDoong-Api/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 # commons
 api:
   prefix : ${API_PREFIX:/api}
+
+logging:
+  pattern:
+    console: "[%d{HH:mm:ss.SSS}] [%X{traceId:-no-trace}] [%-5level] %logger{36} - %msg%n"
 spring:
   profiles:
     include:

--- a/DuDoong-Infrastructure/src/main/kotlin/band/gosrock/infrastructure/config/slack/SlackAsyncErrorSender.kt
+++ b/DuDoong-Infrastructure/src/main/kotlin/band/gosrock/infrastructure/config/slack/SlackAsyncErrorSender.kt
@@ -6,6 +6,7 @@ import com.slack.api.model.block.Blocks.section
 import com.slack.api.model.block.LayoutBlock
 import com.slack.api.model.block.composition.BlockCompositions.plainText
 import com.slack.api.model.block.composition.MarkdownTextObject
+import org.slf4j.MDC
 import org.springframework.stereotype.Component
 
 @Component
@@ -13,15 +14,19 @@ class SlackAsyncErrorSender(
     private val slackProvider: SlackErrorNotificationProvider,
 ) {
     fun execute(name: String, throwable: Throwable, params: Array<Any>) {
+        val traceId = MDC.get("traceId") ?: "no-trace"
         val layoutBlocks = mutableListOf<LayoutBlock>()
         layoutBlocks.add(Blocks.header { it.text(plainText("비동기 에러 알림")) })
         layoutBlocks.add(divider())
 
+        val traceIdMarkdown = MarkdownTextObject.builder().text("* Trace ID :*\n`$traceId`").build()
         val errorUserIdMarkdown = MarkdownTextObject.builder().text("* 메소드 이름 :*\n$name").build()
+        layoutBlocks.add(section { it.fields(listOf(traceIdMarkdown, errorUserIdMarkdown)) })
+
         val errorUserIpMarkdown = MarkdownTextObject.builder()
             .text("* 요청 파라미터 :*\n${getParamsToString(params)}")
             .build()
-        layoutBlocks.add(section { it.fields(listOf(errorUserIdMarkdown, errorUserIpMarkdown)) })
+        layoutBlocks.add(section { it.fields(listOf(errorUserIpMarkdown)) })
 
         layoutBlocks.add(divider())
         val errorStack = slackProvider.getErrorStack(throwable)


### PR DESCRIPTION
## 개요

nginx `$request_id` → `X-Trace-Id` 헤더 → Spring MDC → Logback 패턴까지 연계하여  
요청 단위로 모든 로그를 묶어 볼 수 있게 합니다.

close #688

## 변경사항

### 신규: `MdcFilter.kt`
- `OncePerRequestFilter` 구현
- `X-Trace-Id` 헤더 수신 → MDC `traceId` 설정
- 헤더 없을 경우 8자리 UUID 자동 생성
- 응답 헤더에 `X-Trace-Id` 에코

### 수정: `ServletFilterConfig.kt`
- `MdcFilter`를 `order = Int.MIN_VALUE` (가장 먼저 실행)로 등록

### 수정: `application.yml`
- `logging.pattern.console` 추가: `[%X{traceId:-no-trace}]` 포함

## 로그 예시

```
[3b2f7a9e] 2026-03-23 02:11:03 INFO  OrderService - 주문 생성 시작
[3b2f7a9e] 2026-03-23 02:11:03 ERROR OrderValidator - 유효하지 않은 티켓
```

## nginx 연계

```
nginx log: ... trace=3b2f7a9e1c4d0e5f
Spring log: [3b2f7a9e] ERROR ...
Slack 알림: traceId=3b2f7a9e
```

에러 발생 시 Slack의 traceId → nginx 로그 검색 → Spring 로그 전체 확인까지 가능

## 하위 호환성

- `X-Trace-Id` 헤더 없는 요청 → 자동 생성 (기존 동작 유지)
- 외부 라이브러리 추가 없음 (Logback MDC 기본 기능 활용)