### PR TITLE
fix: 이벤트 검색 keyword null일 때 NPE 수정

### DIFF
--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/model/mapper/EventMapper.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/event/model/mapper/EventMapper.kt
@@ -90,7 +90,7 @@ class EventMapper(
     }
 
     fun toEventResponseSliceByKeyword(keyword: String?, pageable: Pageable): Slice<EventResponse> {
-        val events = eventAdaptor.querySliceEventsByKeyword(keyword!!, pageable)
+        val events = eventAdaptor.querySliceEventsByKeyword(keyword, pageable)
         return events.map { EventResponse.of(it) }
     }
 

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/adaptor/EventAdaptor.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/adaptor/EventAdaptor.kt
@@ -28,7 +28,7 @@ class EventAdaptor(private val eventRepository: EventRepository) {
     fun querySliceEventsByStatus(status: EventStatus, pageable: Pageable): Slice<Event> =
         eventRepository.querySliceEventsByStatus(status, pageable)
 
-    fun querySliceEventsByKeyword(keyword: String, pageable: Pageable): Slice<Event> =
+    fun querySliceEventsByKeyword(keyword: String?, pageable: Pageable): Slice<Event> =
         eventRepository.querySliceEventsByKeyword(keyword, pageable)
 
     fun queryEventsByEndAtBeforeAndStatusOpen(time: LocalDateTime): List<Event> =

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/repository/EventCustomRepository.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/repository/EventCustomRepository.kt
@@ -11,7 +11,7 @@ interface EventCustomRepository {
 
     fun querySliceEventsByStatus(status: EventStatus, pageable: Pageable): Slice<Event>
 
-    fun querySliceEventsByKeyword(keyword: String, pageable: Pageable): Slice<Event>
+    fun querySliceEventsByKeyword(keyword: String?, pageable: Pageable): Slice<Event>
 
     fun queryEventsByEndAtBeforeAndStatusOpen(time: LocalDateTime): List<Event>
 }

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/event/repository/EventCustomRepositoryImpl.kt
@@ -41,7 +41,7 @@ class EventCustomRepositoryImpl(
         return SliceUtil.valueOf(events, pageable)
     }
 
-    override fun querySliceEventsByKeyword(keyword: String, pageable: Pageable): Slice<Event> {
+    override fun querySliceEventsByKeyword(keyword: String?, pageable: Pageable): Slice<Event> {
         val openEvents = queryFactory
             .selectFrom(event)
             .where(eqStatusOpen().and(nameContains(keyword)))
@@ -60,7 +60,7 @@ class EventCustomRepositoryImpl(
     override fun queryEventsByEndAtBeforeAndStatusOpen(time: LocalDateTime): List<Event> =
         queryFactory.selectFrom(event).where(endAtBefore(time), statusEq(OPEN)).fetch()
 
-    private fun queryClosedEventsByKeywordAndSize(keyword: String, pageable: Pageable, size: Long): List<Event> {
+    private fun queryClosedEventsByKeywordAndSize(keyword: String?, pageable: Pageable, size: Long): List<Event> {
         val totalOpenEventsSize = queryCountByKeywordAndStatus(keyword, OPEN)
         val closedEventsOffset = maxOf(pageable.offset - totalOpenEventsSize, 0L)
         return queryFactory
@@ -72,7 +72,7 @@ class EventCustomRepositoryImpl(
             .fetch()
     }
 
-    private fun queryCountByKeywordAndStatus(keyword: String, status: EventStatus): Long =
+    private fun queryCountByKeywordAndStatus(keyword: String?, status: EventStatus): Long =
         queryFactory
             .from(event)
             .where(statusEq(status).and(nameContains(keyword)))


### PR DESCRIPTION
## Summary\n- `GET /api/v1/events/search` keyword 없이 호출 시 500 에러(NPE) 수정\n- `keyword!!` 제거 → nullable 전파 → `nameContains(null)` 조건 skip → 전체 검색\n- 변경 파일: EventMapper, EventAdaptor, EventCustomRepository, EventCustomRepositoryImpl\n\nclose #695