### PR TITLE
fix: 비동기 이벤트 핸들러 LazyInitializationException + traceId 전파

### DIFF
--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/alimTalk/handler/DoneOrderEventAlimTalkHandler.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/alimTalk/handler/DoneOrderEventAlimTalkHandler.kt
@@ -9,6 +9,7 @@ import band.gosrock.domain.domains.order.adaptor.OrderAdaptor
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
@@ -24,6 +25,7 @@ class DoneOrderEventAlimTalkHandler(
     private val log = LoggerFactory.getLogger(DoneOrderEventAlimTalkHandler::class.java)
 
     @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
     @TransactionalEventListener(classes = [DoneOrderEvent::class], phase = TransactionPhase.AFTER_COMMIT)
     fun handleDoneOrderEvent(doneOrderEvent: DoneOrderEvent) {
         try {

--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/alimTalk/handler/WithDrawOrderEventAlimTalkHandler.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/alimTalk/handler/WithDrawOrderEventAlimTalkHandler.kt
@@ -8,6 +8,7 @@ import band.gosrock.domain.domains.host.adaptor.HostAdaptor
 import band.gosrock.domain.domains.order.adaptor.OrderAdaptor
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
@@ -23,6 +24,7 @@ class WithDrawOrderEventAlimTalkHandler(
     private val log = org.slf4j.LoggerFactory.getLogger(WithDrawOrderEventAlimTalkHandler::class.java)
 
     @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
     @TransactionalEventListener(classes = [WithDrawOrderEvent::class], phase = TransactionPhase.AFTER_COMMIT)
     fun handleWithDrawOrderEvent(withDrawOrderEvent: WithDrawOrderEvent) {
         try {

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/config/EnableAsyncConfig.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/config/EnableAsyncConfig.kt
@@ -4,12 +4,25 @@ import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.AsyncConfigurer
 import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
 
 @EnableAsync
 @Configuration
 class EnableAsyncConfig(
     private val customAsyncExceptionHandler: CustomAsyncExceptionHandler
 ) : AsyncConfigurer {
+
+    override fun getAsyncExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 5
+        executor.maxPoolSize = 10
+        executor.queueCapacity = 50
+        executor.setThreadNamePrefix("async-")
+        executor.setTaskDecorator(MdcTaskDecorator())
+        executor.initialize()
+        return executor
+    }
 
     override fun getAsyncUncaughtExceptionHandler(): AsyncUncaughtExceptionHandler =
         customAsyncExceptionHandler

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/config/MdcTaskDecorator.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/config/MdcTaskDecorator.kt
@@ -1,0 +1,20 @@
+package band.gosrock.domain.config
+
+import org.slf4j.MDC
+import org.springframework.core.task.TaskDecorator
+
+class MdcTaskDecorator : TaskDecorator {
+    override fun decorate(runnable: Runnable): Runnable {
+        val contextMap = MDC.getCopyOfContextMap()
+        return Runnable {
+            if (contextMap != null) {
+                MDC.setContextMap(contextMap)
+            }
+            try {
+                runnable.run()
+            } finally {
+                MDC.clear()
+            }
+        }
+    }
+}

--- a/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/domain/OrderLineItem.kt
+++ b/DuDoong-Domain/src/main/kotlin/band/gosrock/domain/domains/order/domain/OrderLineItem.kt
@@ -31,7 +31,7 @@ class OrderLineItem() : BaseTimeEntity() {
     var quantity: Long? = null
         protected set
 
-    @OneToMany(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    @OneToMany(cascade = [CascadeType.ALL], fetch = FetchType.EAGER)
     @JoinColumn(name = "order_line_item_id")
     var orderOptionAnswers: MutableList<OrderOptionAnswer> = mutableListOf()
         protected set


### PR DESCRIPTION
## Summary\n- `OrderLineItem.orderOptionAnswers` LAZY → EAGER 변경 (항상 함께 필요한 소규모 컬렉션)\n- `MdcTaskDecorator` 추가: `@Async` 스레드에 MDC traceId 자동 전파 (Slack 알림에 `no-trace` → 실제 traceId)\n- `EnableAsyncConfig`에 `ThreadPoolTaskExecutor` + `MdcTaskDecorator` 등록\n- AlimTalk 핸들러에 `@Transactional(REQUIRES_NEW, readOnly)` 추가\n\n## 검증\n- E2E 테스트 21개 전체 통과\n- 서버 로그에서 `LazyInitializationException` 0건 확인\n\nclose #697