### PR TITLE
fix: trailing slash 요청 시 405 에러 수정

### DIFF
--- a/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/WebMvcConfig.kt
+++ b/DuDoong-Api/src/main/kotlin/band/gosrock/api/config/WebMvcConfig.kt
@@ -3,6 +3,7 @@ package band.gosrock.api.config
 import band.gosrock.api.config.security.CurrentUserIdResolver
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
@@ -12,5 +13,9 @@ class WebMvcConfig(
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
         resolvers.add(currentUserIdResolver)
+    }
+
+    override fun configurePathMatch(configurer: PathMatchConfigurer) {
+        configurer.setUseTrailingSlashMatch(true)
     }
 }


### PR DESCRIPTION
## Summary\n- Spring Boot 3.x에서 비활성화된 trailing slash 매칭 재활성화\n- `WebMvcConfig.configurePathMatch`에 `setUseTrailingSlashMatch(true)` 추가\n- `/api/v1/orders/` 등 trailing slash 요청이 405 대신 정상 처리됨\n\nclose #700